### PR TITLE
ui: Every user can see the user/groups table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Added-->
 
-<!-- ### Changed-->
+### Changed
+
+- Every user can see the users and groups table [#333](https://github.com/openkfw/TruBudget/issues/333)
 
 <!-- ### Deprecated -->
 

--- a/e2e-test/cypress/integration/change_user_password_spec.js
+++ b/e2e-test/cypress/integration/change_user_password_spec.js
@@ -4,10 +4,6 @@ describe("Users/Groups Dashboard", function() {
     cy.visit("/users");
   });
 
-  it("User can edit his/her own user profile", function() {
-    cy.get("[data-test=edit-user-mstein]").should("be.visible");
-  });
-
   it("If a user is granted permission to edit another user's password, the edit button appears next to the user", function() {
     // Log in as root and grant the permission
     cy.login("root", "root-secret");

--- a/e2e-test/cypress/integration/groups_spec.js
+++ b/e2e-test/cypress/integration/groups_spec.js
@@ -12,31 +12,31 @@ describe("User/Groups Dashboard", function() {
 
   it("Create new group", function() {
     cy.get("[data-test=create]").click();
-    cy.get("#id")
+    cy.get("[data-test=groupid] input")
       .type("TestGroup")
       .should("have.value", "TestGroup");
-    cy.get("#name")
+    cy.get("[data-test=groupname] input")
       .type("testgroup")
       .should("have.value", "testgroup");
-    cy.get("#autoComplete-input")
+    cy.get("[data-test=autocomplete] input")
       .type("mstein")
       .should("have.value", "mstein");
-    cy.get("#autoComplete-item-0")
+    cy.get("[data-test=autocomplete-item-0]")
       .should("be.visible")
       .should("have.text", "mstein")
       .click();
-    cy.get("#autoComplete-input")
+    cy.get("[data-test=autocomplete] input")
       .type("thouse")
       .should("have.value", "thouse");
-    cy.get("#autoComplete-item-0")
+    cy.get("[data-test=autocomplete-item-0]")
       .should("be.visible")
       .should("have.text", "thouse")
       .click();
-    cy.get("[aria-label=submit]").click();
+    cy.get("[data-test=submit]").click();
   });
 
   it("Created group should be visible", function() {
-    cy.get("#group-TestGroup")
+    cy.get("[data-test=group-TestGroup]")
       .find("th")
       .then($th => {
         expect($th).to.have.length(1);

--- a/e2e-test/cypress/integration/users_spec.js
+++ b/e2e-test/cypress/integration/users_spec.js
@@ -1,30 +1,99 @@
+const testUser = {
+  userName: "dviolin",
+  password: "test"
+};
+
 describe("Users/Groups Dashboard", function() {
   before(() => {
     cy.login();
     cy.visit("/users");
   });
 
-  it("Show user dashboard", function() {
+  it("User dashboard is displayed for user with basic permissions", function() {
+    cy.login(testUser.userName, testUser.password);
+    cy.visit("/users");
+
+    // User dashboard should be visible to this user
     cy.location("pathname").should("eq", "/users");
     cy.get("[data-test=userdashboard]").should("be.visible");
   });
 
+  it("Button to add user not visible to user without proper permission", function() {
+    // Login as user without permissions
+    cy.login(testUser.userName, testUser.password);
+    cy.visit("/users");
+
+    // User dashboard should be visible to this user
+    cy.location("pathname").should("eq", "/users");
+    cy.get("[data-test=userdashboard]").should("be.visible");
+
+    cy.get("[data-test=create]").should("not.exist");
+  });
+
+  it("Button to change password should be visible for all users", function() {
+    // Login as user with basic permissions
+    cy.login(testUser.userName, testUser.password);
+    cy.visit("/users");
+
+    // User dashboard should be visible to this user
+    cy.location("pathname").should("eq", "/users");
+    cy.get("[data-test=userdashboard]").should("be.visible");
+
+    cy.get(`[data-test=edit-user-${testUser.userName}]`).should("be.visible");
+  });
+
+  it("Button to change user permissions is not visible to user without proper permission", function() {
+    // Login as user without permissions
+    cy.login(testUser.userName, testUser.password);
+    cy.visit("/users");
+
+    // User dashboard should be visible to this user
+    cy.location("pathname").should("eq", "/users");
+    cy.get("[data-test=userdashboard]").should("be.visible");
+
+    cy.get("[data-test*=edit-permissions-]").should("not.exist");
+  });
+
+  it("Button to add user is visible to user with proper permission", function() {
+    // Login as user with permissions
+    cy.login();
+    cy.visit("/users");
+
+    // User dashboard should be visible to this user
+    cy.location("pathname").should("eq", "/users");
+    cy.get("[data-test=userdashboard]").should("be.visible");
+
+    cy.get("[data-test=create]").should("be.visible");
+  });
+
+  it("Button to edit user permissions is visible to user with proper permission", function() {
+    // Login as user with permissions
+    cy.login();
+    cy.visit("/users");
+
+    // User dashboard should be visible to this user
+    cy.location("pathname").should("eq", "/users");
+    cy.get("[data-test=userdashboard]").should("be.visible");
+
+    cy.get("[data-test*=edit-permissions-]").should("be.visible");
+  });
+
   it("Create new user", function() {
     cy.get("[data-test=create]").click();
-    cy.get("#fullname")
+    cy.get("[data-test=fullname] input")
       .type("Test User")
       .should("have.value", "Test User");
-    cy.get("#username")
+    cy.get("[data-test=username] input")
       .type("testuser")
       .should("have.value", "testuser");
-    cy.get("#password")
+    cy.get("[data-test=password] input")
       .type("test")
       .should("have.value", "test");
-    cy.get("[aria-label=submit]").click();
+    cy.get("[data-test=submit]").click();
   });
 
   it("Created user should be visible", function() {
-    cy.get("#user-testuser")
+    cy.get("[data-test=user-testuser]")
       .find("th")
       .then($th => {
         expect($th).to.have.length(1);

--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -52,6 +52,29 @@ Cypress.Commands.add("login", (username = "mstein", password = "test") => {
     });
 });
 
+Cypress.Commands.add("addUser", (username, userId, password, organization = "KfW") => {
+  cy.request({
+    url: `${baseUrl}/api/global.createUser`,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: {
+      apiVersion: "1.0",
+      data: {
+        user: {
+          id: userId,
+          displayName: username,
+          organization: organization,
+          password: password
+        }
+      }
+    }
+  })
+    .its("body")
+    .then(body => Promise.resolve(body));
+});
+
 Cypress.Commands.add("fetchProjects", () => {
   cy.request({
     url: `${baseUrl}/api/project.list`,

--- a/frontend/src/pages/Common/AutoComplete.js
+++ b/frontend/src/pages/Common/AutoComplete.js
@@ -18,6 +18,8 @@ const renderInput = inputProps => {
         classes: {
           root: classes.inputRoot
         },
+        // eslint-disable-next-line no-useless-computed-key
+        ["data-test"]: "autocomplete",
         ...InputProps
       }}
       {...other}
@@ -33,6 +35,7 @@ const renderSuggestion = ({ suggestion, index, itemProps, highlightedIndex, sele
       {...itemProps}
       key={suggestion.id}
       selected={isHighlighted}
+      data-test={`autocomplete-item-${index}`}
       component="div"
       style={{
         fontWeight: isSelected ? 500 : 400

--- a/frontend/src/pages/Navbar/SideNav.js
+++ b/frontend/src/pages/Navbar/SideNav.js
@@ -3,15 +3,14 @@ import React from "react";
 import Drawer from "@material-ui/core/Drawer";
 
 import SideNavCard from "./SideNavCard";
-import { canViewUserDashboard, canViewNodesDashboard } from "../../permissions";
+import { canViewNodesDashboard } from "../../permissions";
 
 const SideNav = props => {
   const { showSidebar, toggleSidebar, allowedIntents, ...rest } = props;
-  const userDashboardEnabled = canViewUserDashboard(allowedIntents);
   const nodeDashboardEnabled = canViewNodesDashboard(allowedIntents);
   return (
     <Drawer anchor="left" open={showSidebar} onClose={toggleSidebar}>
-      <SideNavCard nodeDashboardEnabled={nodeDashboardEnabled} userDashboardEnabled={userDashboardEnabled} {...rest} />
+      <SideNavCard nodeDashboardEnabled={nodeDashboardEnabled} {...rest} />
     </Drawer>
   );
 };

--- a/frontend/src/pages/Navbar/SideNavCard.js
+++ b/frontend/src/pages/Navbar/SideNavCard.js
@@ -86,14 +86,12 @@ const SideNavCard = ({
         </ListItemIcon>
         <ListItemText primary={strings.navigation.menu_item_notifications} />
       </ListItem>
-      {userDashboardEnabled ? (
-        <ListItem button onClick={() => history.push("/users")}>
-          <ListItemIcon>
-            <UsersIcon />
-          </ListItemIcon>
-          <ListItemText primary={strings.navigation.menu_item_users} />
-        </ListItem>
-      ) : null}
+      <ListItem button onClick={() => history.push("/users")}>
+        <ListItemIcon>
+          <UsersIcon />
+        </ListItemIcon>
+        <ListItemText primary={strings.navigation.menu_item_users} />
+      </ListItem>
       {nodeDashboardEnabled ? (
         <ListItem button onClick={() => history.push("/nodes")}>
           <ListItemIcon>

--- a/frontend/src/pages/Users/GroupDialogContent.js
+++ b/frontend/src/pages/Users/GroupDialogContent.js
@@ -52,13 +52,13 @@ const GroupDialogContent = ({
           error={false}
           disabled={editMode}
           icon={<NameIcon />}
-          id="id"
+          data-test="groupid"
           onChange={event => storeGroupId(event.target.value)}
         />
         <TextInputWithIcon
           className={classes.textInput}
           label={editMode ? displayName : strings.common.name}
-          id="name"
+          data-test="groupname"
           error={false}
           disabled={editMode}
           icon={<OrgaIcon />}

--- a/frontend/src/pages/Users/GroupTable.js
+++ b/frontend/src/pages/Users/GroupTable.js
@@ -37,10 +37,10 @@ const GroupsTable = ({ groups, permissionIconDisplayed, showDashboardDialog, cla
             <TableCell />
           </TableRow>
         </TableHead>
-        <TableBody id="grouptablebody">
+        <TableBody data-test="grouptablebody">
           {sortedGroups.map(group => {
             return (
-              <TableRow id={`group-${group.groupId}`} key={group.groupId}>
+              <TableRow data-test={`group-${group.groupId}`} key={group.groupId}>
                 <TableCell component="th" scope="row">
                   {group.groupId}
                 </TableCell>

--- a/frontend/src/pages/Users/UserDialogContent.js
+++ b/frontend/src/pages/Users/UserDialogContent.js
@@ -54,14 +54,14 @@ const UserDialogContent = ({
           value={displayName}
           error={false}
           icon={<NameIcon />}
-          id="fullname"
+          data-test="fullname"
           onChange={event => setDisplayName(event.target.value)}
         />
         <TextInputWithIcon
           className={classes.textInput}
           label={strings.common.organization}
           value={organization}
-          id="organization"
+          data-test="organization"
           disabled={true}
           error={false}
           icon={<OrgaIcon />}
@@ -69,14 +69,14 @@ const UserDialogContent = ({
         />
       </div>
       <div className={classes.textInputContainer}>
-        <Username username={username} storeUsername={setUsername} failed={false} id="username" />
+        <Username username={username} storeUsername={setUsername} failed={false} data-test="username" />
         <Password
           password={password}
           iconDisplayed={true}
           setPassword={setPassword}
           storePassword={setPassword}
           failed={false}
-          id="password"
+          data-test="password"
         />
       </div>
     </div>

--- a/frontend/src/pages/Users/UserManagementContainer.js
+++ b/frontend/src/pages/Users/UserManagementContainer.js
@@ -2,8 +2,6 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 
 import { toJS } from "../../helper";
-import { canViewUserDashboard } from "../../permissions";
-import NotAuthorized from "../Error/NotAuthorized";
 import withInitialLoading from "../Loading/withInitialLoading";
 import { fetchUser } from "../Login/actions";
 import { showSnackbar, storeSnackbarMessage } from "../Notifications/actions";
@@ -42,12 +40,7 @@ class UserManagementContainer extends Component {
     this.props.resetState();
   }
   render() {
-    const canView = canViewUserDashboard(this.props.allowedIntents);
-    if (canView) {
-      return <Users {...this.props} />;
-    } else {
-      return <NotAuthorized />;
-    }
+    return <Users {...this.props} />;
   }
 }
 

--- a/frontend/src/pages/Users/Users.js
+++ b/frontend/src/pages/Users/Users.js
@@ -55,18 +55,20 @@ const Users = props => {
             <Tab label={strings.users.groups} aria-label="groupsTab" />
           </Tabs>
         </AppBar>
-        <div style={styles.createButtonContainer}>
-          <Fab
-            disabled={isCreateButtonDisabled}
-            data-test="create"
-            onClick={onClick}
-            color="primary"
-            style={styles.createButton}
-            aria-label="Add"
-          >
-            <Add />
-          </Fab>
-        </div>
+        {!isCreateButtonDisabled ? (
+          <div style={styles.createButtonContainer}>
+            <Fab
+              disabled={isCreateButtonDisabled}
+              data-test="create"
+              onClick={onClick}
+              color="primary"
+              style={styles.createButton}
+              aria-label="Add"
+            >
+              <Add />
+            </Fab>
+          </div>
+        ) : null}
         {tabIndex === 0 && <UsersTable permissionIconDisplayed={permissionIconDisplayed} {...props} />}
         {tabIndex === 1 && <GroupTable permissionIconDisplayed={permissionIconDisplayed} {...props} />}
       </div>

--- a/frontend/src/pages/Users/UsersTable.js
+++ b/frontend/src/pages/Users/UsersTable.js
@@ -46,7 +46,7 @@ const UsersTable = ({ classes, users, permissionIconDisplayed, showDashboardDial
               user.permissions["user.changePassword"].some(x => x === userId);
 
             return (
-              <TableRow id={`user-${user.id}`} key={user.id}>
+              <TableRow data-test={`user-${user.id}`} key={user.id}>
                 <TableCell component="th" scope="row">
                   {user.id}
                 </TableCell>
@@ -54,7 +54,10 @@ const UsersTable = ({ classes, users, permissionIconDisplayed, showDashboardDial
                 <TableCell>{user.organization}</TableCell>
                 <TableCell>
                   {permissionIconDisplayed ? (
-                    <IconButton onClick={() => showDashboardDialog("editUserPermissions", user.id)}>
+                    <IconButton
+                      data-test={`edit-permissions-${user.id}`}
+                      onClick={() => showDashboardDialog("editUserPermissions", user.id)}
+                    >
                       <PermissionIcon className={classes.iconColor} />
                     </IconButton>
                   ) : null}

--- a/frontend/src/permissions.js
+++ b/frontend/src/permissions.js
@@ -23,10 +23,6 @@ export const canCreateSubProject = i => can("project.createSubproject", i);
 export const canAssignProject = i => can("project.assign", i);
 export const canCloseProject = i => can("project.close", i);
 
-export const canViewUserDashboard = i => can("global.createUser", i) || can("global.createGroup", i) || can("global.listPermissions", i);
-
-
-
 export const globalIntentOrder = [
   {
     name: "admin",


### PR DESCRIPTION
# Changes 

Since every user can now change his/her password, every user should also
be able to see the users table. The check for the permissions global.createUser, global.createGroup and global.listPermissions have been removed.

E2E tests have been added to test this scenario. Additionally, the E2E
tests check for the availability of the buttons to add users and edit
user permissions.

Closes #333 

# How to test

Create a user with only basic permissions. This user should still see the "Users" menu in the navigation on the left and see the users table. 