### PR TITLE
danger: Add check for missing e2e-tests

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,23 +3,42 @@ const { includes } = require("lodash");
 
 const apiSources = danger.git.fileMatch("api/src/**/*.ts");
 const blockchainSources = danger.git.fileMatch("blockchain/src/*");
-const frontendSources = danger.git.fileMatch("frontend/src/*");
+const frontendRootSources = danger.git.fileMatch("frontend/src/*.*");
+const frontendPageSources = danger.git.fileMatch("frontend/src/pages/*");
+const frontendLanguageSources = danger.git.fileMatch("frontend/src/pages/*");
 const provisioningSources = danger.git.fileMatch("provisioning/src/*");
 const e2eTestSources = danger.git.fileMatch("e2e-test/cypress/*");
 
 const title = danger.github.pr.title.toLowerCase();
 const trivialPR = title.includes("refactor");
 const changelogChanges = includes(danger.git.modified_files, "CHANGELOG.md");
+const frontendChanges =
+  frontendRootSources.edited ||
+  frontendPageSources.edited ||
+  frontendLanguageSources.edited;
 
 // When there are app-changes and it's not a PR marked as trivial, expect there to be CHANGELOG changes.
 if (
-  (apiSources.modified ||
-    blockchainSources.modified ||
-    frontendSources.modified ||
-    provisioningSources.modified ||
-    e2eTestSources.modified) &&
+  (frontendChanges ||
+    apiSources.edited ||
+    blockchainSources.edited ||
+    frontendRootSources.edited ||
+    provisioningSources.edited ||
+    e2eTestSources.edited) &&
   !trivialPR &&
   !changelogChanges
 ) {
   warn("No CHANGELOG added.");
+}
+
+// If there are changes in the UI (except language files)
+// and PR is not marked as trivial, expect there to be E2E-test updates
+if (
+  (frontendRootSources.edited || frontendPageSources.edited) &&
+  !e2eTestSources.modified &&
+  !trivialPR
+) {
+  warn(
+    "There were changes in the frontend, but no E2E-test was added or modified!"
+  );
 }


### PR DESCRIPTION
Danger warns about missing E2E-tests for the following conditions:
- There are changes in the frontend
- AND there are no changes in the e2e tests
- AND the pull request is not marked as trivial

Closes #256 