### PR TITLE
api: Add 'additionalProperties' to subproject_list

### DIFF
--- a/api/src/subproject_list.ts
+++ b/api/src/subproject_list.ts
@@ -70,7 +70,7 @@ function mkSwaggerSchema(server: FastifyInstance) {
                               },
                             },
                           },
-                          additionalData: { type: "object" },
+                          additionalData: { type: "object", additionalProperties: true },
                         },
                       },
                       log: {
@@ -79,7 +79,10 @@ function mkSwaggerSchema(server: FastifyInstance) {
                           type: "object",
                           required: ["entityId", "entityType", "businessEvent", "snapshot"],
                           properties: {
-                            entityId: { type: "string", example: "d0e8c69eg298c87e3899119e025eff1f" },
+                            entityId: {
+                              type: "string",
+                              example: "d0e8c69eg298c87e3899119e025eff1f",
+                            },
                             entityType: { type: "string", example: "subproject" },
                             businessEvent: {
                               type: "object",


### PR DESCRIPTION
This is to fix the bug where 'additionalData' is not returned when
calling 'subproject_list'.
The solution is to add the 'additionalProperties: true' to the Swagger
schema which enables the display of JSON like data in the response.

Closes #214 