### PR TITLE
api: New endpoints for project/subproject/workflowitem history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Projected budget ratio on project analytics screen [#242](https://github.com/openkfw/TruBudget/pull/242)
+- New endpoint `/workflowitem.viewHistory` that returns all changes that have been applied to a particular workflowitem in chronological order. [#252](https://github.com/openkfw/TruBudget/issues/252)
 
 ### Changed
 
@@ -17,12 +18,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added groups to provisioning [#57](https://github.com/openkfw/TruBudget/issues/57)
 - In the frontend directory, the `.env_example` file was removed and the `.env` file is copied into the Docker container instead [#176](https://github.com/openkfw/TruBudget/issues/176)
 
+### Deprecated
+
+- `/project.viewHistory` deprecated in favor of `/project.viewHistory.v2`. [#252](https://github.com/openkfw/TruBudget/issues/252)
+- `/subproject.viewHistory` deprecated in favor of `/subproject.viewHistory.v2`. [#252](https://github.com/openkfw/TruBudget/issues/252)
+
+<!-- ### Removed -->
+
 ### Fixed
 
 - Fixed line of YAML file for master deployments via docker-compose, so that image of excel export service is pulled correctly [#223](https://github.com/openkfw/TruBudget/issues/223)
 - Backup/restore works again. [#237](https://github.com/openkfw/TruBudget/issues/237)
 - Budgets on project analytics do not contain open workflow items [#230](https://github.com/openkfw/TruBudget/issues/230)
 - Fixed a bug where on smaller screens the action buttons (create & cancel) are hidden and no item could be created [#240](https://github.com/openkfw/TruBudget/issues/240)
+
+<!-- ### Security -->
 
 ## [1.0.0-beta.9] - 2019-04-23
 

--- a/api/src/authz/intents.ts
+++ b/api/src/authz/intents.ts
@@ -13,14 +13,14 @@ type Intent =
   | "project.intent.listPermissions"
   | "project.intent.grantPermission"
   | "project.intent.revokePermission"
-  | "project.viewSummary" // IDs + meta data + allowed intents
-  | "project.viewDetails" // ID + meta data + allowed intents + history
+  | "project.viewSummary"
+  | "project.viewDetails"
+  | "project.viewHistory"
   | "project.assign"
   | "project.update"
   | "project.close"
   | "project.archive"
   | "project.createSubproject"
-  | "project.viewHistory"
   | "project.budget.updateProjected"
   | "project.budget.deleteProjected"
   | "subproject.intent.listPermissions"
@@ -29,19 +29,20 @@ type Intent =
   // TODO: rename to subproject.list
   | "subproject.viewSummary"
   | "subproject.viewDetails"
+  | "subproject.viewHistory"
   | "subproject.assign"
   | "subproject.update"
   | "subproject.close"
   | "subproject.archive"
   | "subproject.createWorkflowitem"
   | "subproject.reorderWorkflowitems"
-  | "subproject.viewHistory"
   | "subproject.budget.updateProjected"
   | "subproject.budget.deleteProjected"
   | "workflowitem.intent.listPermissions"
   | "workflowitem.intent.grantPermission"
   | "workflowitem.intent.revokePermission"
   | "workflowitem.view"
+  | "workflowitem.viewHistory"
   | "workflowitem.assign"
   | "workflowitem.update"
   | "workflowitem.close"
@@ -110,12 +111,12 @@ export const projectIntents: Intent[] = [
   "project.intent.revokePermission",
   "project.viewSummary",
   "project.viewDetails",
+  "project.viewHistory",
   "project.assign",
   "project.update",
   "project.close",
   "project.archive",
   "project.createSubproject",
-  "project.viewHistory",
   "project.budget.updateProjected",
   "project.budget.deleteProjected",
 ];
@@ -126,13 +127,13 @@ export const subprojectIntents: Intent[] = [
   "subproject.intent.revokePermission",
   "subproject.viewSummary",
   "subproject.viewDetails",
+  "subproject.viewHistory",
   "subproject.assign",
   "subproject.update",
   "subproject.close",
   "subproject.archive",
   "subproject.createWorkflowitem",
   "subproject.reorderWorkflowitems",
-  "subproject.viewHistory",
   "subproject.budget.updateProjected",
   "subproject.budget.deleteProjected",
 ];
@@ -142,6 +143,7 @@ export const workflowitemIntents: Intent[] = [
   "workflowitem.intent.grantPermission",
   "workflowitem.intent.revokePermission",
   "workflowitem.view",
+  "workflowitem.viewHistory",
   "workflowitem.assign",
   "workflowitem.update",
   "workflowitem.close",
@@ -165,12 +167,12 @@ export const allIntents: Intent[] = [
   "project.intent.revokePermission",
   "project.viewSummary",
   "project.viewDetails",
+  "project.viewHistory",
   "project.assign",
   "project.update",
   "project.close",
   "project.archive",
   "project.createSubproject",
-  "project.viewHistory",
   "project.budget.updateProjected",
   "project.budget.deleteProjected",
   "subproject.intent.listPermissions",
@@ -178,19 +180,20 @@ export const allIntents: Intent[] = [
   "subproject.intent.revokePermission",
   "subproject.viewSummary",
   "subproject.viewDetails",
+  "subproject.viewHistory",
   "subproject.assign",
   "subproject.update",
   "subproject.close",
   "subproject.archive",
   "subproject.createWorkflowitem",
   "subproject.reorderWorkflowitems",
-  "subproject.viewHistory",
   "subproject.budget.updateProjected",
   "subproject.budget.deleteProjected",
   "workflowitem.intent.listPermissions",
   "workflowitem.intent.grantPermission",
   "workflowitem.intent.revokePermission",
   "workflowitem.view",
+  "workflowitem.viewHistory",
   "workflowitem.assign",
   "workflowitem.update",
   "workflowitem.close",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -29,6 +29,7 @@ import * as ProjectPermissionsListAPI from "./project_permissions_list";
 import * as ProjectUpdateAPI from "./project_update";
 import * as ProjectViewDetailsAPI from "./project_view_details";
 import * as ProjectViewHistoryAPI from "./project_view_history";
+import * as ProjectViewHistoryAPIv2 from "./project_view_history_v2";
 import * as Multichain from "./service";
 import * as Cache from "./service/cache2";
 import * as DocumentValidationService from "./service/document_validation";
@@ -52,6 +53,7 @@ import * as ProjectPermissionRevokeService from "./service/project_permission_re
 import * as ProjectPermissionsListService from "./service/project_permissions_list";
 import * as ProjectProjectedBudgetDeleteService from "./service/project_projected_budget_delete";
 import * as ProjectProjectedBudgetUpdateService from "./service/project_projected_budget_update";
+import * as ProjectTraceEventsService from "./service/project_trace_events";
 import * as ProjectUpdateService from "./service/project_update";
 import { ConnectionSettings } from "./service/RpcClient.h";
 import * as SubprojectAssignService from "./service/subproject_assign";
@@ -64,6 +66,7 @@ import * as SubprojectPermissionRevokeService from "./service/subproject_permiss
 import * as SubprojectPermissionListService from "./service/subproject_permissions_list";
 import * as SubprojectProjectedBudgetDeleteService from "./service/subproject_projected_budget_delete";
 import * as SubprojectProjectedBudgetUpdateService from "./service/subproject_projected_budget_update";
+import * as SubprojectTraceEventsService from "./service/subproject_trace_events";
 import * as SubprojectUpdateService from "./service/subproject_update";
 import * as UserAuthenticateService from "./service/user_authenticate";
 import * as UserCreateService from "./service/user_create";
@@ -76,6 +79,7 @@ import * as WorkflowitemListService from "./service/workflowitem_list";
 import * as WorkflowitemPermissionGrantService from "./service/workflowitem_permission_grant";
 import * as WorkflowitemPermissionRevokeService from "./service/workflowitem_permission_revoke";
 import * as WorkflowitemPermissionsListService from "./service/workflowitem_permissions_list";
+import * as WorkflowitemTraceEventsService from "./service/workflowitem_trace_events";
 import * as WorkflowitemUpdateService from "./service/workflowitem_update";
 import * as WorkflowitemsReorderService from "./service/workflowitems_reorder";
 import * as SubprojectAssignAPI from "./subproject_assign";
@@ -90,6 +94,7 @@ import * as SubprojectPermissionListAPI from "./subproject_permissions_list";
 import * as SubprojectUpdateAPI from "./subproject_update";
 import * as SubprojectViewDetailsAPI from "./subproject_view_details";
 import * as SubprojectViewHistoryAPI from "./subproject_view_history";
+import * as SubprojectViewHistoryAPIv2 from "./subproject_view_history_v2";
 import * as UserAuthenticateAPI from "./user_authenticate";
 import * as UserCreateAPI from "./user_create";
 import * as UserListAPI from "./user_list";
@@ -102,6 +107,7 @@ import * as WorkflowitemPermissionRevokeAPI from "./workflowitem_permission_revo
 import * as WorkflowitemPermissionsListAPI from "./workflowitem_permissions_list";
 import * as WorkflowitemUpdateAPI from "./workflowitem_update";
 import * as WorkflowitemValidateDocumentAPI from "./workflowitem_validate_document";
+import * as WorkflowitemViewHistoryAPI from "./workflowitem_view_history";
 import * as WorkflowitemsReorderAPI from "./workflowitems_reorder";
 
 const URL_PREFIX = "/api";
@@ -371,6 +377,11 @@ ProjectViewHistoryAPI.addHttpHandler(server, URL_PREFIX, {
     SubprojectListService.listSubprojects(db, ctx, user, projectId),
 });
 
+ProjectViewHistoryAPIv2.addHttpHandler(server, URL_PREFIX, {
+  getProjectTraceEvents: (ctx, user, projectId) =>
+    ProjectTraceEventsService.getTraceEvents(db, ctx, user, projectId),
+});
+
 ProjectProjectedBudgetUpdateAPI.addHttpHandler(server, URL_PREFIX, {
   updateProjectedBudget: (ctx, user, projectId, orga, amount, currencyCode) =>
     ProjectProjectedBudgetUpdateService.updateProjectedBudget(
@@ -433,6 +444,11 @@ SubprojectViewHistoryAPI.addHttpHandler(server, URL_PREFIX, {
     SubprojectGetService.getSubproject(db, ctx, user, projectId, subprojectId),
   getWorkflowitems: (ctx, user, projectId, subprojectId) =>
     WorkflowitemListService.listWorkflowitems(db, ctx, user, projectId, subprojectId),
+});
+
+SubprojectViewHistoryAPIv2.addHttpHandler(server, URL_PREFIX, {
+  getSubprojectTraceEvents: (ctx, user, projectId, subprojectId) =>
+    SubprojectTraceEventsService.getTraceEvents(db, ctx, user, projectId, subprojectId),
 });
 
 SubprojectPermissionListAPI.addHttpHandler(server, URL_PREFIX, {
@@ -498,6 +514,7 @@ SubprojectProjectedBudgetDeleteAPI.addHttpHandler(server, URL_PREFIX, {
       currencyCode,
     ),
 });
+
 WorkflowitemsReorderAPI.addHttpHandler(server, URL_PREFIX, {
   setWorkflowitemOrdering: (ctx, user, projectId, subprojectId, ordering) =>
     WorkflowitemsReorderService.setWorkflowitemOrdering(
@@ -522,6 +539,18 @@ SubprojectUpdateAPI.addHttpHandler(server, URL_PREFIX, {
 WorkflowitemListAPI.addHttpHandler(server, URL_PREFIX, {
   listWorkflowitems: (ctx, user, projectId, subprojectId) =>
     WorkflowitemListService.listWorkflowitems(db, ctx, user, projectId, subprojectId),
+});
+
+WorkflowitemViewHistoryAPI.addHttpHandler(server, URL_PREFIX, {
+  getWorkflowitemTraceEvents: (ctx, user, projectId, subprojectId, workflowitemId) =>
+    WorkflowitemTraceEventsService.getTraceEvents(
+      db,
+      ctx,
+      user,
+      projectId,
+      subprojectId,
+      workflowitemId,
+    ),
 });
 
 WorkflowitemPermissionsListAPI.addHttpHandler(server, URL_PREFIX, {

--- a/api/src/project_view_history_v2.ts
+++ b/api/src/project_view_history_v2.ts
@@ -1,26 +1,24 @@
 import { FastifyInstance } from "fastify";
-import Joi = require("joi");
 
 import { toHttpError } from "./http_errors";
 import * as NotAuthenticated from "./http_errors/not_authenticated";
 import { AuthenticatedRequest } from "./httpd/lib";
 import { Ctx } from "./lib/ctx";
 import { isNonemptyString } from "./lib/validation";
-import * as Result from "./result";
-import { BusinessEvent } from "./service/domain/business_event";
 import { ServiceUser } from "./service/domain/organization/service_user";
 import * as Project from "./service/domain/workflow/project";
+import { ProjectTraceEvent } from "./service/domain/workflow/project_trace_event";
 import * as Subproject from "./service/domain/workflow/subproject";
+import { SubprojectTraceEvent } from "./service/domain/workflow/subproject_trace_event";
 
 function mkSwaggerSchema(server: FastifyInstance) {
   return {
     beforeHandler: [(server as any).authenticate],
     schema: {
-      deprecated: true,
       description:
         "View the history of a given project (filtered by what the user is allowed to see).",
       tags: ["project"],
-      summary: "View history",
+      summary: "View project history",
       querystring: {
         type: "object",
         properties: {
@@ -41,56 +39,48 @@ function mkSwaggerSchema(server: FastifyInstance) {
           },
         },
       },
-      security: [
-        {
-          bearerToken: [],
-        },
-      ],
+      security: [{ bearerToken: [] }],
       response: {
         200: {
-          description: "successful response",
+          description: "changes related to the given project in chronological order",
           type: "object",
           properties: {
-            apiVersion: { type: "string", example: "1.0" },
-            data: {
-              type: "object",
-              properties: {
-                events: {
-                  type: "array",
-                  items: {
+            historyItemsCount: {
+              type: "number",
+              description:
+                "Total number of history items (greater or equal to the number of returned items)",
+              example: 10,
+            },
+            events: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  entityId: { type: "string", example: "d0e8c69eg298c87e3899119e025eff1f" },
+                  entityType: { type: "string", example: "project" },
+                  businessEvent: {
                     type: "object",
+                    additionalProperties: true,
                     properties: {
-                      entityId: { type: "string", example: "d0e8c69eg298c87e3899119e025eff1f" },
-                      entityType: { type: "string", example: "project" },
-                      businessEvent: {
-                        type: "object",
-                        additionalProperties: true,
-                        properties: {
-                          type: { type: "string" },
-                          source: { type: "string" },
-                          time: { type: "string" },
-                          publisher: { type: "string" },
-                        },
-                        example: {
-                          type: "project_closed",
-                          source: "http",
-                          time: "2018-09-05T13:37:25.775Z",
-                          publisher: "jdoe",
-                        },
-                      },
-                      snapshot: {
-                        type: "object",
-                        additionalProperties: true,
-                        properties: {
-                          displayName: { type: "string", example: "townproject" },
-                        },
-                      },
+                      type: { type: "string" },
+                      source: { type: "string" },
+                      time: { type: "string" },
+                      publisher: { type: "string" },
+                    },
+                    example: {
+                      type: "project_closed",
+                      source: "http",
+                      time: "2018-09-05T13:37:25.775Z",
+                      publisher: "jdoe",
                     },
                   },
-                },
-                historyItemsCount: {
-                  type: "number",
-                  example: 10,
+                  snapshot: {
+                    type: "object",
+                    additionalProperties: true,
+                    properties: {
+                      displayName: { type: "string", example: "Build a country" },
+                    },
+                  },
                 },
               },
             },
@@ -102,23 +92,17 @@ function mkSwaggerSchema(server: FastifyInstance) {
   };
 }
 
-interface ExposedEvent {
-  entityId: string;
-  entityType: "project" | "subproject";
-  businessEvent: BusinessEvent;
-  snapshot: {
-    displayName?: string;
-  };
-}
-
 interface Service {
-  getProject(ctx: Ctx, user: ServiceUser, projectId: string): Promise<Result.Type<Project.Project>>;
-  getSubprojects(ctx: Ctx, user: ServiceUser, projectId: string): Promise<Subproject.Subproject[]>;
+  getProjectTraceEvents(
+    ctx: Ctx,
+    user: ServiceUser,
+    projectId: Project.Id,
+  ): Promise<ProjectTraceEvent[]>;
 }
 
 export function addHttpHandler(server: FastifyInstance, urlPrefix: string, service: Service) {
   server.get(
-    `${urlPrefix}/project.viewHistory`,
+    `${urlPrefix}/project.viewHistory.v2`,
     mkSwaggerSchema(server),
     async (request, reply) => {
       const ctx: Ctx = { requestId: request.id, source: "http" };
@@ -167,21 +151,7 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
       }
 
       try {
-        const projectResult = await service.getProject(ctx, user, projectId);
-        if (Result.isErr(projectResult)) {
-          projectResult.message = `project.viewHistory failed: ${projectResult.message}`;
-          throw projectResult;
-        }
-        const project: Project.Project = projectResult;
-
-        // Add subprojects' logs to the project log and sort by creation time:
-        const subprojects = await service.getSubprojects(ctx, user, projectId);
-        const events: ExposedEvent[] = project.log;
-        for (const subproject of subprojects) {
-          events.push(...subproject.log);
-        }
-
-        events.sort(byEventTime);
+        const events = await service.getProjectTraceEvents(ctx, user, projectId);
 
         const offsetIndex = offset < 0 ? Math.max(0, events.length + offset) : offset;
         const slice = events.slice(
@@ -191,11 +161,8 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
 
         const code = 200;
         const body = {
-          apiVersion: "1.0",
-          data: {
-            events: slice,
-            historyItemsCount: events.length,
-          },
+          historyItemsCount: events.length,
+          events: slice,
         };
         reply.status(code).send(body);
       } catch (err) {
@@ -204,12 +171,4 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
       }
     },
   );
-}
-
-function byEventTime(a: ExposedEvent, b: ExposedEvent): -1 | 0 | 1 {
-  const timeA = new Date(a.businessEvent.time);
-  const timeB = new Date(b.businessEvent.time);
-  if (timeA < timeB) return -1;
-  if (timeA > timeB) return 1;
-  return 0;
 }

--- a/api/src/service/project_trace_events.ts
+++ b/api/src/service/project_trace_events.ts
@@ -1,0 +1,17 @@
+import { Ctx } from "../lib/ctx";
+import * as Result from "../result";
+import { ConnToken } from "./conn";
+import { ServiceUser } from "./domain/organization/service_user";
+import { ProjectTraceEvent } from "./domain/workflow/project_trace_event";
+import * as ProjectGet from "./project_get";
+
+export async function getTraceEvents(
+  conn: ConnToken,
+  ctx: Ctx,
+  serviceUser: ServiceUser,
+  projectId: string,
+): Promise<ProjectTraceEvent[]> {
+  const project = await ProjectGet.getProject(conn, ctx, serviceUser, projectId);
+  if (Result.isErr(project)) throw project;
+  return project.log;
+}

--- a/api/src/service/subproject_trace_events.ts
+++ b/api/src/service/subproject_trace_events.ts
@@ -1,0 +1,25 @@
+import { Ctx } from "../lib/ctx";
+import * as Result from "../result";
+import { ConnToken } from "./conn";
+import { ServiceUser } from "./domain/organization/service_user";
+import { SubprojectTraceEvent } from "./domain/workflow/subproject_trace_event";
+import * as SubprojectGet from "./subproject_get";
+
+export async function getTraceEvents(
+  conn: ConnToken,
+  ctx: Ctx,
+  serviceUser: ServiceUser,
+  projectId: string,
+  subprojectId: string,
+): Promise<SubprojectTraceEvent[]> {
+  const subproject = await SubprojectGet.getSubproject(
+    conn,
+    ctx,
+    serviceUser,
+    projectId,
+    subprojectId,
+  );
+  if (Result.isErr(subproject)) throw subproject;
+
+  return subproject.log;
+}

--- a/api/src/service/workflowitem_trace_events.ts
+++ b/api/src/service/workflowitem_trace_events.ts
@@ -1,0 +1,27 @@
+import { Ctx } from "../lib/ctx";
+import * as Result from "../result";
+import { ConnToken } from "./conn";
+import { ServiceUser } from "./domain/organization/service_user";
+import { WorkflowitemTraceEvent } from "./domain/workflow/workflowitem_trace_event";
+import * as WorkflowitemGet from "./workflowitem_get";
+
+export async function getTraceEvents(
+  conn: ConnToken,
+  ctx: Ctx,
+  serviceUser: ServiceUser,
+  projectId: string,
+  subprojectId: string,
+  workflowitemId: string,
+): Promise<WorkflowitemTraceEvent[]> {
+  const workflowitem = await WorkflowitemGet.getWorkflowitem(
+    conn,
+    ctx,
+    serviceUser,
+    projectId,
+    subprojectId,
+    workflowitemId,
+  );
+  if (Result.isErr(workflowitem)) throw workflowitem;
+
+  return workflowitem.log;
+}

--- a/api/src/subproject_view_history.ts
+++ b/api/src/subproject_view_history.ts
@@ -13,34 +13,11 @@ import * as Project from "./service/domain/workflow/project";
 import * as Subproject from "./service/domain/workflow/subproject";
 import * as Workflowitem from "./service/domain/workflow/workflowitem";
 
-interface RequestBodyV1 {
-  apiVersion: "1.0";
-  data: {
-    projectId: Project.Id;
-    subprojectId: Subproject.Id;
-  };
-}
-
-const requestBodyV1Schema = Joi.object({
-  apiVersion: Joi.valid("1.0").required(),
-  data: Joi.object({
-    projectId: Project.idSchema.required(),
-    subprojectId: Subproject.idSchema.required(),
-  }),
-});
-
-type RequestBody = RequestBodyV1;
-const requestBodySchema = Joi.alternatives([requestBodyV1Schema]);
-
-function validateRequestBody(body: any): Result.Type<RequestBody> {
-  const { error, value } = Joi.validate(body, requestBodySchema);
-  return !error ? value : error;
-}
-
 function mkSwaggerSchema(server: FastifyInstance) {
   return {
     beforeHandler: [(server as any).authenticate],
     schema: {
+      deprecated: true,
       description:
         "View the history of a given project (filtered by what the user is allowed to see).",
       tags: ["subproject"],
@@ -178,7 +155,7 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
       }
 
       const subprojectId = request.query.subprojectId;
-      if (!isNonemptyString(projectId)) {
+      if (!isNonemptyString(subprojectId)) {
         reply.status(404).send({
           apiVersion: "1.0",
           error: {

--- a/api/src/subproject_view_history_v2.ts
+++ b/api/src/subproject_view_history_v2.ts
@@ -1,30 +1,30 @@
 import { FastifyInstance } from "fastify";
-import Joi = require("joi");
 
 import { toHttpError } from "./http_errors";
 import * as NotAuthenticated from "./http_errors/not_authenticated";
 import { AuthenticatedRequest } from "./httpd/lib";
 import { Ctx } from "./lib/ctx";
 import { isNonemptyString } from "./lib/validation";
-import * as Result from "./result";
-import { BusinessEvent } from "./service/domain/business_event";
 import { ServiceUser } from "./service/domain/organization/service_user";
 import * as Project from "./service/domain/workflow/project";
 import * as Subproject from "./service/domain/workflow/subproject";
+import { SubprojectTraceEvent } from "./service/domain/workflow/subproject_trace_event";
 
 function mkSwaggerSchema(server: FastifyInstance) {
   return {
     beforeHandler: [(server as any).authenticate],
     schema: {
-      deprecated: true,
       description:
-        "View the history of a given project (filtered by what the user is allowed to see).",
-      tags: ["project"],
-      summary: "View history",
+        "View the history of a given subproject (filtered by what the user is allowed to see).",
+      tags: ["subproject"],
+      summary: "View subproject history",
       querystring: {
         type: "object",
         properties: {
           projectId: {
+            type: "string",
+          },
+          subprojectId: {
             type: "string",
           },
           limit: {
@@ -41,56 +41,48 @@ function mkSwaggerSchema(server: FastifyInstance) {
           },
         },
       },
-      security: [
-        {
-          bearerToken: [],
-        },
-      ],
+      security: [{ bearerToken: [] }],
       response: {
         200: {
-          description: "successful response",
+          description: "changes related to the given subproject in chronological order",
           type: "object",
           properties: {
-            apiVersion: { type: "string", example: "1.0" },
-            data: {
-              type: "object",
-              properties: {
-                events: {
-                  type: "array",
-                  items: {
+            historyItemsCount: {
+              type: "number",
+              description:
+                "Total number of history items (greater or equal to the number of returned items)",
+              example: 10,
+            },
+            events: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  entityId: { type: "string", example: "d0e8c69eg298c87e3899119e025eff1f" },
+                  entityType: { type: "string", example: "subproject" },
+                  businessEvent: {
                     type: "object",
+                    additionalProperties: true,
                     properties: {
-                      entityId: { type: "string", example: "d0e8c69eg298c87e3899119e025eff1f" },
-                      entityType: { type: "string", example: "project" },
-                      businessEvent: {
-                        type: "object",
-                        additionalProperties: true,
-                        properties: {
-                          type: { type: "string" },
-                          source: { type: "string" },
-                          time: { type: "string" },
-                          publisher: { type: "string" },
-                        },
-                        example: {
-                          type: "project_closed",
-                          source: "http",
-                          time: "2018-09-05T13:37:25.775Z",
-                          publisher: "jdoe",
-                        },
-                      },
-                      snapshot: {
-                        type: "object",
-                        additionalProperties: true,
-                        properties: {
-                          displayName: { type: "string", example: "townproject" },
-                        },
-                      },
+                      type: { type: "string" },
+                      source: { type: "string" },
+                      time: { type: "string" },
+                      publisher: { type: "string" },
+                    },
+                    example: {
+                      type: "subproject_closed",
+                      source: "http",
+                      time: "2018-09-05T13:37:25.775Z",
+                      publisher: "jdoe",
                     },
                   },
-                },
-                historyItemsCount: {
-                  type: "number",
-                  example: 10,
+                  snapshot: {
+                    type: "object",
+                    additionalProperties: true,
+                    properties: {
+                      displayName: { type: "string", example: "Build a town" },
+                    },
+                  },
                 },
               },
             },
@@ -102,23 +94,18 @@ function mkSwaggerSchema(server: FastifyInstance) {
   };
 }
 
-interface ExposedEvent {
-  entityId: string;
-  entityType: "project" | "subproject";
-  businessEvent: BusinessEvent;
-  snapshot: {
-    displayName?: string;
-  };
-}
-
 interface Service {
-  getProject(ctx: Ctx, user: ServiceUser, projectId: string): Promise<Result.Type<Project.Project>>;
-  getSubprojects(ctx: Ctx, user: ServiceUser, projectId: string): Promise<Subproject.Subproject[]>;
+  getSubprojectTraceEvents(
+    ctx: Ctx,
+    user: ServiceUser,
+    projectId: Project.Id,
+    subprojectId: Subproject.Id,
+  ): Promise<SubprojectTraceEvent[]>;
 }
 
 export function addHttpHandler(server: FastifyInstance, urlPrefix: string, service: Service) {
   server.get(
-    `${urlPrefix}/project.viewHistory`,
+    `${urlPrefix}/subproject.viewHistory.v2`,
     mkSwaggerSchema(server),
     async (request, reply) => {
       const ctx: Ctx = { requestId: request.id, source: "http" };
@@ -135,6 +122,19 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
           error: {
             code: 404,
             message: "required query parameter `projectId` not present (must be non-empty string)",
+          },
+        });
+        return;
+      }
+
+      const subprojectId = request.query.subprojectId;
+      if (!isNonemptyString(subprojectId)) {
+        reply.status(404).send({
+          apiVersion: "1.0",
+          error: {
+            code: 404,
+            message:
+              "required query parameter `subprojectId` not present (must be non-empty string)",
           },
         });
         return;
@@ -167,21 +167,7 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
       }
 
       try {
-        const projectResult = await service.getProject(ctx, user, projectId);
-        if (Result.isErr(projectResult)) {
-          projectResult.message = `project.viewHistory failed: ${projectResult.message}`;
-          throw projectResult;
-        }
-        const project: Project.Project = projectResult;
-
-        // Add subprojects' logs to the project log and sort by creation time:
-        const subprojects = await service.getSubprojects(ctx, user, projectId);
-        const events: ExposedEvent[] = project.log;
-        for (const subproject of subprojects) {
-          events.push(...subproject.log);
-        }
-
-        events.sort(byEventTime);
+        const events = await service.getSubprojectTraceEvents(ctx, user, projectId, subprojectId);
 
         const offsetIndex = offset < 0 ? Math.max(0, events.length + offset) : offset;
         const slice = events.slice(
@@ -191,11 +177,8 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
 
         const code = 200;
         const body = {
-          apiVersion: "1.0",
-          data: {
-            events: slice,
-            historyItemsCount: events.length,
-          },
+          historyItemsCount: events.length,
+          events: slice,
         };
         reply.status(code).send(body);
       } catch (err) {
@@ -204,12 +187,4 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
       }
     },
   );
-}
-
-function byEventTime(a: ExposedEvent, b: ExposedEvent): -1 | 0 | 1 {
-  const timeA = new Date(a.businessEvent.time);
-  const timeB = new Date(b.businessEvent.time);
-  if (timeA < timeB) return -1;
-  if (timeA > timeB) return 1;
-  return 0;
 }


### PR DESCRIPTION
The new endpoints return only the history for the selected project, subproject
or workflowitem. Previously, a subproject's history would also contain the
workflowitems' history elements.

Co-authored-by: Mathias Höld <mathias.hoeld@accenture.com>

Related to #252 