### PR TITLE
Fix fetching of history items and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+- Correct number of display items is displayed when history drawer/list is opened [#275](https://github.com/openkfw/TruBudget/pull/275)
+- Display formatted string when user edits or deletes projected budget [#279](https://github.com/openkfw/TruBudget/pull/279)
+
 
 <!-- ### Security -->
 

--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -329,6 +329,8 @@ const en = {
     project_createSubproject: "{0} created subproject {1}",
     project_grantPermission: "{0} granted permission {1} to {2}",
     project_grantPermission_details: "{0} granted permission {1} to {2} on {3}",
+    project_projected_budget_updated: "{0} updated the projected budget of {1}",
+    project_projected_budget_deleted: "{0} deleted the projected budget of {1}",
     project_revokePermission: "{0} revoked permission {1} from {2}",
     project_revokePermission_details: "{0} revoked permission {1} from {2} on {3}",
     project_update: "{0} changed project {1} ",

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -331,6 +331,8 @@ const fr = {
     project_createSubproject: "{0} a crée la composante {1}",
     project_grantPermission: "{0} a accordé l'autorisation {1} à {2}",
     project_grantPermission_details: "{0} a modifié l'autorisation {1} à {2} de {3}",
+    project_projected_budget_updated: "{0} a mis à jour le budget prévu de {1}",
+    project_projected_budget_deleted: "{0} a supprimé le budget prévu de {1}",
     project_revokePermission: "{0} a révoquer l'autorisation {1} de {2}",
     project_revokePermission_details: "{0} a revoqué l'autorisation  {1} à {2} de {3}",
     project_update: "{0} a modifié le projet {1} ",

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -329,6 +329,8 @@ const de = {
     project_createSubproject: "German: {0} created subproject {1}",
     project_grantPermission: "German: {0} granted permission {1} to {2}",
     project_grantPermission_details: "{0} gab Rechte {1} an {2} für {3}",
+    project_projected_budget_updated: "{0} veränderte das geplante Budget von {1}",
+    project_projected_budget_deleted: "{0} löschte das geplante Budget von {1}",
     project_revokePermission: "German: {0} revoked permission {1} from {2}",
     project_revokePermission_details: "{0} entzog Rechte {1} von {2} für {3}",
     project_update: "{0} veränderte Projekt {1} ",

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -330,6 +330,8 @@ const pt = {
     project_createSubproject: "Portuguese: {0} created subproject {1}",
     project_grantPermission: "Portuguese: {0} granted permission {1} to {2}",
     project_grantPermission_details: "Portuguese: {0} granted permission {1} to {2} on {3}",
+    project_projected_budget_updated: "PORTUGUESE: {0} updated the projected budget of {1}",
+    project_projected_budget_deleted: "PORTUGUESE: {0} deleted the projected budget of {1}",
     project_revokePermission: "Portuguese: {0} revoked permission {1} from {2}",
     project_revokePermission_details: "Portuguese: {0} revoked permission {1} of {3} from {2}",
     project_update: "{0} modificou o projeto {1} ",

--- a/frontend/src/pages/Common/History/ScrollingHistory.js
+++ b/frontend/src/pages/Common/History/ScrollingHistory.js
@@ -12,21 +12,15 @@ const styles = {
   }
 };
 
-export default function ScrollingHistory({
-  nEventsTotal,
-  events,
-  fetchNext,
-  hasMore,
-  isLoading,
-  getUserDisplayname,
-  initialLoad = false
-}) {
+export default function ScrollingHistory({ nEventsTotal, events, fetchNext, hasMore, isLoading, getUserDisplayname }) {
   return (
     <InfiniteScroll
       pageStart={0}
-      initialLoad={initialLoad}
+      initialLoad={true}
       useWindow={false}
-      loadMore={_ => isLoading || fetchNext()}
+      loadMore={_ => {
+        if (!isLoading && hasMore) fetchNext();
+      }}
       hasMore={hasMore}
       loader={
         <div className="loader" key={0} style={styles.loader}>

--- a/frontend/src/pages/Notifications/actions.js
+++ b/frontend/src/pages/Notifications/actions.js
@@ -85,7 +85,7 @@ export function markNotificationAsRead(notificationId, offset, limit) {
   };
 }
 
-export function showHistory() {
+export function openHistory() {
   return {
     type: OPEN_HISTORY
   };

--- a/frontend/src/pages/SubProjects/ProjectHistoryDrawer.js
+++ b/frontend/src/pages/SubProjects/ProjectHistoryDrawer.js
@@ -1,21 +1,22 @@
 import React from "react";
 import { connect } from "react-redux";
+
+import { toJS } from "../../helper";
 import HistoryDrawer from "../Common/History/HistoryDrawer";
 import { hideHistory } from "../Notifications/actions";
-import { fetchProjectHistory } from "./actions";
+import { fetchNextProjectHistoryPage } from "./actions";
 
 function ProjectHistoryDrawer({
   projectId,
-  offset,
-  limit,
   doShow,
   events,
   nEventsTotal,
-  hasMore,
+  currentHistoryPage,
+  lastHistoryPage,
   isLoading,
   getUserDisplayname,
   hideHistory,
-  fetchProjectHistory
+  fetchNextProjectHistoryPage
 }) {
   return (
     <HistoryDrawer
@@ -23,8 +24,8 @@ function ProjectHistoryDrawer({
       onClose={hideHistory}
       events={events}
       nEventsTotal={nEventsTotal}
-      fetchNext={() => fetchProjectHistory(projectId, offset, limit)}
-      hasMore={hasMore}
+      fetchNext={() => fetchNextProjectHistoryPage(projectId)}
+      hasMore={currentHistoryPage < lastHistoryPage}
       isLoading={isLoading}
       getUserDisplayname={getUserDisplayname}
     />
@@ -33,20 +34,19 @@ function ProjectHistoryDrawer({
 
 function mapStateToProps(state) {
   return {
-    offset: state.getIn(["detailview", "offset"]),
-    limit: state.getIn(["detailview", "limit"]),
     doShow: state.getIn(["detailview", "showHistory"]),
     events: state.getIn(["detailview", "historyItems"]),
-    nEventsTotal: state.getIn(["detailview", "historyItemsCount"]),
-    hasMore: state.getIn(["detailview", "hasMoreHistory"]),
+    nEventsTotal: state.getIn(["detailview", "totalHistoryItemCount"]),
     isLoading: state.getIn(["detailview", "isHistoryLoading"]),
+    currentHistoryPage: state.getIn(["detailview", "currentHistoryPage"]),
+    lastHistoryPage: state.getIn(["detailview", "lastHistoryPage"]),
     getUserDisplayname: uid => state.getIn(["login", "userDisplayNameMap", uid]) || "Somebody"
   };
 }
 
 const mapDispatchToProps = {
   hideHistory,
-  fetchProjectHistory
+  fetchNextProjectHistoryPage
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(ProjectHistoryDrawer);
+export default connect(mapStateToProps, mapDispatchToProps)(toJS(ProjectHistoryDrawer));

--- a/frontend/src/pages/SubProjects/SubProjectContainer.js
+++ b/frontend/src/pages/SubProjects/SubProjectContainer.js
@@ -10,11 +10,10 @@ import AdditionalInfo from "../Common/AdditionalInfo";
 import LiveUpdates from "../LiveUpdates/LiveUpdates";
 import { fetchUser } from "../Login/actions";
 import { setSelectedView } from "../Navbar/actions";
-import { hideHistory, showHistory } from "../Notifications/actions";
+import { hideHistory, openHistory } from "../Notifications/actions";
 import {
   closeProject,
   fetchAllProjectDetails,
-  fetchProjectHistory,
   hideSubProjectAdditionalData,
   liveUpdateProject,
   showEditDialog,
@@ -95,9 +94,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     liveUpdate: projectId => dispatch(liveUpdateProject(projectId)),
     showSubprojectDialog: () => dispatch(showSubprojectDialog()),
 
-    openHistory: (projectId, offset, limit) => {
-      dispatch(fetchProjectHistory(projectId, offset, limit, true));
-      dispatch(showHistory());
+    openHistory: () => {
+      dispatch(openHistory());
     },
     hideHistory: () => dispatch(hideHistory()),
     setSelectedView: (id, section) => dispatch(setSelectedView(id, section)),
@@ -131,8 +129,6 @@ const mapStateToProps = state => {
     user: state.getIn(["login", "user"]),
     allowedIntents: state.getIn(["detailview", "allowedIntents"]),
     thumbnail: state.getIn(["detailview", "thumbnail"]),
-    offset: state.getIn(["detailview", "offset"]),
-    limit: state.getIn(["detailview", "limit"]),
     projectedBudgets: state.getIn(["detailview", "projectedBudgets"]),
     isSubProjectAdditionalDataShown: state.getIn(["detailview", "isSubProjectAdditionalDataShown"]),
     idForInfo: state.getIn(["detailview", "idForInfo"])

--- a/frontend/src/pages/SubProjects/SubProjects.js
+++ b/frontend/src/pages/SubProjects/SubProjects.js
@@ -43,7 +43,7 @@ const SubProjects = props => {
         <Fab
           id="project-history-button"
           size="small"
-          onClick={() => props.openHistory(props.projectId, props.offset, props.limit)}
+          onClick={props.openHistory}
           style={{
             position: "relative",
             marginTop: "8px"

--- a/frontend/src/pages/SubProjects/SubprojectHistoryDrawer.js
+++ b/frontend/src/pages/SubProjects/SubprojectHistoryDrawer.js
@@ -1,22 +1,23 @@
 import React from "react";
 import { connect } from "react-redux";
+
+import { toJS } from "../../helper";
 import HistoryDrawer from "../Common/History/HistoryDrawer";
 import { hideHistory } from "../Notifications/actions";
-import { fetchSubprojectHistory } from "../Workflows/actions";
+import { fetchNextSubprojectHistoryPage } from "../Workflows/actions";
 
 function SubprojectHistoryDrawer({
   projectId,
   subprojectId,
-  offset,
-  limit,
   doShow,
   events,
   nEventsTotal,
-  hasMore,
   isLoading,
   getUserDisplayname,
   hideHistory,
-  fetchSubprojectHistory
+  fetchNextSubprojectHistoryPage,
+  currentHistoryPage,
+  lastHistoryPage
 }) {
   return (
     <HistoryDrawer
@@ -24,8 +25,8 @@ function SubprojectHistoryDrawer({
       onClose={hideHistory}
       events={events}
       nEventsTotal={nEventsTotal}
-      fetchNext={() => fetchSubprojectHistory(projectId, subprojectId, offset, limit)}
-      hasMore={hasMore}
+      fetchNext={() => fetchNextSubprojectHistoryPage(projectId, subprojectId)}
+      hasMore={currentHistoryPage < lastHistoryPage}
       isLoading={isLoading}
       getUserDisplayname={getUserDisplayname}
     />
@@ -34,20 +35,19 @@ function SubprojectHistoryDrawer({
 
 function mapStateToProps(state) {
   return {
-    offset: state.getIn(["workflow", "offset"]),
-    limit: state.getIn(["workflow", "limit"]),
     doShow: state.getIn(["workflow", "showHistory"]),
     events: state.getIn(["workflow", "historyItems"]),
     nEventsTotal: state.getIn(["workflow", "historyItemsCount"]),
-    hasMore: state.getIn(["workflow", "hasMoreHistory"]),
     isLoading: state.getIn(["workflow", "isHistoryLoading"]),
+    currentHistoryPage: state.getIn(["workflow", "currentHistoryPage"]),
+    lastHistoryPage: state.getIn(["workflow", "lastHistoryPage"]),
     getUserDisplayname: uid => state.getIn(["login", "userDisplayNameMap", uid]) || "Somebody"
   };
 }
 
 const mapDispatchToProps = {
   hideHistory,
-  fetchSubprojectHistory
+  fetchNextSubprojectHistoryPage
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(SubprojectHistoryDrawer);
+export default connect(mapStateToProps, mapDispatchToProps)(toJS(SubprojectHistoryDrawer));

--- a/frontend/src/pages/SubProjects/actions.js
+++ b/frontend/src/pages/SubProjects/actions.js
@@ -32,8 +32,9 @@ export const ASSIGN_PROJECT_SUCCESS = "ASSIGN_PROJECT_SUCCESS";
 
 export const SET_HISTORY_OFFSET = "SET_HISTORY_OFFSET";
 
-export const FETCH_PROJECT_HISTORY = "FETCH_PROJECT_HISTORY";
-export const FETCH_PROJECT_HISTORY_SUCCESS = "FETCH_PROJECT_HISTORY_SUCCESS";
+export const SET_TOTAL_PROJECT_HISTORY_ITEM_COUNT = "SET_TOTAL_PROJECT_HISTORY_ITEM_COUNT";
+export const FETCH_NEXT_PROJECT_HISTORY_PAGE = "FETCH_NEXT_PROJECT_HISTORY_PAGE";
+export const FETCH_NEXT_PROJECT_HISTORY_PAGE_SUCCESS = "FETCH_NEXT_PROJECT_HISTORY_PAGE_SUCCESS";
 
 export const CLOSE_PROJECT = "CLOSE_PROJECT";
 export const CLOSE_PROJECT_SUCCESS = "CLOSE_PROJECT_SUCCESS";
@@ -94,19 +95,17 @@ export function fetchAllProjectDetails(projectId, showLoading = false) {
   };
 }
 
-export function setProjectHistoryOffset(offset) {
+export function setTotalHistoryItemCount(count) {
   return {
-    type: SET_HISTORY_OFFSET,
-    offset
+    type: SET_TOTAL_PROJECT_HISTORY_ITEM_COUNT,
+    count
   };
 }
 
-export function fetchProjectHistory(projectId, offset, limit, showLoading = false) {
+export function fetchNextProjectHistoryPage(projectId, showLoading = false) {
   return {
-    type: FETCH_PROJECT_HISTORY,
+    type: FETCH_NEXT_PROJECT_HISTORY_PAGE,
     projectId,
-    offset,
-    limit,
     showLoading
   };
 }

--- a/frontend/src/pages/SubProjects/reducer.js
+++ b/frontend/src/pages/SubProjects/reducer.js
@@ -6,14 +6,14 @@ import { HIDE_HISTORY } from "../Notifications/actions";
 import {
   CREATE_SUBPROJECT_SUCCESS,
   FETCH_ALL_PROJECT_DETAILS_SUCCESS,
-  FETCH_PROJECT_HISTORY,
-  FETCH_PROJECT_HISTORY_SUCCESS,
+  FETCH_NEXT_PROJECT_HISTORY_PAGE,
+  FETCH_NEXT_PROJECT_HISTORY_PAGE_SUCCESS,
+  SET_TOTAL_PROJECT_HISTORY_ITEM_COUNT,
   FETCH_SUBPROJECT_PERMISSIONS_SUCCESS,
   HIDE_PROJECT_ASSIGNEES,
   HIDE_SUBPROJECT_ADDITIONAL_DATA,
   HIDE_SUBPROJECT_DIALOG,
   HIDE_SUBPROJECT_PERMISSIONS,
-  SET_HISTORY_OFFSET,
   SHOW_PROJECT_ASSIGNEES,
   SHOW_SUBPROJECT_ADDITIONAL_DATA,
   SHOW_SUBPROJECT_CREATE,
@@ -27,7 +27,7 @@ import {
   OPEN_HISTORY
 } from "./actions";
 
-const initialLimit = 50;
+const historyPageSize = 50;
 
 const defaultState = fromJS({
   id: "",
@@ -52,9 +52,10 @@ const defaultState = fromJS({
   logs: [],
   historyItems: [],
   isHistoryLoading: false,
-  historyItemsCount: 0,
-  offset: -initialLimit,
-  limit: initialLimit,
+  totalHistoryItemCount: 0,
+  historyPageSize: historyPageSize,
+  currentHistoryPage: 0,
+  lastHistoryPage: 1,
   allowedIntents: [],
   showSubProjectPermissions: false,
   isSubProjectAdditionalDataShown: false,
@@ -130,27 +131,29 @@ export default function detailviewReducer(state = defaultState, action) {
       return state.set("showProjectAssignees", false);
     case HIDE_SUBPROJECT_ADDITIONAL_DATA:
       return state.set("isSubProjectAdditionalDataShown", false);
-    case SET_HISTORY_OFFSET:
-      return state.set("offset", action.offset);
-    case FETCH_PROJECT_HISTORY:
+    case FETCH_NEXT_PROJECT_HISTORY_PAGE:
       return state.set("isHistoryLoading", true);
-    case FETCH_PROJECT_HISTORY_SUCCESS:
+    case SET_TOTAL_PROJECT_HISTORY_ITEM_COUNT:
+      return state.merge({
+        totalHistoryItemCount: action.totalHistoryItemsCount,
+        lastHistoryPage: action.lastHistoryPage
+      });
+
+    case FETCH_NEXT_PROJECT_HISTORY_PAGE_SUCCESS:
       return state.merge({
         historyItems: state.get("historyItems").concat(fromJS(action.events).reverse()),
-        historyItemsCount: action.historyItemsCount,
-        isHistoryLoading: false,
-        offset: action.offset,
-        limit: action.limit,
-        hasMoreHistory: action.hasMore
+        currentHistoryPage: action.currentHistoryPage,
+        isHistoryLoading: false
       });
     case OPEN_HISTORY:
       return state.set("showHistory", true);
     case HIDE_HISTORY:
       return state.merge({
         historyItems: fromJS([]),
-        offset: defaultState.get("offset"),
-        limit: defaultState.get("limit"),
-        showHistory: false
+        showHistory: false,
+        lastHistoryPage: defaultState.get("lastHistoryPage"),
+        currentHistoryPage: defaultState.get("currentHistoryPage"),
+        totalHistoryItemCount: defaultState.get("totalHistoryItemCount")
       });
     case SHOW_SUBPROJECT_EDIT: {
       return state

--- a/frontend/src/pages/WorkflowitemDetails/WorkflowHistoryTab.js
+++ b/frontend/src/pages/WorkflowitemDetails/WorkflowHistoryTab.js
@@ -1,30 +1,30 @@
 import React from "react";
 import { connect } from "react-redux";
 
+import { toJS } from "../../helper";
 import ScrollingHistory from "../Common/History/ScrollingHistory";
-import { fetchWorkflowitemHistory } from "../WorkflowitemDetails/actions";
+import { fetchNextWorkflowitemHistoryPage } from "../WorkflowitemDetails/actions";
 
 function WorkflowitemHistoryTab({
   projectId,
   subprojectId,
   workflowitemId,
-  offset,
-  limit,
   events,
   nEventsTotal,
-  hasMore,
   isLoading,
   getUserDisplayname,
-  fetchWorkflowitemHistory
+  fetchNextWorkflowitemHistoryPage,
+  currentHistoryPage,
+  lastHistoryPage
 }) {
   return (
     <ScrollingHistory
       events={events}
       nEventsTotal={nEventsTotal}
-      hasMore={hasMore}
+      hasMore={currentHistoryPage < lastHistoryPage}
       isLoading={isLoading}
       getUserDisplayname={getUserDisplayname}
-      fetchNext={() => fetchWorkflowitemHistory(projectId, subprojectId, workflowitemId, offset, limit)}
+      fetchNext={() => fetchNextWorkflowitemHistoryPage(projectId, subprojectId, workflowitemId)}
       initialLoad={true}
     />
   );
@@ -32,18 +32,17 @@ function WorkflowitemHistoryTab({
 
 function mapStateToProps(state) {
   return {
-    offset: state.getIn(["workflowitemDetails", "offset"]),
-    limit: state.getIn(["workflowitemDetails", "limit"]),
     events: state.getIn(["workflowitemDetails", "events"]),
-    nEventsTotal: state.getIn(["workflowitemDetails", "nEventsTotal"]),
-    hasMore: state.getIn(["workflowitemDetails", "hasMore"]),
-    isLoading: state.getIn(["workflowitemDetails", "isLoading"]),
+    nEventsTotal: state.getIn(["workflowitemDetails", "totalHistoryItemCount"]),
+    isLoading: state.getIn(["workflowitemDetails", "isHistoryLoading"]),
+    currentHistoryPage: state.getIn(["workflowitemDetails", "currentHistoryPage"]),
+    lastHistoryPage: state.getIn(["workflowitemDetails", "lastHistoryPage"]),
     getUserDisplayname: uid => state.getIn(["login", "userDisplayNameMap", uid]) || "Somebody"
   };
 }
 
 const mapDispatchToProps = {
-  fetchWorkflowitemHistory
+  fetchNextWorkflowitemHistoryPage
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(WorkflowitemHistoryTab);
+export default connect(mapStateToProps, mapDispatchToProps)(toJS(WorkflowitemHistoryTab));

--- a/frontend/src/pages/WorkflowitemDetails/actions.js
+++ b/frontend/src/pages/WorkflowitemDetails/actions.js
@@ -1,14 +1,20 @@
-export const FETCH_WORKFLOWITEM_HISTORY = "FETCH_WORKFLOWITEM_HISTORY";
-export const FETCH_WORKFLOWITEM_HISTORY_SUCCESS = "FETCH_WORKFLOWITEM_HISTORY_SUCCESS";
+export const SET_TOTAL_WORKFLOWITEM_HISTORY_ITEM_COUNT = "SET_TOTAL_WORKFLOWITEM_HISTORY_ITEM_COUNT";
+export const FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE = "FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE";
+export const FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE_SUCCESS = "FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE_SUCCESS";
 
-export function fetchWorkflowitemHistory(projectId, subprojectId, workflowitemId, offset, limit, showLoading = false) {
+export function setTotalHistoryItemCount(count) {
   return {
-    type: FETCH_WORKFLOWITEM_HISTORY,
+    type: SET_TOTAL_WORKFLOWITEM_HISTORY_ITEM_COUNT,
+    count
+  };
+}
+
+export function fetchNextWorkflowitemHistoryPage(projectId, subprojectId, workflowitemId, showLoading = false) {
+  return {
+    type: FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE,
     projectId,
     subprojectId,
     workflowitemId,
-    offset,
-    limit,
     showLoading
   };
 }

--- a/frontend/src/pages/WorkflowitemDetails/reducer.js
+++ b/frontend/src/pages/WorkflowitemDetails/reducer.js
@@ -1,34 +1,42 @@
 import { fromJS } from "immutable";
 
-import { FETCH_WORKFLOWITEM_HISTORY, FETCH_WORKFLOWITEM_HISTORY_SUCCESS } from "./actions";
-import { WORKFLOWITEM_DETAILS_CLEANUP_STATE } from "../Workflows/actions";
+import {
+  SET_TOTAL_WORKFLOWITEM_HISTORY_ITEM_COUNT,
+  FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE,
+  FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE_SUCCESS
+} from "./actions";
+import { CLOSE_WORKFLOWITEM_DETAILS } from "../Workflows/actions";
 
-const initialLimit = 30;
+const historyPageSize = 30;
 
 const initialState = fromJS({
-  offset: -initialLimit,
-  limit: initialLimit,
   events: [],
-  nEventsTotal: 0,
-  hasMore: true,
-  isLoading: false
+  totalHistoryItemCount: 0,
+  historyPageSize: historyPageSize,
+  currentHistoryPage: 0,
+  lastHistoryPage: 1,
+  isHistoryLoading: false
 });
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
-    case FETCH_WORKFLOWITEM_HISTORY:
-      return state.set("isLoading", true);
+    case FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE:
+      return state.set("isHistoryLoading", true);
 
-    case FETCH_WORKFLOWITEM_HISTORY_SUCCESS:
-      return state
-        .set("offset", action.offset)
-        .set("limit", action.limit)
-        .updateIn(["events"], events => events.push(...action.events.map(event => fromJS(event)).reverse()))
-        .set("nEventsTotal", action.historyItemsCount)
-        .set("hasMore", action.hasMore)
-        .set("isLoading", false);
+    case SET_TOTAL_WORKFLOWITEM_HISTORY_ITEM_COUNT:
+      return state.merge({
+        totalHistoryItemCount: action.totalHistoryItemsCount,
+        lastHistoryPage: action.lastHistoryPage
+      });
 
-    case WORKFLOWITEM_DETAILS_CLEANUP_STATE:
+    case FETCH_NEXT_WORKFLOWITEM_HISTORY_PAGE_SUCCESS:
+      return state.merge({
+        events: state.get("events").concat(fromJS(action.events).reverse()),
+        currentHistoryPage: action.currentHistoryPage,
+        isHistoryLoading: false
+      });
+
+    case CLOSE_WORKFLOWITEM_DETAILS:
       return initialState;
 
     default:

--- a/frontend/src/pages/Workflows/Workflow.js
+++ b/frontend/src/pages/Workflows/Workflow.js
@@ -51,7 +51,7 @@ const Workflow = props => {
           id="subproject-history-button"
           size="small"
           disabled={props.workflowSortEnabled}
-          onClick={() => props.openHistory(props.projectId, props.subProjectId, props.offset, props.limit)}
+          onClick={props.openHistory}
           color="default"
           style={{
             position: "relative",

--- a/frontend/src/pages/Workflows/WorkflowContainer.js
+++ b/frontend/src/pages/Workflows/WorkflowContainer.js
@@ -11,17 +11,16 @@ import { addDocument } from "../Documents/actions";
 import LiveUpdates from "../LiveUpdates/LiveUpdates";
 import { fetchUser } from "../Login/actions";
 import { setSelectedView } from "../Navbar/actions";
-import { showHistory } from "../Notifications/actions";
+import { openHistory } from "../Notifications/actions";
 import SubprojectHistoryDrawer from "../SubProjects/SubprojectHistoryDrawer";
 import {
-  cleanupWorkflowitemDetailsState,
+  closeWorkflowitemDetailsDialog,
   closeSubproject,
   closeWorkflowItem,
   disableWorkflowEdit,
   enableSubProjectBudgetEdit,
   enableWorkflowEdit,
   fetchAllSubprojectDetails,
-  fetchSubprojectHistory,
   fetchWorkflowItems,
   hideWorkflowDetails,
   hideWorkflowDialog,
@@ -134,13 +133,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     showCreateDialog: () => dispatch(showCreateDialog()),
     updateSubProject: (pId, sId) => dispatch(liveUpdateSubproject(pId, sId)),
     showSubProjectAssignee: () => dispatch(showSubProjectAssignee()),
-    openHistory: (projectId, subprojectId, offset, limit) => {
-      dispatch(fetchSubprojectHistory(projectId, subprojectId, offset, limit, true));
-      dispatch(showHistory());
+    openHistory: () => {
+      dispatch(openHistory());
     },
     openWorkflowDetails: id => dispatch(showWorkflowDetails(id)),
     hideWorkflowDetails: () => dispatch(hideWorkflowDetails()),
-    cleanupWorkflowitemDetailsState: () => dispatch(cleanupWorkflowitemDetailsState()),
+    closeWorkflowitemDetailsDialog: () => dispatch(closeWorkflowitemDetailsDialog()),
     closeSubproject: (pId, sId) => dispatch(closeSubproject(pId, sId, true)),
     closeWorkflowItem: (pId, sId, wId) => dispatch(closeWorkflowItem(pId, sId, wId, true)),
 
@@ -195,13 +193,10 @@ const mapStateToProps = state => {
     workflowDocuments: state.getIn(["documents", "tempDocuments"]),
     validatedDocuments: state.getIn(["documents", "validatedDocuments"]),
     users: state.getIn(["login", "user"]),
-    offset: state.getIn(["workflow", "offset"]),
-    limit: state.getIn(["workflow", "limit"]),
     selectedWorkflowItems: state.getIn(["workflow", "selectedWorkflowItems"]),
     projectedBudgets: state.getIn(["workflow", "projectedBudgets"]),
     idForInfo: state.getIn(["workflow", "idForInfo"]),
     isWorkflowitemAdditionalDataShown: state.getIn(["workflow", "isWorkflowitemAdditionalDataShown"]),
-    historyItemsCount: state.getIn(["workflow", "historyItemsCount"]),
     isLoading: state.getIn(["workflow", "isHistoryLoading"])
   };
 };

--- a/frontend/src/pages/Workflows/WorkflowDetails.js
+++ b/frontend/src/pages/Workflows/WorkflowDetails.js
@@ -128,7 +128,7 @@ function WorkflowDetails({
   showWorkflowDetails,
   showDetailsItemId,
   hideWorkflowDetails,
-  cleanupWorkflowitemDetailsState,
+  closeWorkflowitemDetailsDialog,
   users,
   validateDocument,
   validatedDocuments,
@@ -165,7 +165,7 @@ function WorkflowDetails({
   }
 
   return (
-    <Dialog open={showWorkflowDetails} style={styles.dialog} onExited={cleanupWorkflowitemDetailsState}>
+    <Dialog open={showWorkflowDetails} style={styles.dialog} onExited={closeWorkflowitemDetailsDialog}>
       <DialogTitle data-test="workflowInfoDialog">{strings.workflow.workflowitem_details}</DialogTitle>
       <DialogContent style={styles.dialogContent}>
         <Tabs value={tabIndex} onChange={(_, index) => setTabIndex(index)}>

--- a/frontend/src/pages/Workflows/actions.js
+++ b/frontend/src/pages/Workflows/actions.js
@@ -42,7 +42,7 @@ export const EDIT_WORKFLOW_ITEM_SUCCESS = "EDIT_WORKFLOW_ITEM_SUCCESS";
 export const WORKFLOW_EDIT = "WORKFLOW_EDIT";
 export const SHOW_WORKFLOW_DETAILS = "SHOW_WORKFLOW_DETAILS";
 export const HIDE_WORKFLOW_DETAILS = "HIDE_WORKFLOW_DETAILS";
-export const WORKFLOWITEM_DETAILS_CLEANUP_STATE = "WORKFLOWITEM_DETAILS_CLEANUP_STATE";
+export const CLOSE_WORKFLOWITEM_DETAILS = "CLOSE_WORKFLOWITEM_DETAILS";
 
 export const ENABLE_WORKFLOW_EDIT = "ENABLE_WORKFLOW_EDIT";
 export const DISABLE_WORKFLOW_EDIT = "DISABLE_WORKFLOW_EDIT";
@@ -59,8 +59,9 @@ export const OPEN_HISTORY = "OPEN_HISTORY";
 export const HIDE_HISTORY = "HIDE_HISTORY";
 export const OPEN_HISTORY_SUCCESS = "OPEN_HISTORY_SUCCESS";
 
-export const FETCH_SUBPROJECT_HISTORY = "FETCH_SUBPROJECT_HISTORY";
-export const FETCH_SUBPROJECT_HISTORY_SUCCESS = "FETCH_SUBPROJECT_HISTORY_SUCCESS";
+export const SET_TOTAL_SUBPROJECT_HISTORY_ITEM_COUNT = "SET_TOTAL_SUBPROJECT_HISTORY_ITEM_COUNT";
+export const FETCH_NEXT_SUBPROJECT_HISTORY_PAGE = "FETCH_NEXT_SUBPROJECT_HISTORY_PAGE";
+export const FETCH_NEXT_SUBPROJECT_HISTORY_PAGE_SUCCESS = "FETCH_NEXT_SUBPROJECT_HISTORY_PAGE_SUCCESS";
 
 export const ENABLE_BUDGET_EDIT = "ENABLE_BUDGET_EDIT";
 export const POST_SUBPROJECT_EDIT = "POST_SUBPROJECT_EDIT";
@@ -130,13 +131,18 @@ export function resetSucceededWorkflowitems() {
   };
 }
 
-export function fetchSubprojectHistory(projectId, subprojectId, offset, limit, showLoading = false) {
+export function setTotalHistoryItemCount(count) {
   return {
-    type: FETCH_SUBPROJECT_HISTORY,
+    type: SET_TOTAL_SUBPROJECT_HISTORY_ITEM_COUNT,
+    count
+  };
+}
+
+export function fetchNextSubprojectHistoryPage(projectId, subprojectId, showLoading = false) {
+  return {
+    type: FETCH_NEXT_SUBPROJECT_HISTORY_PAGE,
     projectId,
     subprojectId,
-    offset,
-    limit,
     showLoading
   };
 }
@@ -184,9 +190,9 @@ export function hideWorkflowDetails() {
   };
 }
 
-export function cleanupWorkflowitemDetailsState() {
+export function closeWorkflowitemDetailsDialog() {
   return {
-    type: WORKFLOWITEM_DETAILS_CLEANUP_STATE
+    type: CLOSE_WORKFLOWITEM_DETAILS
   };
 }
 

--- a/frontend/src/pages/Workflows/reducer.js
+++ b/frontend/src/pages/Workflows/reducer.js
@@ -11,9 +11,10 @@ import {
   EDIT_WORKFLOW_ITEM_SUCCESS,
   ENABLE_BUDGET_EDIT,
   ENABLE_WORKFLOW_EDIT,
+  FETCH_NEXT_SUBPROJECT_HISTORY_PAGE,
+  FETCH_NEXT_SUBPROJECT_HISTORY_PAGE_SUCCESS,
+  SET_TOTAL_SUBPROJECT_HISTORY_ITEM_COUNT,
   FETCH_ALL_SUBPROJECT_DETAILS_SUCCESS,
-  FETCH_SUBPROJECT_HISTORY,
-  FETCH_SUBPROJECT_HISTORY_SUCCESS,
   FETCH_WORKFLOWITEM_PERMISSIONS_SUCCESS,
   GRANT_WORKFLOWITEM_PERMISSION_SUCCESS,
   HIDE_SUBPROJECT_ASSIGNEES,
@@ -52,7 +53,7 @@ import {
   OPEN_HISTORY
 } from "./actions";
 
-const initialLimit = 50;
+const historyPageSize = 50;
 
 const defaultState = fromJS({
   id: "",
@@ -85,9 +86,6 @@ const defaultState = fromJS({
   showDetails: false,
   showDetailsItemId: "",
   showHistory: false,
-  hasMoreHistory: true,
-  offset: -initialLimit,
-  limit: initialLimit,
   currentStep: 0,
   workflowSortEnabled: false,
   workflowType: "workflow",
@@ -96,6 +94,10 @@ const defaultState = fromJS({
   roles: [],
   historyItems: [],
   isHistoryLoading: false,
+  totalHistoryItemCount: 0,
+  historyPageSize: historyPageSize,
+  currentHistoryPage: 0,
+  lastHistoryPage: 1,
   showWorkflowAssignee: false,
   showSubProjectAssignee: false,
   editDialogShown: false,
@@ -291,23 +293,26 @@ export default function detailviewReducer(state = defaultState, action) {
       return state.set("showSubProjectAssignee", true);
     case HIDE_SUBPROJECT_ASSIGNEES:
       return state.set("showSubProjectAssignee", false);
-    case FETCH_SUBPROJECT_HISTORY:
+    case FETCH_NEXT_SUBPROJECT_HISTORY_PAGE:
       return state.set("isHistoryLoading", true);
-    case FETCH_SUBPROJECT_HISTORY_SUCCESS:
+    case FETCH_NEXT_SUBPROJECT_HISTORY_PAGE_SUCCESS:
       return state.merge({
         historyItems: state.get("historyItems").concat(fromJS(action.events).reverse()),
-        historyItemsCount: action.historyItemsCount,
-        isHistoryLoading: false,
-        offset: action.offset,
-        limit: action.limit,
-        hasMoreHistory: action.hasMore
+        currentHistoryPage: action.currentHistoryPage,
+        isHistoryLoading: false
+      });
+    case SET_TOTAL_SUBPROJECT_HISTORY_ITEM_COUNT:
+      return state.merge({
+        totalHistoryItemCount: action.totalHistoryItemsCount,
+        lastHistoryPage: action.lastHistoryPage
       });
     case HIDE_HISTORY:
       return state.merge({
         historyItems: fromJS([]),
         showHistory: false,
-        offset: defaultState.get("offset"),
-        limit: defaultState.get("limit")
+        lastHistoryPage: defaultState.get("lastHistoryPage"),
+        currentHistoryPage: defaultState.get("currentHistoryPage"),
+        totalHistoryItemCount: defaultState.get("totalHistoryItemCount")
       });
     case STORE_WORKFLOWACTIONS:
       return state.set("workflowActions", fromJS(action.actions));


### PR DESCRIPTION
# What was changed
## Fetching of history items
The project/subproject/workflowitem history uses infinite scrolling.
Before this commit: When the last page is reached, the limit was not adjusted which lead to
overfetching.
Now: The limit is calculated based on the offsetIndex. If it is 0 (i.e.
the last page is reached), the limit is set to the modulus of the number
of events and the limit, which leaves only the events that were not
fetched before.
This also fixes the problem where the history drawer was populated with the wrong items after closing.

## Bugfixes
* Added stringify entries for update and delete projected budgets
* Fixed stringify of permission related history entries. The "formatPermission" method was restored to translate the permissions from the event to a value that can be read from the language files.

Closes #275 
Closes #279 

# How to test
Create more than 50 (current initial fetching limit) events for project/subproject/workflowitem, open the history and scroll to the bottom. The history items should be correctly loaded and no item should appear more than once. The number of items displayed should match the number of history events. (The number of history events can be checked via the `viewHistory`/`viewHistory.v2` endpoint of each resource.)
Each history entry should have a properly formatted text. 