### PR TITLE
Sync version bump

### DIFF
--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trubudget-e2e-test",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trubudget-e2e-test",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.9",
   "private": true,
   "repository": {
     "type": "git",

--- a/excel-export/package-lock.json
+++ b/excel-export/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "excel-export",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/excel-export/package.json
+++ b/excel-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "excel-export",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.9",
   "private": true,
   "description": "Export TruBudget data to Excel",
   "main": "src/index.js",

--- a/npmversion.sh
+++ b/npmversion.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+prog="$0"
+
+function usage() {
+    echo "$prog [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]"
+    echo
+    echo "Looks into all top-level package directories and bumps the version according to the given value."
+    echo "For JS/TS projects the script writes the new version back to the package.json, package-lock.json, and, if present, npm-shrinkwrap.json files."
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 0
+fi
+
+git diff-index --quiet HEAD || { echo "commit or stash your changes first" 1>&2; exit 1; }
+
+for dir in */; do
+    (cd "$dir" && [[ -e package.json ]] && npm version "$@")
+done
+
+git status

--- a/provisioning/package-lock.json
+++ b/provisioning/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trubudget-provisioning",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/provisioning/package.json
+++ b/provisioning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trubudget-provisioning",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.9",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

It has proven a bit tedious to update package versions when cutting a release. This PR introduces a small script that uses `npm version` to update those versions, providing the same "API" while applying the change to all `package.json` (and related) files.

@gonzochic @Stezido @mathiashoeld Thoughts? Suggestions?

# Usage Examples

For example, for the upcoming release we could use either one of those:

```bash
./npmversion.sh 1.0.0-beta.10
```

```bash
./npmversion.sh prerelease
```

Simply run `./npmversion.sh` without arguments to see the usage help (copied mostly from `npm version`).