### PR TITLE
api: Add endpoint to change a user's password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+- New API endpoint to change a user's password [#79](https://github.com/openkfw/TruBudget/issues/79)
 - Different background color for unread notifications [#300](https://github.com/openkfw/TruBudget/issues/300)
 
 ### Changed
+
 - Notification displays name of parent project and subproject [#298](https://github.com/openkfw/TruBudget/issues/298)
 - Move 'Read All' button to the left side [#301](https://github.com/openkfw/TruBudget/issues/301)
 - Don't display view button if user is not allowed to see project/subproject [#302](https://github.com/openkfw/TruBudget/issues/302)
@@ -28,17 +31,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Workflowitem amount is only displayed if amount and exchange rate are available [#297](https://github.com/openkfw/TruBudget/issues/297)
 
 <!-- ### Security -->
-## [1.0.1] - 2019-05-21
 
-<!-- ### Added -->
+## [1.0.1] - 2019-05-21
 
 ### Changed
 
 - Increased Multichain Version to 2.0.1 [#273](https://github.com/openkfw/TruBudget/issues/273)
-
-<!-- ### Deprecated -->
-
-<!-- ### Removed -->
 
 ### Fixed
 
@@ -49,8 +47,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The link to the project/subproject is now active when the user has permissions to see it [#284](https://github.com/openkfw/TruBudget/issues/284)
 - The link to the project/subproject in fly-in notifications correctly redirects the user [#285](https://github.com/openkfw/TruBudget/issues/285)
 - When a workflow item is assigned, the new assignee gets notified [#272](https://github.com/openkfw/TruBudget/issues/272)
-
-<!-- ### Security -->
 
 ## [1.0.0] - 2019-05-08
 

--- a/api/src/authz/intents.ts
+++ b/api/src/authz/intents.ts
@@ -7,6 +7,7 @@ type Intent =
   | "global.createUser"
   | "global.createGroup"
   | "user.authenticate"
+  | "user.changePassword"
   | "user.view"
   | "group.addUser"
   | "group.removeUser"
@@ -66,6 +67,7 @@ export const globalIntents: Intent[] = [
   "global.createUser",
   "global.createGroup",
   "user.authenticate",
+  "user.changePassword",
   "network.registerNode",
   "network.list",
   "network.listActive",
@@ -94,6 +96,7 @@ export const userAssignableIntents: Intent[] = [
   "network.voteForPermission",
   "network.approveNewOrganization",
   "network.approveNewNodeForExistingOrganization",
+  "user.changePassword",
 ];
 
 export const userDefaultIntents: Intent[] = [
@@ -102,7 +105,7 @@ export const userDefaultIntents: Intent[] = [
   "network.listActive",
 ];
 
-export const userIntents: Intent[] = ["user.view", "user.authenticate"];
+export const userIntents: Intent[] = ["user.view", "user.authenticate", "user.changePassword"];
 export const groupIntents: Intent[] = ["group.addUser", "group.removeUser"];
 
 export const projectIntents: Intent[] = [
@@ -159,6 +162,7 @@ export const allIntents: Intent[] = [
   "global.createUser",
   "global.createGroup",
   "user.authenticate",
+  "user.changePassword",
   "user.view",
   "group.addUser",
   "group.removeUser",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -70,6 +70,7 @@ import * as SubprojectTraceEventsService from "./service/subproject_trace_events
 import * as SubprojectUpdateService from "./service/subproject_update";
 import * as UserAuthenticateService from "./service/user_authenticate";
 import * as UserCreateService from "./service/user_create";
+import * as UserPasswordChangeService from "./service/user_password_change";
 import * as UserQueryService from "./service/user_query";
 import * as WorkflowitemAssignService from "./service/workflowitem_assign";
 import * as WorkflowitemCloseService from "./service/workflowitem_close";
@@ -98,6 +99,7 @@ import * as SubprojectViewHistoryAPIv2 from "./subproject_view_history_v2";
 import * as UserAuthenticateAPI from "./user_authenticate";
 import * as UserCreateAPI from "./user_create";
 import * as UserListAPI from "./user_list";
+import * as UserPasswordChangeAPI from "./user_password_change";
 import * as WorkflowitemAssignAPI from "./workflowitem_assign";
 import * as WorkflowitemCloseAPI from "./workflowitem_close";
 import * as WorkflowitemCreateAPI from "./workflowitem_create";
@@ -268,6 +270,11 @@ UserCreateAPI.addHttpHandler(server, URL_PREFIX, {
 UserListAPI.addHttpHandler(server, URL_PREFIX, {
   listUsers: (ctx, issuer) => UserQueryService.getUsers(db, ctx, issuer),
   listGroups: (ctx, issuer) => GroupQueryService.getGroups(db, ctx, issuer),
+});
+
+UserPasswordChangeAPI.addHttpHandler(server, URL_PREFIX, {
+  changeUserPassword: (ctx, issuer, reqData) =>
+    UserPasswordChangeService.changeUserPassword(db, ctx, issuer, reqData),
 });
 
 /*

--- a/api/src/service/cache2.ts
+++ b/api/src/service/cache2.ts
@@ -11,6 +11,7 @@ import * as GroupCreated from "./domain/organization/group_created";
 import * as GroupMemberAdded from "./domain/organization/group_member_added";
 import * as GroupMemberRemoved from "./domain/organization/group_member_removed";
 import * as UserCreated from "./domain/organization/user_created";
+import * as UserPasswordChanged from "./domain/organization/user_password_changed";
 import * as GlobalPermissionsGranted from "./domain/workflow/global_permission_granted";
 import * as GlobalPermissionsRevoked from "./domain/workflow/global_permission_revoked";
 import * as NotificationCreated from "./domain/workflow/notification_created";
@@ -528,6 +529,7 @@ const EVENT_PARSER_MAP = {
   subproject_projected_budget_updated: SubprojectProjectedBudgetUpdated.validate,
   subproject_updated: SubprojectUpdated.validate,
   user_created: UserCreated.validate,
+  user_password_changed: UserPasswordChanged.validate,
   workflowitem_assigned: WorkflowitemAssigned.validate,
   workflowitem_closed: WorkflowitemClosed.validate,
   workflowitem_created: WorkflowitemCreated.validate,

--- a/api/src/service/domain/business_event.ts
+++ b/api/src/service/domain/business_event.ts
@@ -6,6 +6,7 @@ import * as GroupMemberRemoved from "./organization/group_member_removed";
 import * as GroupPermissionGranted from "./organization/group_permissions_granted";
 import * as GroupPermissionRevoked from "./organization/group_permissions_revoked";
 import * as UserCreated from "./organization/user_created";
+import * as UserPasswordChanged from "./organization/user_password_changed";
 import * as GlobalPermissionsGranted from "./workflow/global_permission_granted";
 import * as GlobalPermissionsRevoked from "./workflow/global_permission_revoked";
 import * as NotificationCreated from "./workflow/notification_created";
@@ -21,7 +22,6 @@ import * as ProjectUpdated from "./workflow/project_updated";
 import * as SubprojectAssigned from "./workflow/subproject_assigned";
 import * as SubprojectClosed from "./workflow/subproject_closed";
 import * as SubprojectCreated from "./workflow/subproject_created";
-import * as WorkflowitemsReordered from "./workflow/workflowitems_reordered";
 import * as SubprojectPermissionGranted from "./workflow/subproject_permission_granted";
 import * as SubprojectPermissionRevoked from "./workflow/subproject_permission_revoked";
 import * as SubprojectProjectedBudgetDeleted from "./workflow/subproject_projected_budget_deleted";
@@ -33,6 +33,7 @@ import * as WorkflowitemCreated from "./workflow/workflowitem_created";
 import * as WorkflowitemPermissionGranted from "./workflow/workflowitem_permission_granted";
 import * as WorkflowitemPermissionRevoked from "./workflow/workflowitem_permission_revoked";
 import * as WorkflowitemUpdated from "./workflow/workflowitem_updated";
+import * as WorkflowitemsReordered from "./workflow/workflowitems_reordered";
 
 export type BusinessEvent =
   | GlobalPermissionsGranted.Event
@@ -62,6 +63,7 @@ export type BusinessEvent =
   | SubprojectProjectedBudgetUpdated.Event
   | SubprojectUpdated.Event
   | UserCreated.Event
+  | UserPasswordChanged.Event
   | WorkflowitemAssigned.Event
   | WorkflowitemClosed.Event
   | WorkflowitemCreated.Event

--- a/api/src/service/domain/organization/user_eventsourcing.ts
+++ b/api/src/service/domain/organization/user_eventsourcing.ts
@@ -1,73 +1,165 @@
+import { VError } from "verror";
+
 import { Ctx } from "../../../lib/ctx";
+import deepcopy from "../../../lib/deepcopy";
 import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
 import { EventSourcingError } from "../errors/event_sourcing_error";
 import * as UserCreated from "./user_created";
+import * as UserPasswordChanged from "./user_password_changed";
 import * as UserRecord from "./user_record";
 import { UserTraceEvent } from "./user_trace_event";
 
 export function sourceUserRecords(
   ctx: Ctx,
   events: BusinessEvent[],
-): { users: UserRecord.UserRecord[]; errors: EventSourcingError[] } {
-  const users = new Map<UserRecord.Id, UserRecord.UserRecord>();
-  const errors: EventSourcingError[] = [];
+  origin?: Map<UserRecord.Id, UserRecord.UserRecord>,
+): { users: UserRecord.UserRecord[]; errors: Error[] } {
+  const users =
+    origin === undefined
+      ? new Map<UserRecord.Id, UserRecord.UserRecord>()
+      : new Map<UserRecord.Id, UserRecord.UserRecord>(origin);
+  const errors: Error[] = [];
+
   for (const event of events) {
-    apply(ctx, users, event, errors);
+    if (!event.type.startsWith("user_")) {
+      continue;
+    }
+
+    const user = sourceEvent(ctx, event, users);
+    if (Result.isErr(user)) {
+      errors.push(user);
+    } else {
+      user.log.push(newTraceEvent(user, event));
+      users.set(user.id, user);
+    }
   }
+
   return { users: [...users.values()], errors };
 }
 
-function apply(
-  ctx: Ctx,
-  users: Map<UserRecord.Id, UserRecord.UserRecord>,
-  event: BusinessEvent,
-  errors: EventSourcingError[],
-) {
-  if (event.type === "user_created") {
-    handleUserCreated(ctx, users, event, errors);
-  }
-}
-
-function handleUserCreated(
-  ctx: Ctx,
-  users: Map<UserRecord.Id, UserRecord.UserRecord>,
-  userCreated: UserCreated.Event,
-  errors: EventSourcingError[],
-) {
-  const initialData = userCreated.user;
-
-  let user = users.get(initialData.id);
-  if (user !== undefined) return;
-
-  user = {
-    id: initialData.id,
-    createdAt: userCreated.time,
-    displayName: initialData.displayName,
-    organization: initialData.organization,
-    passwordHash: initialData.passwordHash,
-    address: initialData.address,
-    encryptedPrivKey: initialData.encryptedPrivKey,
-    permissions: initialData.permissions,
-    log: [],
-    additionalData: initialData.additionalData,
-  };
-
-  const result = UserRecord.validate(user);
-  if (Result.isErr(result)) {
-    errors.push(new EventSourcingError({ ctx, event: userCreated }, result));
-    return;
-  }
-
-  const traceEvent: UserTraceEvent = {
-    entityId: initialData.id,
+function newTraceEvent(user: UserRecord.UserRecord, event: BusinessEvent): UserTraceEvent {
+  return {
+    entityId: user.id,
     entityType: "user",
-    businessEvent: userCreated,
+    businessEvent: event,
     snapshot: {
       displayName: user.displayName,
     },
   };
-  user.log.push(traceEvent);
+}
 
-  users.set(initialData.id, user);
+function sourceEvent(
+  ctx: Ctx,
+  event: BusinessEvent,
+  users: Map<UserRecord.Id, UserRecord.UserRecord>,
+): Result.Type<UserRecord.UserRecord> {
+  const userId = getUserId(event);
+  let user: Result.Type<UserRecord.UserRecord>;
+  if (Result.isOk(userId)) {
+    // The event refers to an existing user, so
+    // the user should have been initialized already.
+
+    user = get(users, userId);
+    if (Result.isErr(user)) {
+      return new VError(`user ID ${userId} found in event ${event.type} is invalid`);
+    }
+
+    user = newUserFromEvent(ctx, user, event);
+    if (Result.isErr(user)) {
+      return user; // <- event-sourcing error
+    }
+  } else {
+    // The event does not refer to a user ID, so it must be a creation event:
+    if (event.type !== "user_created") {
+      return new VError(
+        `event ${event.type} is not of type "user_created" but also ` +
+          "does not include a user ID",
+      );
+    }
+
+    user = UserCreated.createFrom(ctx, event);
+    if (Result.isErr(user)) {
+      return new VError(user, "could not create user from event");
+    }
+  }
+
+  return user;
+}
+
+function get(
+  users: Map<UserRecord.Id, UserRecord.UserRecord>,
+  userId: UserRecord.Id,
+): Result.Type<UserRecord.UserRecord> {
+  const user = users.get(userId);
+  if (user === undefined) {
+    return new VError(`user ${userId} not yet initialized`);
+  }
+  return user;
+}
+
+function getUserId(event: BusinessEvent): Result.Type<UserRecord.Id> {
+  switch (event.type) {
+    case "user_password_changed":
+      return event.user.id;
+
+    default:
+      return new VError(`cannot find user ID in event of type ${event.type}`);
+  }
+}
+
+/** Returns a new user with the given event applied, or an error. */
+export function newUserFromEvent(
+  ctx: Ctx,
+  user: UserRecord.UserRecord,
+  event: BusinessEvent,
+): Result.Type<UserRecord.UserRecord> {
+  const eventModule = getEventModule(event);
+
+  // Ensure that we never modify user or event in-place by passing copies. When
+  // copying the user, its event log is omitted for performance reasons.
+  const eventCopy = deepcopy(event);
+  const userCopy = copyUserExceptLog(user);
+
+  try {
+    // Apply the event to the copied user:
+    const mutation = eventModule.mutate(userCopy, eventCopy);
+    if (Result.isErr(mutation)) {
+      throw mutation;
+    }
+
+    // Validate the modified user:
+    const validation = UserRecord.validate(userCopy);
+    if (Result.isErr(validation)) {
+      throw validation;
+    }
+
+    // Restore the event log:
+    userCopy.log = user.log;
+
+    // Return the modified (and validated) user:
+    return userCopy;
+  } catch (error) {
+    return new EventSourcingError({ ctx, event, target: user }, error);
+  }
+}
+
+type EventModule = {
+  mutate: (user: UserRecord.UserRecord, event: BusinessEvent) => Result.Type<void>;
+};
+function getEventModule(event: BusinessEvent): EventModule {
+  switch (event.type) {
+    case "user_password_changed":
+      return UserPasswordChanged;
+
+    default:
+      throw new VError(`unknown user event ${event.type}`);
+  }
+}
+
+function copyUserExceptLog(user: UserRecord.UserRecord): UserRecord.UserRecord {
+  const { log, ...tmp } = user;
+  const copy = deepcopy(tmp);
+  (copy as any).log = [];
+  return copy as UserRecord.UserRecord;
 }

--- a/api/src/service/domain/organization/user_password_change.spec.ts
+++ b/api/src/service/domain/organization/user_password_change.spec.ts
@@ -1,0 +1,112 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { hashPassword, isPasswordMatch } from "../../password";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { newUserFromEvent } from "./user_eventsourcing";
+import { changeUserPassword, RequestData } from "./user_password_change";
+import { UserRecord } from "./user_record";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+
+const dummy = "dummy";
+const passwordChangeUser: UserRecord = {
+  id: dummy,
+  createdAt: new Date().toISOString(),
+  displayName: dummy,
+  organization: dummy,
+  passwordHash: dummy,
+  address: dummy,
+  encryptedPrivKey: dummy,
+  permissions: {},
+  log: [],
+  additionalData: {},
+};
+
+const requestData: RequestData = {
+  userId: dummy,
+  newPassword: "newtest",
+};
+
+const baseRepository = {
+  getUser: () => Promise.resolve(passwordChangeUser),
+  hash: () => Promise.resolve("passwordHash"),
+};
+
+describe("change a user's password: authorization", () => {
+  it("Without the user.changePassword permission, a user cannot change a password", async () => {
+    const result = await changeUserPassword(ctx, alice, requestData, {
+      ...baseRepository,
+    });
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("The root user doesn't need permission to change a user's password", async () => {
+    const result = await changeUserPassword(ctx, root, requestData, {
+      ...baseRepository,
+    });
+    if (Result.isErr(result)) {
+      throw result;
+    }
+    assert.isTrue(Result.isOk(result));
+    assert.isTrue(result.length > 0);
+  });
+
+  it("A user can change another user's password if the correct permissions are given", async () => {
+    const result = await changeUserPassword(ctx, alice, requestData, {
+      ...baseRepository,
+      getUser: () =>
+        Promise.resolve({
+          ...passwordChangeUser,
+          permissions: { "user.changePassword": [alice.id] },
+        }),
+    });
+    if (Result.isErr(result)) {
+      throw result;
+    }
+    assert.isTrue(Result.isOk(result));
+    assert.isTrue(result.length > 0);
+  });
+});
+
+describe("change a user's password: how modifications are applied", () => {
+  it("Changes the user's password immediately", async () => {
+    const oldPassword = "passwordTest";
+    const oldPasswordHash = await hashPassword(oldPassword);
+    const newPassword = "newPassword";
+    const reqData = {
+      userId: dummy,
+      newPassword,
+    };
+
+    assert.isTrue(await isPasswordMatch(oldPassword, oldPasswordHash));
+    const result = await changeUserPassword(ctx, alice, reqData, {
+      ...baseRepository,
+      hash: async passwordPlaintext => hashPassword(passwordPlaintext),
+      getUser: async () =>
+        Promise.resolve({
+          ...passwordChangeUser,
+          permissions: { "user.changePassword": [alice.id] },
+        }),
+    });
+    if (Result.isErr(result)) {
+      throw result;
+    }
+
+    const sourcedUser = result.reduce(
+      (user, event) => newUserFromEvent(ctx, user, event),
+      passwordChangeUser,
+    );
+    if (Result.isErr(sourcedUser)) {
+      throw sourcedUser;
+    }
+    assert.isTrue(Result.isOk(result));
+    assert.isFalse(await isPasswordMatch(oldPassword, sourcedUser.passwordHash));
+    assert.isTrue(await isPasswordMatch(newPassword, sourcedUser.passwordHash));
+  });
+});

--- a/api/src/service/domain/organization/user_password_change.ts
+++ b/api/src/service/domain/organization/user_password_change.ts
@@ -1,0 +1,69 @@
+import Joi = require("joi");
+
+import Intent from "../../../authz/intents";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { InvalidCommand } from "../errors/invalid_command";
+import { NotAuthorized } from "../errors/not_authorized";
+import { PreconditionError } from "../errors/precondition_error";
+import { ServiceUser } from "./service_user";
+import * as UserEventSourcing from "./user_eventsourcing";
+import * as UserPasswordChanged from "./user_password_changed";
+import * as UserRecord from "./user_record";
+
+export interface RequestData {
+  userId: string;
+  newPassword: string;
+}
+
+const requestDataSchema = Joi.object({
+  userId: UserRecord.idSchema.required(),
+  newPassword: Joi.string().required(),
+});
+
+export function validate(input: any): Result.Type<RequestData> {
+  const { value, error } = Joi.validate(input, requestDataSchema);
+  return !error ? value : error;
+}
+
+interface Repository {
+  getUser(userId: string): Promise<Result.Type<UserRecord.UserRecord>>;
+  hash(plaintext: string): Promise<string>;
+}
+
+export async function changeUserPassword(
+  ctx: Ctx,
+  issuer: ServiceUser,
+  data: RequestData,
+  repository: Repository,
+): Promise<Result.Type<BusinessEvent[]>> {
+  const source = ctx.source;
+  const publisher = issuer.id;
+  const passwordChanged = UserPasswordChanged.createEvent(source, publisher, {
+    id: data.userId,
+    passwordHash: await repository.hash(data.newPassword),
+  });
+
+  const userResult = await repository.getUser(data.userId);
+  if (Result.isErr(userResult)) {
+    return new PreconditionError(ctx, passwordChanged, "Error getting user");
+  }
+  const user = userResult;
+
+  // Check authorization (if not root):
+  if (issuer.id !== "root") {
+    const intent: Intent = "user.changePassword";
+    const isAuthorized = UserRecord.permits(user, issuer, [intent]);
+    if (!isAuthorized) {
+      return new NotAuthorized({ ctx, userId: issuer.id, intent });
+    }
+  }
+
+  const result = UserEventSourcing.newUserFromEvent(ctx, user, passwordChanged);
+  if (Result.isErr(result)) {
+    return new InvalidCommand(ctx, passwordChanged, [result]);
+  }
+
+  return [passwordChanged];
+}

--- a/api/src/service/domain/organization/user_password_changed.ts
+++ b/api/src/service/domain/organization/user_password_changed.ts
@@ -1,0 +1,82 @@
+import Joi = require("joi");
+import { VError } from "verror";
+
+import * as Result from "../../../result";
+import * as UserRecord from "../organization/user_record";
+import { Identity } from "./identity";
+
+type eventTypeType = "user_password_changed";
+const eventType: eventTypeType = "user_password_changed";
+
+interface InitialData {
+  id: UserRecord.Id;
+  passwordHash: string;
+}
+
+const initialDataSchema = Joi.object({
+  id: UserRecord.idSchema.required(),
+  passwordHash: Joi.string().required(),
+});
+
+export interface Event {
+  type: eventTypeType;
+  source: string;
+  time: string; // ISO timestamp
+  publisher: Identity;
+  user: InitialData;
+}
+
+export const schema = Joi.object({
+  type: Joi.valid(eventType).required(),
+  source: Joi.string()
+    .allow("")
+    .required(),
+  time: Joi.date()
+    .iso()
+    .required(),
+  publisher: Joi.string().required(),
+  user: initialDataSchema.required(),
+});
+
+export function createEvent(
+  source: string,
+  publisher: Identity,
+  user: InitialData,
+  time: string = new Date().toISOString(),
+): Event {
+  const event = {
+    type: eventType,
+    source,
+    publisher,
+    time,
+    user,
+  };
+  const validationResult = validate(event);
+  if (Result.isErr(validationResult)) {
+    throw new VError(validationResult, `not a valid ${eventType} event`);
+  }
+  return event;
+}
+
+export function validate(input: any): Result.Type<Event> {
+  const { error, value } = Joi.validate(input, schema);
+  return !error ? value : error;
+}
+
+/**
+ * Applies the event to the given user, or returns an error.
+ *
+ * When an error is returned (or thrown), any already applied modifications are
+ * discarded.
+ *
+ * This function is not expected to validate its changes; instead, the modified user
+ * is automatically validated when obtained using
+ * `user_eventsourcing.ts`:`newUserFromEvent`.
+ */
+export function mutate(user: UserRecord.UserRecord, event: Event): Result.Type<void> {
+  if (event.type !== "user_password_changed") {
+    throw new VError(`illegal event type: ${event.type}`);
+  }
+
+  user.passwordHash = event.user.passwordHash;
+}

--- a/api/src/service/project_update.ts
+++ b/api/src/service/project_update.ts
@@ -17,8 +17,8 @@ export async function updateProject(
 ): Promise<void> {
   const result = await Cache.withCache(conn, ctx, async cache =>
     ProjectUpdate.updateProject(ctx, serviceUser, projectId, requestData, {
-      getProject: async projectId => {
-        return cache.getProject(projectId);
+      getProject: async pId => {
+        return cache.getProject(pId);
       },
       getUsersForIdentity: async identity => {
         return GroupQuery.resolveUsers(conn, ctx, serviceUser, identity);

--- a/api/src/service/store.ts
+++ b/api/src/service/store.ts
@@ -58,6 +58,13 @@ export async function store(conn: ConnToken, ctx: Ctx, event: BusinessEvent): Pr
         event,
       });
 
+    case "user_password_changed":
+      return writeTo(conn, ctx, {
+        stream: "users",
+        keys: [event.user.id],
+        event,
+      });
+
     case "workflowitems_reordered":
       return writeTo(conn, ctx, {
         stream: event.projectId,

--- a/api/src/service/user_password_change.ts
+++ b/api/src/service/user_password_change.ts
@@ -1,0 +1,25 @@
+import { Ctx } from "../lib/ctx";
+import * as Result from "../result";
+import { ConnToken } from "./conn";
+import { ServiceUser } from "./domain/organization/service_user";
+import * as UserPasswordChange from "./domain/organization/user_password_change";
+import { hashPassword } from "./password";
+import { store } from "./store";
+import * as UserQuery from "./user_query";
+
+export async function changeUserPassword(
+  conn: ConnToken,
+  ctx: Ctx,
+  serviceUser: ServiceUser,
+  requestData: UserPasswordChange.RequestData,
+): Promise<void> {
+  const result = await UserPasswordChange.changeUserPassword(ctx, serviceUser, requestData, {
+    getUser: () => UserQuery.getUser(conn, ctx, serviceUser, requestData.userId),
+    hash: passwordPlainText => hashPassword(passwordPlainText),
+  });
+  if (Result.isErr(result)) return Promise.reject(result);
+
+  for (const event of result) {
+    await store(conn, ctx, event);
+  }
+}

--- a/api/src/user_password_change.ts
+++ b/api/src/user_password_change.ts
@@ -1,0 +1,129 @@
+import { FastifyInstance } from "fastify";
+import Joi = require("joi");
+import { VError } from "verror";
+
+import { toHttpError } from "./http_errors";
+import * as NotAuthenticated from "./http_errors/not_authenticated";
+import { AuthenticatedRequest } from "./httpd/lib";
+import { Ctx } from "./lib/ctx";
+import * as Result from "./result";
+import { ServiceUser } from "./service/domain/organization/service_user";
+import * as UserChangePassword from "./service/domain/organization/user_password_change";
+
+interface RequestBodyV1 {
+  apiVersion: "1.0";
+  data: {
+    userId: string;
+    newPassword: string;
+  };
+}
+
+const requestBodyV1Schema = Joi.object({
+  apiVersion: Joi.valid("1.0").required(),
+  data: Joi.object({
+    userId: Joi.string().required(),
+    newPassword: Joi.string().required(),
+  }).required(),
+});
+
+type RequestBody = RequestBodyV1;
+const requestBodySchema = Joi.alternatives([requestBodyV1Schema]);
+
+function validateRequestBody(body: any): Result.Type<RequestBody> {
+  const { error, value } = Joi.validate(body, requestBodySchema);
+  return !error ? value : error;
+}
+
+function mkSwaggerSchema(server: FastifyInstance) {
+  return {
+    beforeHandler: [(server as any).authenticate],
+    schema: {
+      description: "Change a user's password",
+      tags: ["user"],
+      summary: "Change a user's password",
+      security: [
+        {
+          bearerToken: [],
+        },
+      ],
+      body: {
+        type: "object",
+        required: ["apiVersion", "data"],
+        properties: {
+          apiVersion: { type: "string", example: "1.0" },
+          data: {
+            type: "object",
+            required: ["userId", "newPassword"],
+            properties: {
+              userId: { type: "string", example: "aSmith" },
+              newPassword: { type: "string", example: "123456" },
+            },
+          },
+        },
+      },
+      response: {
+        200: {
+          description: "successful response",
+          type: "object",
+          properties: {
+            apiVersion: { type: "string", example: "1.0" },
+            data: {
+              type: "object",
+            },
+          },
+        },
+        401: NotAuthenticated.schema,
+      },
+    },
+  };
+}
+
+interface Service {
+  changeUserPassword(
+    ctx: Ctx,
+    serviceUser: ServiceUser,
+    requestData: UserChangePassword.RequestData,
+  ): Promise<void>;
+}
+
+export function addHttpHandler(server: FastifyInstance, urlPrefix: string, service: Service) {
+  server.post(`${urlPrefix}/user.changePassword`, mkSwaggerSchema(server), (request, reply) => {
+    const ctx: Ctx = { requestId: request.id, source: "http" };
+
+    const serviceUser: ServiceUser = {
+      id: (request as AuthenticatedRequest).user.userId,
+      groups: (request as AuthenticatedRequest).user.groups,
+    };
+
+    const bodyResult = validateRequestBody(request.body);
+
+    if (Result.isErr(bodyResult)) {
+      const { code, body } = toHttpError(
+        new VError(bodyResult, "failed to change user's password"),
+      );
+      reply.status(code).send(body);
+      return;
+    }
+
+    const data = bodyResult.data;
+    const reqData = {
+      userId: data.userId,
+      newPassword: data.newPassword,
+    };
+
+    service
+      .changeUserPassword(ctx, serviceUser, reqData)
+      .then(() => {
+        const code = 200;
+        const body = {
+          apiVersion: "1.0",
+          data: {},
+        };
+        reply.status(code).send(body);
+      })
+      .catch(err => {
+        const { code, body } = toHttpError(err);
+        reply.status(code).send(body);
+      });
+  });
+}


### PR DESCRIPTION
# Changes

A new API endpoint was added that enables the change of a user's
password. For this, the following has been added:
* New intent 'user.changePassword'
* This new intent is given to every user per default so every user can change his/her own password
* New HTTP endpoint 'user.changePassword'
* New service
* New business event 'UserPasswordChanged'
* New unit test
* New business logic 'user_password_change'
* New event 'user_password_changed'

To be consistent with the rest of the API, the files for user handling
(creating, getting, sourcing) have been refactored.

Relates to #79 

# How to test
Call the API endpoint `user.changePassword` with `userId` and a new password and try authenticating the user using the old password (should not be possible) and then the new password (should be possible).