### PR TITLE
api: Add user permission endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - New API endpoint to change a user's password [#79](https://github.com/openkfw/TruBudget/issues/79)
+- New API endpoints to grant, revoke and list permissions [#310](https://github.com/openkfw/TruBudget/issues/310)
 - Different background color for unread notifications [#300](https://github.com/openkfw/TruBudget/issues/300)
 
 ### Changed

--- a/api/src/authz/intents.ts
+++ b/api/src/authz/intents.ts
@@ -9,6 +9,9 @@ type Intent =
   | "user.authenticate"
   | "user.changePassword"
   | "user.view"
+  | "user.intent.listPermissions"
+  | "user.intent.grantPermission"
+  | "user.intent.revokePermission"
   | "group.addUser"
   | "group.removeUser"
   | "project.intent.listPermissions"
@@ -67,7 +70,6 @@ export const globalIntents: Intent[] = [
   "global.createUser",
   "global.createGroup",
   "user.authenticate",
-  "user.changePassword",
   "network.registerNode",
   "network.list",
   "network.listActive",
@@ -105,7 +107,15 @@ export const userDefaultIntents: Intent[] = [
   "network.listActive",
 ];
 
-export const userIntents: Intent[] = ["user.view", "user.authenticate", "user.changePassword"];
+export const userIntents: Intent[] = [
+  "user.view",
+  "user.authenticate",
+  "user.changePassword",
+  "user.intent.listPermissions",
+  "user.intent.grantPermission",
+  "user.intent.revokePermission",
+];
+
 export const groupIntents: Intent[] = ["group.addUser", "group.removeUser"];
 
 export const projectIntents: Intent[] = [
@@ -163,6 +173,9 @@ export const allIntents: Intent[] = [
   "global.createGroup",
   "user.authenticate",
   "user.changePassword",
+  "user.intent.listPermissions",
+  "user.intent.grantPermission",
+  "user.intent.revokePermission",
   "user.view",
   "group.addUser",
   "group.removeUser",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -71,6 +71,9 @@ import * as SubprojectUpdateService from "./service/subproject_update";
 import * as UserAuthenticateService from "./service/user_authenticate";
 import * as UserCreateService from "./service/user_create";
 import * as UserPasswordChangeService from "./service/user_password_change";
+import * as UserPermissionGrantService from "./service/user_permission_grant";
+import * as UserPermissionRevokeService from "./service/user_permission_revoke";
+import * as UserPermissionsListService from "./service/user_permissions_list";
 import * as UserQueryService from "./service/user_query";
 import * as WorkflowitemAssignService from "./service/workflowitem_assign";
 import * as WorkflowitemCloseService from "./service/workflowitem_close";
@@ -100,6 +103,9 @@ import * as UserAuthenticateAPI from "./user_authenticate";
 import * as UserCreateAPI from "./user_create";
 import * as UserListAPI from "./user_list";
 import * as UserPasswordChangeAPI from "./user_password_change";
+import * as UserPermissionGrantAPI from "./user_permission_grant";
+import * as UserPermissionRevokeAPI from "./user_permission_revoke";
+import * as UserPermissionsListAPI from "./user_permissions_list";
 import * as WorkflowitemAssignAPI from "./workflowitem_assign";
 import * as WorkflowitemCloseAPI from "./workflowitem_close";
 import * as WorkflowitemCreateAPI from "./workflowitem_create";
@@ -275,6 +281,21 @@ UserListAPI.addHttpHandler(server, URL_PREFIX, {
 UserPasswordChangeAPI.addHttpHandler(server, URL_PREFIX, {
   changeUserPassword: (ctx, issuer, reqData) =>
     UserPasswordChangeService.changeUserPassword(db, ctx, issuer, reqData),
+});
+
+UserPermissionGrantAPI.addHttpHandler(server, URL_PREFIX, {
+  grantUserPermission: (ctx, granter, userId, grantee, intent) =>
+    UserPermissionGrantService.grantUserPermission(db, ctx, granter, userId, grantee, intent),
+});
+
+UserPermissionRevokeAPI.addHttpHandler(server, URL_PREFIX, {
+  revokeUserPermission: (ctx, revoker, userId, revokee, intent) =>
+    UserPermissionRevokeService.revokeUserPermission(db, ctx, revoker, userId, revokee, intent),
+});
+
+UserPermissionsListAPI.addHttpHandler(server, URL_PREFIX, {
+  getUserPermissions: (ctx, user, userId) =>
+    UserPermissionsListService.getUserPermissions(db, ctx, user, userId),
 });
 
 /*

--- a/api/src/service/cache2.ts
+++ b/api/src/service/cache2.ts
@@ -12,6 +12,8 @@ import * as GroupMemberAdded from "./domain/organization/group_member_added";
 import * as GroupMemberRemoved from "./domain/organization/group_member_removed";
 import * as UserCreated from "./domain/organization/user_created";
 import * as UserPasswordChanged from "./domain/organization/user_password_changed";
+import * as UserPermissionsGranted from "./domain/organization/user_permission_granted";
+import * as UserPermissionsRevoked from "./domain/organization/user_permission_revoked";
 import * as GlobalPermissionsGranted from "./domain/workflow/global_permission_granted";
 import * as GlobalPermissionsRevoked from "./domain/workflow/global_permission_revoked";
 import * as NotificationCreated from "./domain/workflow/notification_created";
@@ -530,6 +532,8 @@ const EVENT_PARSER_MAP = {
   subproject_updated: SubprojectUpdated.validate,
   user_created: UserCreated.validate,
   user_password_changed: UserPasswordChanged.validate,
+  user_permission_granted: UserPermissionsGranted.validate,
+  user_permission_revoked: UserPermissionsRevoked.validate,
   workflowitem_assigned: WorkflowitemAssigned.validate,
   workflowitem_closed: WorkflowitemClosed.validate,
   workflowitem_created: WorkflowitemCreated.validate,

--- a/api/src/service/domain/business_event.ts
+++ b/api/src/service/domain/business_event.ts
@@ -7,6 +7,8 @@ import * as GroupPermissionGranted from "./organization/group_permissions_grante
 import * as GroupPermissionRevoked from "./organization/group_permissions_revoked";
 import * as UserCreated from "./organization/user_created";
 import * as UserPasswordChanged from "./organization/user_password_changed";
+import * as UserPermissionGranted from "./organization/user_permission_granted";
+import * as UserPermissionRevoked from "./organization/user_permission_revoked";
 import * as GlobalPermissionsGranted from "./workflow/global_permission_granted";
 import * as GlobalPermissionsRevoked from "./workflow/global_permission_revoked";
 import * as NotificationCreated from "./workflow/notification_created";
@@ -64,6 +66,8 @@ export type BusinessEvent =
   | SubprojectUpdated.Event
   | UserCreated.Event
   | UserPasswordChanged.Event
+  | UserPermissionGranted.Event
+  | UserPermissionRevoked.Event
   | WorkflowitemAssigned.Event
   | WorkflowitemClosed.Event
   | WorkflowitemCreated.Event

--- a/api/src/service/domain/organization/user_permission_grant.spec.ts
+++ b/api/src/service/domain/organization/user_permission_grant.spec.ts
@@ -1,0 +1,129 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { newUserFromEvent } from "./user_eventsourcing";
+import { grantUserPermission } from "./user_permission_grant";
+import { UserRecord } from "./user_record";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const charlie: ServiceUser = { id: "charlie", groups: ["alice_and_bob_and_charlie"] };
+
+const grantIntent = "user.intent.grantPermission";
+const userId = "dummy";
+const baseUser: UserRecord = {
+  id: userId,
+  createdAt: new Date().toISOString(),
+  organization: "dummy",
+  displayName: "dummy",
+  passwordHash: "password",
+  permissions: {},
+  address: "12345",
+  encryptedPrivKey: "encrypted",
+  log: [],
+  additionalData: {},
+};
+
+const baseRepository = {
+  getTargetUser: async () => baseUser,
+};
+
+describe("Granting user permissions: permissions", () => {
+  it("Without the user.intent.grantPermission permission, a user cannot grant user permissions", async () => {
+    const result = await grantUserPermission(ctx, alice, userId, bob.id, grantIntent, {
+      ...baseRepository,
+    });
+
+    // NotAuthorized error due to the missing permissions:
+    assert.isTrue(Result.isErr(result), "Alice is not authorized to grant this permission");
+    assert.instanceOf(result, NotAuthorized, "The error is of the type 'Not Authorized'");
+  });
+
+  it("The root user can always grant user permissions", async () => {
+    const result = await grantUserPermission(ctx, root, userId, bob.id, grantIntent, {
+      ...baseRepository,
+    });
+
+    assert.isTrue(Result.isOk(result));
+  });
+});
+
+describe("Granting user permissions: updates", () => {
+  it("The permission is granted if the user has the correct permissions", async () => {
+    const permissionTestUser: UserRecord = {
+      ...baseUser,
+      permissions: { "user.intent.grantPermission": [alice.id] },
+    };
+    const result = await grantUserPermission(ctx, alice, userId, bob.id, grantIntent, {
+      getTargetUser: async () => Promise.resolve(permissionTestUser),
+    });
+    if (Result.isErr(result)) {
+      throw result;
+    }
+
+    const userAfterGrantingPermission = result.reduce(
+      (user, event) => newUserFromEvent(ctx, user, event),
+      permissionTestUser,
+    );
+    if (Result.isErr(userAfterGrantingPermission)) {
+      throw userAfterGrantingPermission;
+    }
+
+    assert.isTrue(Result.isOk(result), "Alice is authorized to grant this permission");
+    // Bob now has the permission
+    assert.isTrue(
+      userAfterGrantingPermission.permissions["user.intent.grantPermission"]!.some(
+        x => x === bob.id,
+      ),
+    );
+    // Alice still has the permission
+    assert.isTrue(
+      userAfterGrantingPermission.permissions["user.intent.grantPermission"]!.some(
+        x => x === alice.id,
+      ),
+    );
+  });
+
+  it("An existing permission is granted, nothing happens", async () => {
+    const testUser: UserRecord = {
+      id: userId,
+      createdAt: new Date().toISOString(),
+      organization: "dummy",
+      displayName: "dummy",
+      passwordHash: "password",
+      permissions: { "user.intent.grantPermission": [alice.id] },
+      address: "12345",
+      encryptedPrivKey: "encrypted",
+      log: [],
+      additionalData: {},
+    };
+    const result = await grantUserPermission(ctx, alice, userId, alice.id, grantIntent, {
+      getTargetUser: async () => Promise.resolve(testUser),
+    });
+    if (Result.isErr(result)) {
+      throw result;
+    }
+
+    const userAfterGrantingPermission = result.reduce(
+      (user, event) => newUserFromEvent(ctx, user, event),
+      testUser,
+    );
+    if (Result.isErr(userAfterGrantingPermission)) {
+      throw userAfterGrantingPermission;
+    }
+
+    assert.isTrue(Result.isOk(result), "Alice is authorized to grant this permission");
+    assert.deepEqual(result, []);
+    // Alice still has the permission
+    assert.isTrue(
+      userAfterGrantingPermission.permissions["user.intent.grantPermission"]!.some(
+        x => x === alice.id,
+      ),
+    );
+  });
+});

--- a/api/src/service/domain/organization/user_permission_grant.ts
+++ b/api/src/service/domain/organization/user_permission_grant.ts
@@ -1,0 +1,66 @@
+import isEqual = require("lodash.isequal");
+
+import Intent from "../../../authz/intents";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { InvalidCommand } from "../errors/invalid_command";
+import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
+import { Identity } from "./identity";
+import { ServiceUser } from "./service_user";
+import * as UserEventSourcing from "./user_eventsourcing";
+import * as UserPermissionGranted from "./user_permission_granted";
+import * as UserRecord from "./user_record";
+
+interface Repository {
+  getTargetUser(userId: UserRecord.Id): Promise<Result.Type<UserRecord.UserRecord>>;
+}
+
+type eventTypeType = "user_permission_granted";
+const eventType: eventTypeType = "user_permission_granted";
+
+export async function grantUserPermission(
+  ctx: Ctx,
+  issuer: ServiceUser,
+  userId: UserRecord.Id,
+  grantee: Identity,
+  intent: Intent,
+  repository: Repository,
+): Promise<Result.Type<BusinessEvent[]>> {
+  const user = await repository.getTargetUser(userId);
+
+  if (Result.isErr(user)) {
+    return new NotFound(ctx, "user", userId);
+  }
+
+  // Create the new event:
+  const permissionGranted = UserPermissionGranted.createEvent(
+    ctx.source,
+    issuer.id,
+    userId,
+    intent,
+    grantee,
+  );
+
+  // Check authorization (if not root):
+  if (issuer.id !== "root") {
+    const grantIntent: Intent = "user.intent.grantPermission";
+    if (!UserRecord.permits(user, issuer, [grantIntent])) {
+      return new NotAuthorized({ ctx, userId: issuer.id, intent: grantIntent, target: user });
+    }
+  }
+
+  // Check that the new event is indeed valid:
+  const updatedUser = UserEventSourcing.newUserFromEvent(ctx, user, permissionGranted);
+  if (Result.isErr(updatedUser)) {
+    return new InvalidCommand(ctx, permissionGranted, [updatedUser]);
+  }
+
+  // Only emit the event if it causes any changes to the permissions:
+  if (isEqual(user.permissions, updatedUser.permissions)) {
+    return [];
+  } else {
+    return [permissionGranted];
+  }
+}

--- a/api/src/service/domain/organization/user_permission_granted.ts
+++ b/api/src/service/domain/organization/user_permission_granted.ts
@@ -1,0 +1,86 @@
+import Joi = require("joi");
+import { VError } from "verror";
+
+import Intent, { userIntents } from "../../../authz/intents";
+import * as Result from "../../../result";
+import { Identity } from "./identity";
+import * as UserRecord from "./user_record";
+
+type eventTypeType = "user_permission_granted";
+const eventType: eventTypeType = "user_permission_granted";
+
+export interface Event {
+  type: eventTypeType;
+  source: string;
+  time: string; // ISO timestamp
+  publisher: Identity;
+  userId: UserRecord.Id;
+  permission: Intent;
+  grantee: Identity;
+}
+
+export const schema = Joi.object({
+  type: Joi.valid(eventType).required(),
+  source: Joi.string()
+    .allow("")
+    .required(),
+  time: Joi.date()
+    .iso()
+    .required(),
+  publisher: Joi.string().required(),
+  userId: UserRecord.idSchema.required(),
+  permission: Joi.valid(userIntents).required(),
+  grantee: Joi.string().required(),
+});
+
+export function createEvent(
+  source: string,
+  publisher: Identity,
+  userId: UserRecord.Id,
+  permission: Intent,
+  grantee: Identity,
+  time: string = new Date().toISOString(),
+): Event {
+  const event = {
+    type: eventType,
+    source,
+    publisher,
+    time,
+    userId,
+    permission,
+    grantee,
+  };
+  const validationResult = validate(event);
+  if (Result.isErr(validationResult)) {
+    throw new VError(validationResult, `not a valid ${eventType} event`);
+  }
+  return event;
+}
+
+export function validate(input: any): Result.Type<Event> {
+  const { error, value } = Joi.validate(input, schema);
+  return !error ? value : error;
+}
+
+/**
+ * Applies the event to the given user, or returns an error.
+ *
+ * When an error is returned (or thrown), any already applied modifications are
+ * discarded.
+ *
+ * This function is not expected to validate its changes; instead, the modified user
+ * is automatically validated when obtained using
+ * `user_eventsourcing.ts`:`newUserFromEvent`.
+ */
+export function mutate(user: UserRecord.UserRecord, event: Event): Result.Type<void> {
+  if (event.type !== "user_permission_granted") {
+    throw new VError(`illegal event type: ${event.type}`);
+  }
+
+  const eligibleIdentities = user.permissions[event.permission] || [];
+  if (!eligibleIdentities.includes(event.grantee)) {
+    eligibleIdentities.push(event.grantee);
+  }
+
+  user.permissions[event.permission] = eligibleIdentities;
+}

--- a/api/src/service/domain/organization/user_permission_revoke.spec.ts
+++ b/api/src/service/domain/organization/user_permission_revoke.spec.ts
@@ -1,0 +1,128 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { newUserFromEvent } from "./user_eventsourcing";
+import { revokeUserPermission } from "./user_permission_revoke";
+import { UserRecord } from "./user_record";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const charlie: ServiceUser = { id: "charlie", groups: ["alice_and_bob_and_charlie"] };
+
+const grantIntent = "user.intent.grantPermission";
+const userId = "dummy";
+const baseUser: UserRecord = {
+  id: userId,
+  createdAt: new Date().toISOString(),
+  organization: "dummy",
+  displayName: "dummy",
+  passwordHash: "password",
+  permissions: { "user.intent.revokePermission": [alice.id] },
+  address: "12345",
+  encryptedPrivKey: "encrypted",
+  log: [],
+  additionalData: {},
+};
+
+const baseRepository = {
+  getTargetUser: async () => baseUser,
+};
+
+describe("Revoking user permissions: permissions", () => {
+  it("Without the user.intent.revokePermission permission, a user cannot revoke user permissions", async () => {
+    const result = await revokeUserPermission(ctx, alice, userId, bob.id, grantIntent, {
+      getTargetUser: async () =>
+        Promise.resolve({
+          ...baseUser,
+          permissions: { "user.intent.grantPermission": [alice.id] },
+        }),
+    });
+
+    // NotAuthorized error due to the missing permissions:
+    assert.isTrue(Result.isErr(result), "Alice is not authorized to grant this permission");
+    assert.instanceOf(result, NotAuthorized, "The error is of the type 'Not Authorized'");
+  });
+
+  it("The root user can always revoke user permissions", async () => {
+    const result = await revokeUserPermission(ctx, root, userId, bob.id, grantIntent, {
+      ...baseRepository,
+    });
+
+    assert.isTrue(Result.isOk(result));
+  });
+});
+
+describe("Revoking user permissions: updates", () => {
+  it("The permission is revoked if the user has the correct permissions", async () => {
+    const permissionTestUser: UserRecord = {
+      ...baseUser,
+      permissions: {
+        "user.intent.revokePermission": [alice.id],
+        "user.intent.grantPermission": [bob.id],
+      },
+    };
+    const result = await revokeUserPermission(ctx, alice, userId, bob.id, grantIntent, {
+      getTargetUser: async () => Promise.resolve(permissionTestUser),
+    });
+    if (Result.isErr(result)) {
+      throw result;
+    }
+
+    const userAfterRevokingPermission = result.reduce(
+      (user, event) => newUserFromEvent(ctx, user, event),
+      baseUser,
+    );
+    if (Result.isErr(userAfterRevokingPermission)) {
+      throw userAfterRevokingPermission;
+    }
+
+    assert.isTrue(Result.isOk(result), "Alice is authorized to grant this permission");
+    assert.isTrue(result.length > 0, "An event is created");
+    // Permission that was revoked does not exist anymore
+    assert.isFalse(userAfterRevokingPermission.permissions.hasOwnProperty(grantIntent));
+    // Alice still has the permission to revoke permissions
+    assert.isTrue(
+      userAfterRevokingPermission.permissions["user.intent.revokePermission"]!.some(
+        x => x === alice.id,
+      ),
+    );
+  });
+
+  it("A not existing permission is revoked, nothing happens", async () => {
+    const testIntent = "user.changePassword";
+    const permissionTestUser: UserRecord = {
+      ...baseUser,
+      permissions: {
+        "user.intent.revokePermission": [alice.id],
+      },
+    };
+    const result = await revokeUserPermission(ctx, alice, userId, alice.id, testIntent, {
+      getTargetUser: async () => Promise.resolve(permissionTestUser),
+    });
+    if (Result.isErr(result)) {
+      throw result;
+    }
+
+    const userAfterRevokingPermission = result.reduce(
+      (user, event) => newUserFromEvent(ctx, user, event),
+      baseUser,
+    );
+    if (Result.isErr(userAfterRevokingPermission)) {
+      throw userAfterRevokingPermission;
+    }
+
+    assert.isTrue(Result.isOk(result), "Alice is authorized to revoke this permission");
+    assert.deepEqual(result, []);
+    // Alice still has the permission to revoke permissions
+    assert.isTrue(
+      userAfterRevokingPermission.permissions["user.intent.revokePermission"]!.some(
+        x => x === alice.id,
+      ),
+    );
+  });
+});

--- a/api/src/service/domain/organization/user_permission_revoke.ts
+++ b/api/src/service/domain/organization/user_permission_revoke.ts
@@ -1,0 +1,63 @@
+import isEqual = require("lodash.isequal");
+
+import Intent from "../../../authz/intents";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { InvalidCommand } from "../errors/invalid_command";
+import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
+import { Identity } from "../organization/identity";
+import { ServiceUser } from "../organization/service_user";
+import * as UserEventSourcing from "./user_eventsourcing";
+import * as UserPermissionRevoked from "./user_permission_revoked";
+import * as UserRecord from "./user_record";
+
+interface Repository {
+  getTargetUser(userId: UserRecord.Id): Promise<Result.Type<UserRecord.UserRecord>>;
+}
+
+export async function revokeUserPermission(
+  ctx: Ctx,
+  issuer: ServiceUser,
+  userId: UserRecord.Id,
+  revokee: Identity,
+  intent: Intent,
+  repository: Repository,
+): Promise<Result.Type<BusinessEvent[]>> {
+  const user = await repository.getTargetUser(userId);
+
+  if (Result.isErr(user)) {
+    return new NotFound(ctx, "user", userId);
+  }
+
+  // Create the new event:
+  const permissionRevoked = UserPermissionRevoked.createEvent(
+    ctx.source,
+    issuer.id,
+    userId,
+    intent,
+    revokee,
+  );
+
+  // Check authorization (if not root):
+  if (issuer.id !== "root") {
+    const revokeIntent = "user.intent.revokePermission";
+    if (!UserRecord.permits(user, issuer, [revokeIntent])) {
+      return new NotAuthorized({ ctx, userId: issuer.id, intent: revokeIntent, target: user });
+    }
+  }
+
+  // Check that the new event is indeed valid:
+  const updatedUser = UserEventSourcing.newUserFromEvent(ctx, user, permissionRevoked);
+  if (Result.isErr(updatedUser)) {
+    return new InvalidCommand(ctx, permissionRevoked, [updatedUser]);
+  }
+
+  // Only emit the event if it causes any changes to the permissions:
+  if (isEqual(user.permissions, updatedUser.permissions)) {
+    return [];
+  } else {
+    return [permissionRevoked];
+  }
+}

--- a/api/src/service/domain/organization/user_permission_revoked.ts
+++ b/api/src/service/domain/organization/user_permission_revoked.ts
@@ -1,0 +1,92 @@
+import Joi = require("joi");
+import { VError } from "verror";
+
+import Intent, { userIntents } from "../../../authz/intents";
+import * as Result from "../../../result";
+import { Identity } from "../organization/identity";
+import * as UserRecord from "./user_record";
+
+type eventTypeType = "user_permission_revoked";
+const eventType: eventTypeType = "user_permission_revoked";
+
+export interface Event {
+  type: eventTypeType;
+  source: string;
+  time: string; // ISO timestamp
+  publisher: Identity;
+  userId: UserRecord.Id;
+  permission: Intent;
+  revokee: Identity;
+}
+
+export const schema = Joi.object({
+  type: Joi.valid(eventType).required(),
+  source: Joi.string()
+    .allow("")
+    .required(),
+  time: Joi.date()
+    .iso()
+    .required(),
+  publisher: Joi.string().required(),
+  userId: UserRecord.idSchema.required(),
+  permission: Joi.valid(userIntents).required(),
+  revokee: Joi.string().required(),
+});
+
+export function createEvent(
+  source: string,
+  publisher: Identity,
+  userId: UserRecord.Id,
+  permission: Intent,
+  revokee: Identity,
+  time: string = new Date().toISOString(),
+): Event {
+  const event = {
+    type: eventType,
+    source,
+    publisher,
+    time,
+    userId,
+    permission,
+    revokee,
+  };
+  const validationResult = validate(event);
+  if (Result.isErr(validationResult)) {
+    throw new VError(validationResult, `not a valid ${eventType} event`);
+  }
+  return event;
+}
+
+export function validate(input: any): Result.Type<Event> {
+  const { error, value } = Joi.validate(input, schema);
+  return !error ? value : error;
+}
+
+/**
+ * Applies the event to the given user, or returns an error.
+ *
+ * When an error is returned (or thrown), any already applied modifications are
+ * discarded.
+ *
+ * This function is not expected to validate its changes; instead, the modified user
+ * is automatically validated when obtained using
+ * `user_eventsourcing.ts`:`newUserFromEvent`.
+ */
+export function mutate(user: UserRecord.UserRecord, event: Event): Result.Type<void> {
+  if (event.type !== "user_permission_revoked") {
+    throw new VError(`illegal event type: ${event.type}`);
+  }
+
+  const eligibleIdentities = user.permissions[event.permission];
+  if (eligibleIdentities === undefined) {
+    // Nothing to do here..
+    return;
+  }
+
+  const foundIndex = eligibleIdentities.indexOf(event.revokee);
+  const hasPermission = foundIndex !== -1;
+  if (hasPermission) {
+    // Remove the user from the array:
+    eligibleIdentities.splice(foundIndex, 1);
+  }
+}

--- a/api/src/service/project_permission_revoke.ts
+++ b/api/src/service/project_permission_revoke.ts
@@ -21,8 +21,8 @@ export async function revokeProjectPermission(
 ): Promise<void> {
   const result = await Cache.withCache(conn, ctx, async cache =>
     ProjectPermissionRevoke.revokeProjectPermission(ctx, serviceUser, projectId, revokee, intent, {
-      getProject: async projectId => {
-        return cache.getProject(projectId);
+      getProject: async id => {
+        return cache.getProject(id);
       },
     }),
   );

--- a/api/src/service/store.ts
+++ b/api/src/service/store.ts
@@ -65,6 +65,14 @@ export async function store(conn: ConnToken, ctx: Ctx, event: BusinessEvent): Pr
         event,
       });
 
+    case "user_permission_granted":
+    case "user_permission_revoked":
+      return writeTo(conn, ctx, {
+        stream: "users",
+        keys: [event.userId],
+        event,
+      });
+
     case "workflowitems_reordered":
       return writeTo(conn, ctx, {
         stream: event.projectId,

--- a/api/src/service/user_permission_grant.ts
+++ b/api/src/service/user_permission_grant.ts
@@ -1,35 +1,38 @@
 import Intent from "../authz/intents";
 import { Ctx } from "../lib/ctx";
 import * as Result from "../result";
-
 import * as Cache from "./cache2";
 import { ConnToken } from "./conn";
 import { Identity } from "./domain/organization/identity";
 import { ServiceUser } from "./domain/organization/service_user";
+import * as UserPermissionGrant from "./domain/organization/user_permission_grant";
 import * as Project from "./domain/workflow/project";
-import * as ProjectPermissionGrant from "./domain/workflow/project_permission_grant";
 import { store } from "./store";
+import * as UserQuery from "./user_query";
 
 export { RequestData } from "./domain/workflow/project_create";
 
-export async function grantProjectPermission(
+export async function grantUserPermission(
   conn: ConnToken,
   ctx: Ctx,
   serviceUser: ServiceUser,
-  projectId: Project.Id,
+  userId: Project.Id,
   grantee: Identity,
   intent: Intent,
 ): Promise<void> {
-  const result = await Cache.withCache(conn, ctx, async cache =>
-    ProjectPermissionGrant.grantProjectPermission(ctx, serviceUser, projectId, grantee, intent, {
-      getProject: async id => {
-        return cache.getProject(id);
-      },
-    }),
+  const result = await UserPermissionGrant.grantUserPermission(
+    ctx,
+    serviceUser,
+    userId,
+    grantee,
+    intent,
+    {
+      getTargetUser: id => UserQuery.getUser(conn, ctx, serviceUser, id),
+    },
   );
   if (Result.isErr(result)) return Promise.reject(result);
 
-  for (const event of result.newEvents) {
+  for (const event of result) {
     await store(conn, ctx, event);
   }
 }

--- a/api/src/service/user_permission_revoke.ts
+++ b/api/src/service/user_permission_revoke.ts
@@ -1,35 +1,33 @@
 import Intent from "../authz/intents";
 import { Ctx } from "../lib/ctx";
 import * as Result from "../result";
-
 import * as Cache from "./cache2";
 import { ConnToken } from "./conn";
 import { Identity } from "./domain/organization/identity";
 import { ServiceUser } from "./domain/organization/service_user";
-import * as Project from "./domain/workflow/project";
-import * as ProjectPermissionGrant from "./domain/workflow/project_permission_grant";
+import * as UserPermissionRevoke from "./domain/organization/user_permission_revoke";
+import * as UserRecord from "./domain/organization/user_record";
 import { store } from "./store";
+import * as UserQuery from "./user_query";
 
 export { RequestData } from "./domain/workflow/project_create";
 
-export async function grantProjectPermission(
+export async function revokeUserPermission(
   conn: ConnToken,
   ctx: Ctx,
   serviceUser: ServiceUser,
-  projectId: Project.Id,
-  grantee: Identity,
+  userId: UserRecord.Id,
+  revokee: Identity,
   intent: Intent,
 ): Promise<void> {
   const result = await Cache.withCache(conn, ctx, async cache =>
-    ProjectPermissionGrant.grantProjectPermission(ctx, serviceUser, projectId, grantee, intent, {
-      getProject: async id => {
-        return cache.getProject(id);
-      },
+    UserPermissionRevoke.revokeUserPermission(ctx, serviceUser, userId, revokee, intent, {
+      getTargetUser: id => UserQuery.getUser(conn, ctx, serviceUser, id),
     }),
   );
   if (Result.isErr(result)) return Promise.reject(result);
 
-  for (const event of result.newEvents) {
+  for (const event of result) {
     await store(conn, ctx, event);
   }
 }

--- a/api/src/service/user_permissions_list.ts
+++ b/api/src/service/user_permissions_list.ts
@@ -1,0 +1,28 @@
+import { Ctx } from "../lib/ctx";
+import * as Result from "../result";
+import * as Cache from "./cache2";
+import { ConnToken } from "./conn";
+import { ServiceUser } from "./domain/organization/service_user";
+import * as UserGet from "./domain/organization/user_get";
+import * as UserRecord from "./domain/organization/user_record";
+import { Permissions } from "./domain/permissions";
+
+export async function getUserPermissions(
+  conn: ConnToken,
+  ctx: Ctx,
+  serviceUser: ServiceUser,
+  userId: UserRecord.Id,
+): Promise<Result.Type<Permissions>> {
+  const userResult = await Cache.withCache(conn, ctx, async cache =>
+    UserGet.getOneUser(ctx, serviceUser, userId, {
+      getUserEvents: async () => cache.getUserEvents(userId),
+    }),
+  );
+
+  if (Result.isErr(userResult)) {
+    userResult.message = `could not fetch user permissions: ${userResult.message}`;
+    return userResult;
+  }
+
+  return userResult.permissions;
+}

--- a/api/src/user_permission_grant.ts
+++ b/api/src/user_permission_grant.ts
@@ -1,0 +1,142 @@
+import { FastifyInstance } from "fastify";
+import Joi = require("joi");
+import { VError } from "verror";
+
+import Intent, { userIntents } from "./authz/intents";
+import { toHttpError } from "./http_errors";
+import * as NotAuthenticated from "./http_errors/not_authenticated";
+import { AuthenticatedRequest } from "./httpd/lib";
+import { Ctx } from "./lib/ctx";
+import * as Result from "./result";
+import { Identity } from "./service/domain/organization/identity";
+import { ServiceUser } from "./service/domain/organization/service_user";
+import * as UserRecord from "./service/domain/organization/user_record";
+
+interface RequestBodyV1 {
+  apiVersion: "1.0";
+  data: {
+    userId: UserRecord.Id;
+    identity: Identity;
+    intent: Intent;
+  };
+}
+
+const requestBodyV1Schema = Joi.object({
+  apiVersion: Joi.valid("1.0").required(),
+  data: Joi.object({
+    userId: UserRecord.idSchema.required(),
+    identity: Joi.string().required(),
+    intent: Joi.valid(userIntents).required(),
+  }).required(),
+});
+
+type RequestBody = RequestBodyV1;
+const requestBodySchema = Joi.alternatives([requestBodyV1Schema]);
+
+function validateRequestBody(body: any): Result.Type<RequestBody> {
+  const { error, value } = Joi.validate(body, requestBodySchema);
+  return !error ? value : error;
+}
+
+function mkSwaggerSchema(server: FastifyInstance) {
+  return {
+    beforeHandler: [(server as any).authenticate],
+    schema: {
+      description:
+        "Grant a permission to a user. After this call has returned, the " +
+        "user will be allowed to execute the given intent.",
+      tags: ["user"],
+      summary: "Grant a permission to a user or group",
+      security: [
+        {
+          bearerToken: [],
+        },
+      ],
+      body: {
+        type: "object",
+        required: ["apiVersion", "data"],
+        properties: {
+          apiVersion: { type: "string", example: "1.0" },
+          data: {
+            type: "object",
+            required: ["identity", "intent", "userId"],
+            properties: {
+              identity: { type: "string", example: "aSmith" },
+              intent: {
+                type: "string",
+                enum: userIntents,
+                example: "user.intent.listPermissions",
+              },
+              userId: { type: "string", example: "aSmith" },
+            },
+          },
+        },
+      },
+      response: {
+        200: {
+          description: "successful response",
+          type: "object",
+          properties: {
+            apiVersion: { type: "string", example: "1.0" },
+            data: {
+              type: "object",
+            },
+          },
+        },
+        401: NotAuthenticated.schema,
+      },
+    },
+  };
+}
+
+interface Service {
+  grantUserPermission(
+    ctx: Ctx,
+    granter: ServiceUser,
+    userId: UserRecord.Id,
+    grantee: Identity,
+    intent: Intent,
+  ): Promise<void>;
+}
+
+export function addHttpHandler(server: FastifyInstance, urlPrefix: string, service: Service) {
+  server.post(
+    `${urlPrefix}/user.intent.grantPermission`,
+    mkSwaggerSchema(server),
+    (request, reply) => {
+      const ctx: Ctx = { requestId: request.id, source: "http" };
+
+      const granter: ServiceUser = {
+        id: (request as AuthenticatedRequest).user.userId,
+        groups: (request as AuthenticatedRequest).user.groups,
+      };
+
+      const bodyResult = validateRequestBody(request.body);
+
+      if (Result.isErr(bodyResult)) {
+        const { code, body } = toHttpError(
+          new VError(bodyResult, "failed to grant user permission"),
+        );
+        reply.status(code).send(body);
+        return;
+      }
+
+      const { userId, identity: grantee, intent } = bodyResult.data;
+
+      service
+        .grantUserPermission(ctx, granter, userId, grantee, intent)
+        .then(() => {
+          const code = 200;
+          const body = {
+            apiVersion: "1.0",
+            data: {},
+          };
+          reply.status(code).send(body);
+        })
+        .catch(err => {
+          const { code, body } = toHttpError(err);
+          reply.status(code).send(body);
+        });
+    },
+  );
+}

--- a/api/src/user_permission_revoke.ts
+++ b/api/src/user_permission_revoke.ts
@@ -1,0 +1,142 @@
+import { FastifyInstance } from "fastify";
+import Joi = require("joi");
+import { VError } from "verror";
+
+import Intent, { userIntents } from "./authz/intents";
+import { toHttpError } from "./http_errors";
+import * as NotAuthenticated from "./http_errors/not_authenticated";
+import { AuthenticatedRequest } from "./httpd/lib";
+import { Ctx } from "./lib/ctx";
+import * as Result from "./result";
+import { Identity } from "./service/domain/organization/identity";
+import { ServiceUser } from "./service/domain/organization/service_user";
+import * as UserRecord from "./service/domain/organization/user_record";
+
+interface RequestBodyV1 {
+  apiVersion: "1.0";
+  data: {
+    userId: UserRecord.Id;
+    identity: Identity;
+    intent: Intent;
+  };
+}
+
+const requestBodyV1Schema = Joi.object({
+  apiVersion: Joi.valid("1.0").required(),
+  data: Joi.object({
+    userId: UserRecord.idSchema.required(),
+    identity: Joi.string().required(),
+    intent: Joi.valid(userIntents).required(),
+  }).required(),
+});
+
+type RequestBody = RequestBodyV1;
+const requestBodySchema = Joi.alternatives([requestBodyV1Schema]);
+
+function validateRequestBody(body: any): Result.Type<RequestBody> {
+  const { error, value } = Joi.validate(body, requestBodySchema);
+  return !error ? value : error;
+}
+
+function mkSwaggerSchema(server: FastifyInstance) {
+  return {
+    beforeHandler: [(server as any).authenticate],
+    schema: {
+      description:
+        "Revoke a permission from a user. After this call has returned, the " +
+        "user will no longer be able to execute the given intent.",
+      tags: ["user"],
+      summary: "Revoke a permission from a user or group",
+      security: [
+        {
+          bearerToken: [],
+        },
+      ],
+      body: {
+        type: "object",
+        required: ["apiVersion", "data"],
+        properties: {
+          apiVersion: { type: "string", example: "1.0" },
+          data: {
+            type: "object",
+            required: ["identity", "intent", "userId"],
+            properties: {
+              identity: { type: "string", example: "aSmith" },
+              intent: {
+                type: "string",
+                enum: userIntents,
+                example: "user.intent.listPermissions",
+              },
+              userId: { type: "string", example: "aSmith" },
+            },
+          },
+        },
+      },
+      response: {
+        200: {
+          description: "successful response",
+          type: "object",
+          properties: {
+            apiVersion: { type: "string", example: "1.0" },
+            data: {
+              type: "object",
+            },
+          },
+        },
+        401: NotAuthenticated.schema,
+      },
+    },
+  };
+}
+
+interface Service {
+  revokeUserPermission(
+    ctx: Ctx,
+    revoker: ServiceUser,
+    userId: UserRecord.Id,
+    revokee: Identity,
+    intent: Intent,
+  ): Promise<void>;
+}
+
+export function addHttpHandler(server: FastifyInstance, urlPrefix: string, service: Service) {
+  server.post(
+    `${urlPrefix}/user.intent.revokePermission`,
+    mkSwaggerSchema(server),
+    (request, reply) => {
+      const ctx: Ctx = { requestId: request.id, source: "http" };
+
+      const revoker: ServiceUser = {
+        id: (request as AuthenticatedRequest).user.userId,
+        groups: (request as AuthenticatedRequest).user.groups,
+      };
+
+      const bodyResult = validateRequestBody(request.body);
+
+      if (Result.isErr(bodyResult)) {
+        const { code, body } = toHttpError(
+          new VError(bodyResult, "failed to revoke user permission"),
+        );
+        reply.status(code).send(body);
+        return;
+      }
+
+      const { userId, identity: revokee, intent } = bodyResult.data;
+
+      service
+        .revokeUserPermission(ctx, revoker, userId, revokee, intent)
+        .then(() => {
+          const code = 200;
+          const body = {
+            apiVersion: "1.0",
+            data: {},
+          };
+          reply.status(code).send(body);
+        })
+        .catch(err => {
+          const { code, body } = toHttpError(err);
+          reply.status(code).send(body);
+        });
+    },
+  );
+}

--- a/api/src/user_permissions_list.ts
+++ b/api/src/user_permissions_list.ts
@@ -1,0 +1,105 @@
+import { FastifyInstance } from "fastify";
+
+import { toHttpError } from "./http_errors";
+import * as NotAuthenticated from "./http_errors/not_authenticated";
+import { AuthenticatedRequest } from "./httpd/lib";
+import { Ctx } from "./lib/ctx";
+import { isNonemptyString } from "./lib/validation";
+import * as Result from "./result";
+import { ServiceUser } from "./service/domain/organization/service_user";
+import { Permissions } from "./service/domain/permissions";
+
+function mkSwaggerSchema(server: FastifyInstance) {
+  return {
+    beforeHandler: [(server as any).authenticate],
+    schema: {
+      description: "See the permissions for a given user.",
+      tags: ["user"],
+      summary: "List all permissions",
+      querystring: {
+        type: "object",
+        properties: {
+          userId: {
+            type: "string",
+          },
+        },
+      },
+      security: [
+        {
+          bearerToken: [],
+        },
+      ],
+      response: {
+        200: {
+          description: "successful response",
+          type: "object",
+          properties: {
+            apiVersion: { type: "string", example: "1.0" },
+            data: {
+              type: "object",
+              additionalProperties: true,
+              example: {
+                "user.changePassword": ["aSmith", "jDoe"],
+              },
+            },
+          },
+        },
+        401: NotAuthenticated.schema,
+      },
+    },
+  };
+}
+
+interface Service {
+  getUserPermissions(
+    ctx: Ctx,
+    user: ServiceUser,
+    userId: string,
+  ): Promise<Result.Type<Permissions>>;
+}
+
+export function addHttpHandler(server: FastifyInstance, urlPrefix: string, service: Service) {
+  server.get(
+    `${urlPrefix}/user.intent.listPermissions`,
+    mkSwaggerSchema(server),
+    async (request, reply) => {
+      const ctx: Ctx = { requestId: request.id, source: "http" };
+
+      const user: ServiceUser = {
+        id: (request as AuthenticatedRequest).user.userId,
+        groups: (request as AuthenticatedRequest).user.groups,
+      };
+
+      const userId = request.query.userId;
+      if (!isNonemptyString(userId)) {
+        reply.status(404).send({
+          apiVersion: "1.0",
+          error: {
+            code: 404,
+            message: "required query parameter `userId` not present (must be non-empty string)",
+          },
+        });
+        return;
+      }
+
+      try {
+        const userPermissions = await service.getUserPermissions(ctx, user, userId);
+
+        if (Result.isErr(userPermissions)) {
+          userPermissions.message = `could not list user permissions: ${userPermissions.message}`;
+          throw userPermissions;
+        }
+
+        const code = 200;
+        const body = {
+          apiVersion: "1.0",
+          data: userPermissions,
+        };
+        reply.status(code).send(body);
+      } catch (err) {
+        const { code, body } = toHttpError(err);
+        reply.status(code).send(body);
+      }
+    },
+  );
+}


### PR DESCRIPTION
# Changes
The following endpoints have been added:
- user.intent.grantPermission
- user.intent.revokePermission
- user.intent.listPermissions

Unit tests for 'user.intent.grantPermission' and 'user.intent.grantPermission' have been added.

Closes #310 