### PR TITLE
danger: Change check for e2e-test files to edited

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -80,7 +80,7 @@ if (
 // and PR is not marked as trivial, expect there to be E2E-test updates
 if (
   (frontendRootSources.edited || frontendPageSources.edited) &&
-  !e2eTestSources.modified &&
+  !e2eTestSources.edited &&
   !trivialPR
 ) {
   warn(


### PR DESCRIPTION
# Changes

The check for e2e-tests was done for the "modified" parameter, which is
only true if files are edited, but not if files were added only. The
check was changed to "edited" since this includes both added and
modified files.