### PR TITLE
UI: make creation dialog responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed line of YAML file for master deployments via docker-compose, so that image of excel export service is pulled correctly [#223](https://github.com/openkfw/TruBudget/issues/223)
 - Backup/restore works again. [#237](https://github.com/openkfw/TruBudget/issues/237)
+- Fixed a bug where on smaller screens the action buttons (create & cancel) are hidden and no item could be created [#240](https://github.com/openkfw/TruBudget/issues/240)
 
 ## [1.0.0-beta.9] - 2019-04-23
 

--- a/frontend/src/pages/Common/CreationDialog.js
+++ b/frontend/src/pages/Common/CreationDialog.js
@@ -7,14 +7,6 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import isEmpty from "lodash/isEmpty";
 import strings from "../../localizeStrings";
 import CreationDialogStepper from "./CreationDialogStepper";
-import { withStyles } from "@material-ui/core";
-
-const styles = {
-  paperRoot: {
-    width: "100%",
-    overflow: "visible"
-  }
-};
 
 const getDialogActions = (props, handleCancel, handleBack, handleNext, handleSubmit) => {
   const { numberOfSteps, currentStep = 0, steps } = props;
@@ -90,9 +82,9 @@ const handleBack = props => props.setCurrentStep(props.currentStep - 1);
 const handleNext = props => props.setCurrentStep(props.currentStep + 1);
 
 const CreationDialog = props => {
-  const { dialogShown, title, handleSubmit, classes } = props;
+  const { dialogShown, title, handleSubmit } = props;
   return (
-    <Dialog classes={{ paper: classes.paperRoot }} open={dialogShown} maxWidth="md" data-test="creation-dialog">
+    <Dialog open={dialogShown} maxWidth="md" data-test="creation-dialog">
       <DialogTitle> {title}</DialogTitle>
       <CreationDialogStepper {...props} />
       <DialogActions>{getDialogActions(props, handleCancel, handleBack, handleNext, handleSubmit)}</DialogActions>
@@ -100,4 +92,4 @@ const CreationDialog = props => {
   );
 };
 
-export default withStyles(styles)(CreationDialog);
+export default CreationDialog;


### PR DESCRIPTION
**Problem**:
If the screen is too small the action buttons of the creation dialog are not accessible.

**Solution**:
Make the dialog scrollable .

Closes #240 