### PR TITLE
ui: Add new error code for failed login to saga

### DIFF
--- a/frontend/src/sagas.js
+++ b/frontend/src/sagas.js
@@ -174,7 +174,7 @@ function* handleError(error) {
   console.error(error);
 
   // which status should we use?
-  if (error.response.status === 401) {
+  if (error.response.status === 401 || error.response.status === 400) {
     yield call(logoutSaga);
   } else if (error.response && error.response.data) {
     yield put({


### PR DESCRIPTION
When a user logs in with invalid credentials, the HTTP error code is now
400. Since it was 401 before, the snackbar after successful login did
not behave correctly.

Added error code 400 to snackbar message configuration. 