### PR TITLE
api: Improve handling of privkey decryption errors

### DIFF
--- a/api/src/lib/symmetricCrypto.spec.ts
+++ b/api/src/lib/symmetricCrypto.spec.ts
@@ -20,6 +20,6 @@ describe("Symmetric Crypto", () => {
     const encodedEncrypted =
       "2ba6a3a892b89f4422db9f7a39b1279b7db7c93144dd7e58946dc59aec21d22168c0255db6921f7b0c0ffb7213a095eb4bfbb670eb";
 
-    expect(() => SUT.decrypt("wrong secret", encodedEncrypted)).to.throw();
+    expect(SUT.decrypt("wrong secret", encodedEncrypted)).to.be.instanceOf(Error);
   });
 });

--- a/api/src/user_authenticate.ts
+++ b/api/src/user_authenticate.ts
@@ -133,6 +133,7 @@ const swaggerSchema = {
           error: {
             type: "object",
             properties: {
+              code: { type: "number" },
               message: {
                 type: "string",
                 example: "Authentication failed.",


### PR DESCRIPTION
Closes #174.

### Test:

1. Start blockchain
1. Start API with `ORGANIZATION=A` and `ORGANIZATION_VAULT_SECRET=a`
1. Run provisioning
1. Restart API with `ORGANIZATION=B` and `ORGANIZATION_VAULT_SECRET=b`
1. Run frontend
1. Log in with `mstein` and `test`

On the UI you should see "Incorrect password" and the logs should show this:

```plain
msg: "authentication failed: failed to decrypt the user's private key with the given organization secret (does the user mstein belong to organization ACMECorp2?): decryption failed"
error: {
  ...
}
```