### PR TITLE
Only allow point as decimal sign for amount and exchangeRate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Only allow the point character as the decimal sign for a workflowitems' amount and exchangeRate fields. While we generally try to avoid interpreting amounts, this change is important to ensure that values on the chain can be read without knowing the author's locale settings. [#216](https://github.com/openkfw/TruBudget/issues/216)
 
 ## [1.0.0-beta.8] - 2019-04-11
 

--- a/api/src/service/domain/workflow/money.ts
+++ b/api/src/service/domain/workflow/money.ts
@@ -8,6 +8,8 @@ export function isAmountOfMoney(value: string): boolean {
   return error === null;
 }
 
+export const conversionRateSchema = Joi.string().regex(/^[0-9]+(\.[0-9]+)?$/, "conversion rate");
+
 const isoCurrencyCodes = [
   "AFN",
   "EUR",

--- a/api/src/service/domain/workflow/workflowitem.ts
+++ b/api/src/service/domain/workflow/workflowitem.ts
@@ -9,6 +9,7 @@ import { Identity } from "../organization/identity";
 import { ServiceUser } from "../organization/service_user";
 import { Permissions } from "../permissions";
 import { StoredDocument } from "./document";
+import { moneyAmountSchema } from "./money";
 import * as Subproject from "./subproject";
 import { WorkflowitemTraceEvent, workflowitemTraceEventSchema } from "./workflowitem_trace_event";
 
@@ -70,6 +71,7 @@ const schema = Joi.object().keys({
     .required(),
   dueDate: Joi.date().iso(),
   displayName: Joi.string().required(),
+  // This should use exchangeRateSchema but can't, because of backward compatibility:
   exchangeRate: Joi.string()
     .when("amountType", {
       is: Joi.valid("N/A"),
@@ -91,7 +93,7 @@ const schema = Joi.object().keys({
       then: Joi.required(),
       otherwise: Joi.optional(),
     }),
-  amount: Joi.string()
+  amount: moneyAmountSchema
     .when("amountType", {
       is: Joi.valid("N/A"),
       then: Joi.forbidden(),

--- a/api/src/service/domain/workflow/workflowitem_updated.ts
+++ b/api/src/service/domain/workflow/workflowitem_updated.ts
@@ -5,6 +5,7 @@ import * as Result from "../../../result";
 import * as AdditionalData from "../additional_data";
 import { Identity } from "../organization/identity";
 import { StoredDocument, storedDocumentSchema } from "./document";
+import { conversionRateSchema, moneyAmountSchema } from "./money";
 import * as Project from "./project";
 import * as Subproject from "./subproject";
 import * as Workflowitem from "./workflowitem";
@@ -28,18 +29,21 @@ export interface Modification {
 export const modificationSchema = Joi.object({
   displayName: Joi.string(),
   description: Joi.string().allow(""),
-  exchangeRate: Joi.string().when("amountType", { is: Joi.valid("N/A"), then: Joi.forbidden() }),
+  exchangeRate: conversionRateSchema
+    .when("amountType", { is: Joi.valid("N/A"), then: Joi.forbidden() }),
   billingDate: Joi.date()
     .iso()
     .when("amountType", { is: Joi.valid("N/A"), then: Joi.forbidden() }),
-  amount: Joi.string().when("amountType", {
-    is: Joi.valid("N/A"),
-    then: Joi.forbidden(),
-  }),
-  currency: Joi.string().when("amountType", {
-    is: Joi.valid("N/A"),
-    then: Joi.forbidden(),
-  }),
+  amount: moneyAmountSchema
+    .when("amountType", {
+      is: Joi.valid("N/A"),
+      then: Joi.forbidden(),
+    }),
+  currency: Joi.string()
+    .when("amountType", {
+      is: Joi.valid("N/A"),
+      then: Joi.forbidden(),
+    }),
   amountType: Joi.valid("N/A", "disbursed", "allocated"),
   dueDate: Joi.date().iso(),
   documents: Joi.array().items(storedDocumentSchema),
@@ -182,7 +186,7 @@ function updateDocuments(workflowitem: Workflowitem.Workflowitem, documents?: St
       if (existingDocument.hash !== document.hash) {
         throw new VError(
           `cannot update document ${document.id}, ` +
-            `as changing existing documents is not allowed`,
+          `as changing existing documents is not allowed`,
         );
       }
     }

--- a/api/src/workflowitem_create.ts
+++ b/api/src/workflowitem_create.ts
@@ -10,6 +10,7 @@ import * as Result from "./result";
 import { ServiceUser } from "./service/domain/organization/service_user";
 import { ResourceMap } from "./service/domain/ResourceMap";
 import { UploadedDocument } from "./service/domain/workflow/document";
+import { conversionRateSchema, moneyAmountSchema } from "./service/domain/workflow/money";
 import * as Project from "./service/domain/workflow/project";
 import * as Subproject from "./service/domain/workflow/subproject";
 import { Id } from "./service/domain/workflow/workflowitem";
@@ -44,10 +45,10 @@ const requestBodyV1Schema = Joi.object({
     description: Joi.string().allow(""),
     assignee: Joi.string(),
     currency: Joi.string(),
-    amount: Joi.string(),
+    amount: moneyAmountSchema,
     amountType: Joi.string().required(),
     billingDate: Joi.string(),
-    exchangeRate: Joi.string(),
+    exchangeRate: conversionRateSchema,
     documents: Joi.array().items(Joi.object().keys({ id: Joi.string(), base64: Joi.string() })),
     additionalData: Joi.object(),
   }).required(),

--- a/provisioning/src/data/prod/gavi.json
+++ b/provisioning/src/data/prod/gavi.json
@@ -152,7 +152,7 @@
           "amount": 1000000,
           "currency": "EUR",
           "amountType": "allocated",
-          "exchangeRate": "1,0"
+          "exchangeRate": "1.0"
         },
         {
           "displayName": "Novartis to DHL: Packaging",
@@ -189,7 +189,7 @@
           "amount": 200000,
           "currency": "EUR",
           "amountType": "disbursed",
-          "exchangeRate":"1.0"
+          "exchangeRate": "1.0"
         },
         {
           "displayName": "DHL to Customs Senegal: Shipping",
@@ -226,7 +226,7 @@
           "amount": 200000,
           "currency": "EUR",
           "amountType": "disbursed",
-          "exchangeRate":"1.0"
+          "exchangeRate": "1.0"
         },
         {
           "displayName": "Customs Senegal to UPS: Customs Clearing",
@@ -327,7 +327,7 @@
           "amount": 100000,
           "currency": "EUR",
           "amountType": "disbursed",
-          "exchangeRate":"1.0"
+          "exchangeRate": "1.0"
         },
         {
           "displayName": "UPS to Health Center Kaya 2",
@@ -363,7 +363,7 @@
           "amount": 100000,
           "currency": "EUR",
           "amountType": "disbursed",
-          "exchangeRate":"1.0"
+          "exchangeRate": "1.0"
         },
         {
           "displayName": "UPS to Health Center Kaya 3",
@@ -399,7 +399,7 @@
           "amount": 100000,
           "currency": "EUR",
           "amountType": "disbursed",
-          "exchangeRate":"1.0"
+          "exchangeRate": "1.0"
         }
       ]
     },
@@ -503,7 +503,7 @@
           "amount": 1000000,
           "currency": "EUR",
           "amountType": "allocated",
-          "exchangeRate": "1,0"
+          "exchangeRate": "1.0"
         },
         {
           "displayName": "Novartis to DHL: Packaging",
@@ -540,7 +540,7 @@
           "amount": 200000,
           "currency": "EUR",
           "amountType": "disbursed",
-          "exchangeRate":"1.0"
+          "exchangeRate": "1.0"
         },
         {
           "displayName": "DHL to Customs Senegal: Shipping",
@@ -577,7 +577,7 @@
           "amount": 200000,
           "currency": "EUR",
           "amountType": "disbursed",
-          "exchangeRate":"1.0"
+          "exchangeRate": "1.0"
         },
         {
           "displayName": "Customs Senegal to UPS: Customs Clearing",

--- a/provisioning/src/data/test/multiple_donors_2.json
+++ b/provisioning/src/data/test/multiple_donors_2.json
@@ -125,7 +125,7 @@
           "amountType": "allocated",
           "amount": "1000000",
           "currency": "EUR",
-          "exchangeRate": "112,945",
+          "exchangeRate": "112.945",
           "billingDate": "2020-01-01T01:00:00+00:00"
         },
         {
@@ -158,7 +158,7 @@
           "amountType": "allocated",
           "amount": "200000",
           "currency": "EUR",
-          "exchangeRate": "113,666",
+          "exchangeRate": "113.666",
           "billingDate": "2020-01-01T01:00:00+00:00"
         },
         {
@@ -167,7 +167,7 @@
           "amountType": "allocated",
           "amount": "500000",
           "currency": "USD",
-          "exchangeRate": "102,153",
+          "exchangeRate": "102.153",
           "billingDate": "2020-01-01T01:00:00+00:00"
         },
         {


### PR DESCRIPTION
## Description

Only allow the point character as the decimal sign for a workflowitems' amount and exchangeRate fields. While we generally try to avoid interpreting amounts, this change is important to ensure that values on the chain can be read without knowing the author's locale settings.

Closes #216 

## How to test this

- checkout acbdd13
- run provisioning => it should fail now, as it includes decimal commas in some exchangeRate fields
- forward to e43e70b
- run provisioning again => should work now, as the fields are fixed in the provisioning data