### PR TITLE
ui: Make subproject projected budget not mandatory

### DIFF
--- a/frontend/src/pages/SubProjects/SubprojectDialog.js
+++ b/frontend/src/pages/SubProjects/SubprojectDialog.js
@@ -69,7 +69,6 @@ const SubprojectDialog = props => {
       content: <SubprojectDialogContent {...props} />,
       nextDisabled:
         _isEmpty(subprojectToAdd.displayName) ||
-        _isEmpty(subprojectToAdd.projectedBudgets) ||
         _isEmpty(subprojectToAdd.currency) ||
         _isEmpty(changes)
     }


### PR DESCRIPTION
# Description

When creating a new subproject the submit button is now active as soon
as description and currency are available.

# Testing
Create a new subproject, add name and currency, but no projected budget -> The submit button should be active. 