### PR TITLE
ui: Don't display amount if no exchange rate is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Empty history displayed after API call is finished [#294](https://github.com/openkfw/TruBudget/issues/294)
+- Workflowitem amount is only displayed if amount and exchange rate are available [#297](https://github.com/openkfw/TruBudget/issues/297)
 
 <!-- ### Security -->
 ## [1.0.1] - 2019-05-21

--- a/frontend/src/pages/Workflows/WorkflowItem.js
+++ b/frontend/src/pages/Workflows/WorkflowItem.js
@@ -253,25 +253,29 @@ const isWorkflowSelectable = (currentWorkflowSelectable, workflowSortEnabled, st
 };
 
 const getAmountField = (amount, type, exchangeRate, sourceCurrency, targetCurrency) => {
-  let amountToShow = toAmountString(amount * exchangeRate, targetCurrency);
+  const amountToShow = toAmountString(amount * exchangeRate, targetCurrency);
 
-  const amountExplTitle = toAmountString(amount, sourceCurrency) + " x " + exchangeRate;
+  const amountExplanationTitle = toAmountString(amount, sourceCurrency) + " x " + exchangeRate;
   const amountExplaination = (
-    <Tooltip title={amountExplTitle}>
+    <Tooltip title={amountExplanationTitle}>
       <SwapIcon />
     </Tooltip>
   );
   return (
-    <div style={styles.chipDiv}>
-      <div>{amountToShow}</div>
-      <div
-        style={{
-          paddingTop: "4px",
-          paddingLeft: "4px"
-        }}
-      >
-        {fromAmountString(exchangeRate) !== 1 ? amountExplaination : null}
-      </div>
+    <div>
+      {amount && exchangeRate ? (
+        <div style={styles.chipDiv}>
+          <div>{amountToShow}</div>
+          <div
+            style={{
+              paddingTop: "4px",
+              paddingLeft: "4px"
+            }}
+          >
+            {fromAmountString(exchangeRate) !== 1 ? amountExplaination : null}
+          </div>
+        </div>
+      ) : null}
       <div>
         <Chip style={styles.amountChip} label={amountTypes(type)} />
       </div>

--- a/frontend/src/pages/Workflows/WorkflowItem.js
+++ b/frontend/src/pages/Workflows/WorkflowItem.js
@@ -261,9 +261,10 @@ const getAmountField = (amount, type, exchangeRate, sourceCurrency, targetCurren
       <SwapIcon />
     </Tooltip>
   );
+  const isAmountDisplayed = amount !== undefined && exchangeRate !== undefined;
   return (
     <div>
-      {amount && exchangeRate ? (
+      {isAmountDisplayed ? (
         <div style={styles.chipDiv}>
           <div>{amountToShow}</div>
           <div


### PR DESCRIPTION
When a workflow item is updated via the API from amount type "N/A" to
"disbursed" or "allocated", the exchange rate does not need to be set
immediately (it is only needed if the workflowitem is closed). Therefore
it can happen that no exchange rate (or amount is set).
If no amount or exchange rate is set, the amount field is left blank.

Closes #297 