### PR TITLE
ui: Fix display of 'No event' in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- Empty history displayed after API call is finished [#294](https://github.com/openkfw/TruBudget/issues/294)
 
 <!-- ### Security -->
 ## [1.0.1] - 2019-05-21

--- a/frontend/src/pages/Common/HistoryList.js
+++ b/frontend/src/pages/Common/HistoryList.js
@@ -41,7 +41,7 @@ export default function HistoryList({ events, nEventsTotal, hasMore, isLoading, 
       subheader={<ListSubheader disableSticky>{strings.common.history}</ListSubheader>}
       style={styles.list}
     >
-      {nEventsTotal === 0 ? (
+      {!isLoading && nEventsTotal === 0 ? (
         <ListItem key="no-element">
           <Avatar alt={""} src="" />
           <ListItemText primary="" secondary={strings.common.no_history} />

--- a/frontend/src/pages/SubProjects/reducer.js
+++ b/frontend/src/pages/SubProjects/reducer.js
@@ -146,7 +146,8 @@ export default function detailviewReducer(state = defaultState, action) {
         isHistoryLoading: false
       });
     case OPEN_HISTORY:
-      return state.set("showHistory", true);
+      return state.set("showHistory", true).set("isHistoryLoading", true);
+
     case HIDE_HISTORY:
       return state.merge({
         historyItems: fromJS([]),

--- a/frontend/src/pages/Workflows/reducer.js
+++ b/frontend/src/pages/Workflows/reducer.js
@@ -326,7 +326,7 @@ export default function detailviewReducer(state = defaultState, action) {
     case LOGOUT:
       return defaultState;
     case OPEN_HISTORY:
-      return state.set("showHistory", true);
+      return state.set("showHistory", true).set("isHistoryLoading", true);
     default:
       return state;
   }


### PR DESCRIPTION
'No event' is displayed only if there are no elements returned from the
API. This is achieved by only displaying the element if the loading
process is finished.

Closes #294 