### PR TITLE
Fix backup/restore feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed line of YAML file for master deployments via docker-compose, so that image of excel export service is pulled correctly [#223](https://github.com/openkfw/TruBudget/issues/223)
-
+- Backup/restore works again. [#237](https://github.com/openkfw/TruBudget/issues/237)
 
 ## [1.0.0-beta.9] - 2019-04-23
 

--- a/api/src/httpd/schema.ts
+++ b/api/src/httpd/schema.ts
@@ -3263,10 +3263,11 @@ const schemas = {
       ],
       consumes: ["application/gzip"],
       body: {
-        description: "binary gzip file",
-        type: "string",
-        // format: "binary",
-        example: "backup.gz (send a backup-file as binary via an API-Testing-Tool like postman)",
+        // type=string + format=binary is not supported by fastify-swagger.
+        // Instead, we use the `AnyValue` schema, which allows anything.
+        AnyValue: {
+          description: "backup.gz (binary gzip file)",
+        },
       },
       response: {
         200: {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -30,6 +30,7 @@ import * as ProjectUpdateAPI from "./project_update";
 import * as ProjectViewDetailsAPI from "./project_view_details";
 import * as ProjectViewHistoryAPI from "./project_view_history";
 import * as Multichain from "./service";
+import * as Cache from "./service/cache2";
 import * as DocumentValidationService from "./service/document_validation";
 import * as GlobalPermissionGrantService from "./service/global_permission_grant";
 import * as GlobalPermissionRevokeService from "./service/global_permission_revoke";
@@ -199,7 +200,9 @@ function registerSelf(): Promise<boolean> {
  * Deprecated API-setup
  */
 
-registerRoutes(server, db, URL_PREFIX, multichainHost, backupApiPort);
+registerRoutes(server, db, URL_PREFIX, multichainHost, backupApiPort, () =>
+  Cache.invalidateCache(db),
+);
 
 /*
  * APIs related to Global Permissions

--- a/api/src/system/restoreBackup.ts
+++ b/api/src/system/restoreBackup.ts
@@ -1,4 +1,6 @@
 import axios from "axios";
+import { VError } from "verror";
+
 import { AuthenticatedRequest, HttpResponse } from "../httpd/lib";
 import logger from "../lib/logger";
 
@@ -22,13 +24,10 @@ export const restoreBackup = async (
   };
   try {
     await axios.post(`http://${multichainHost}:${backupApiPort}/chain/`, data, config);
-  } catch (err) {
-    if (err.response.status === 400) {
-      throw { kind: "CorruptFileError" };
-    } else {
-      logger.error({ error: err }, "An error occured while restoring the backup");
-      throw new Error(err.message);
-    }
+    logger.info("backup restored successfully");
+  } catch (error) {
+    const cause = error.response.status === 400 ? new Error(error.response.data) : error;
+    throw new VError(cause, "failed to restore backup");
   }
   return [
     200,


### PR DESCRIPTION
# Description

Enabling strict schema validation broke the restore feature, because fastify-swagger doesn't support the required type "string" with format "binary". Furthermore, the newly introduced caching required restarting the API after restoring a backup.

This PR fixes that by:

- using AnyValue as the body schema type
- apply cache invalidation after restore (or restore attempt)

Closes #237 

# Test

happy path:

- log in as root
- open the hamburger menu and download a backup
- change things (edit a project or add a new project)
- open the hamburger menu and restore the backup
- log in again and verify that the data has been reset

unhappy path:

- try to upload something else, like a non-gzip file or a gzip files that contains other things (I haven't tested the latter, actually)