### PR TITLE
Grant/revoke global permissions only within organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Organizations and currencies for projected budgets of subprojects can only be selected from values of the parent project [#228](https://github.com/openkfw/TruBudget/issues/228)
+- Global permissions can only be granted/revoked to/from users within the same organizations [#340](https://github.com/openkfw/TruBudget/issues/340)
 
 <!-- ### Deprecated -->
 
-<!-- ### Removed -->
+### Removed
+
+- Permissions button is removed for groups [#345](https://github.com/openkfw/TruBudget/issues/345)
 
 <!-- ### Fixed -->
 

--- a/api/src/global_permission_grant.ts
+++ b/api/src/global_permission_grant.ts
@@ -42,7 +42,7 @@ function mkSwaggerSchema(server: FastifyInstance) {
       description:
         "Grant the right to execute a specific intent on the Global scope to a given user.",
       tags: ["global"],
-      summary: "Grant a permission to a group or user",
+      summary: "Grant a permission to a user",
       security: [
         {
           bearerToken: [],
@@ -82,6 +82,7 @@ interface Service {
   grantGlobalPermission(
     ctx: Ctx,
     user: ServiceUser,
+    userOrganization: string,
     grantee: Identity,
     permission: Intent,
   ): Promise<void>;
@@ -96,6 +97,8 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
       groups: (request as AuthenticatedRequest).user.groups,
     };
 
+    const userOrganization = (request as AuthenticatedRequest).user.organization;
+
     const bodyResult = validateRequestBody(request.body);
 
     if (Result.isErr(bodyResult)) {
@@ -109,7 +112,7 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
     const { identity: grantee, intent } = bodyResult.data;
 
     service
-      .grantGlobalPermission(ctx, user, grantee, intent)
+      .grantGlobalPermission(ctx, user, userOrganization, grantee, intent)
       .then(() => {
         const code = 200;
         const body = {

--- a/api/src/global_permission_revoke.ts
+++ b/api/src/global_permission_revoke.ts
@@ -42,7 +42,7 @@ function mkSwaggerSchema(server: FastifyInstance) {
       description:
         "Revoke the right to execute a specific intent on the Global scope to a given user.",
       tags: ["global"],
-      summary: "Revoke a permission from a group or user",
+      summary: "Revoke a permission from a user",
       security: [
         {
           bearerToken: [],
@@ -82,6 +82,7 @@ interface Service {
   revokeGlobalPermission(
     ctx: Ctx,
     user: ServiceUser,
+    userOrganization: string,
     revokee: Identity,
     permission: Intent,
   ): Promise<void>;
@@ -96,6 +97,8 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
       groups: (request as AuthenticatedRequest).user.groups,
     };
 
+    const userOrganization: string = (request as AuthenticatedRequest).user.organization;
+
     const bodyResult = validateRequestBody(request.body);
 
     if (Result.isErr(bodyResult)) {
@@ -109,7 +112,7 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
     const { identity: revokee, intent } = bodyResult.data;
 
     service
-      .revokeGlobalPermission(ctx, user, revokee, intent)
+      .revokeGlobalPermission(ctx, user, userOrganization, revokee, intent)
       .then(() => {
         const code = 200;
         const body = {

--- a/api/src/global_permissions_grant_all.ts
+++ b/api/src/global_permissions_grant_all.ts
@@ -85,6 +85,7 @@ interface Service {
   grantGlobalPermissions(
     ctx: Ctx,
     user: ServiceUser,
+    userOrganization: string,
     grantee: Identity,
     permission: Intent,
   ): Promise<void>;
@@ -101,6 +102,8 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
         id: (request as AuthenticatedRequest).user.userId,
         groups: (request as AuthenticatedRequest).user.groups,
       };
+
+      const userOrganization: string = (request as AuthenticatedRequest).user.organization;
 
       const bodyResult = validateRequestBody(request.body);
 
@@ -124,7 +127,7 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
           if (identitiesAuthorizedFor(globalPermissions, intent).includes(user.id)) {
             continue;
           }
-          await service.grantGlobalPermissions(ctx, user, grantee, intent);
+          await service.grantGlobalPermissions(ctx, user, userOrganization, grantee, intent);
           logger.debug({ grantee, intent }, "permission granted");
         }
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -223,20 +223,41 @@ registerRoutes(server, db, URL_PREFIX, multichainHost, backupApiPort, () =>
  */
 
 GlobalPermissionGrantAPI.addHttpHandler(server, URL_PREFIX, {
-  grantGlobalPermission: (ctx, user, grantee, permission) =>
-    GlobalPermissionGrantService.grantGlobalPermission(db, ctx, user, grantee, permission),
+  grantGlobalPermission: (ctx, user, userOrganization, grantee, permission) =>
+    GlobalPermissionGrantService.grantGlobalPermission(
+      db,
+      ctx,
+      user,
+      userOrganization,
+      grantee,
+      permission,
+    ),
 });
 
 GlobalPermissionsGrantAllAPI.addHttpHandler(server, URL_PREFIX, {
   getGlobalPermissions: (ctx, user) =>
     GlobalPermissionsGetService.getGlobalPermissions(db, ctx, user),
-  grantGlobalPermissions: (ctx, user, grantee, permission) =>
-    GlobalPermissionGrantService.grantGlobalPermission(db, ctx, user, grantee, permission),
+  grantGlobalPermissions: (ctx, user, userOrganization, grantee, permission) =>
+    GlobalPermissionGrantService.grantGlobalPermission(
+      db,
+      ctx,
+      user,
+      userOrganization,
+      grantee,
+      permission,
+    ),
 });
 
 GlobalPermissionRevokeAPI.addHttpHandler(server, URL_PREFIX, {
-  revokeGlobalPermission: (ctx, user, revokee, permission) =>
-    GlobalPermissionRevokeService.revokeGlobalPermission(db, ctx, user, revokee, permission),
+  revokeGlobalPermission: (ctx, user, userOrganization, revokee, permission) =>
+    GlobalPermissionRevokeService.revokeGlobalPermission(
+      db,
+      ctx,
+      user,
+      userOrganization,
+      revokee,
+      permission,
+    ),
 });
 
 GlobalPermissionsListAPI.addHttpHandler(server, URL_PREFIX, {

--- a/api/src/service/domain/workflow/global_permission_grant.ts
+++ b/api/src/service/domain/workflow/global_permission_grant.ts
@@ -1,25 +1,31 @@
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
 import { InvalidCommand } from "../errors/invalid_command";
 import { NotAuthorized } from "../errors/not_authorized";
+import { PreconditionError } from "../errors/precondition_error";
 import { Identity } from "../organization/identity";
 import { ServiceUser } from "../organization/service_user";
+import * as UserRecord from "../organization/user_record";
 import * as GlobalPermissionGranted from "./global_permission_granted";
 import * as GlobalPermissions from "./global_permissions";
 import { sourceProjects } from "./project_eventsourcing";
 
 interface Repository {
   getGlobalPermissions(): Promise<GlobalPermissions.GlobalPermissions>;
+  isGroup(granteeId): Promise<boolean>;
+  getUser(userId): Promise<Result.Type<UserRecord.UserRecord>>;
 }
 
 export async function grantGlobalPermission(
   ctx: Ctx,
   issuer: ServiceUser,
+  issuerOrganization: string,
   grantee: Identity,
   intent: Intent,
   repository: Repository,
-): Promise<{ newEvents: BusinessEvent[]; errors: Error[] }> {
+): Promise<Result.Type<BusinessEvent[]>> {
   // Create the new event:
   const globalPermissionGranted = GlobalPermissionGranted.createEvent(
     ctx.source,
@@ -28,30 +34,53 @@ export async function grantGlobalPermission(
     grantee,
   );
 
+  const grantIntent = "global.grantPermission";
+  const currentGlobalPermissions = await repository.getGlobalPermissions();
+
+  // Check if grantee is group
+  const isGroup = await repository.isGroup(grantee);
+
+  // If grantee is group, return an error because global permissions cannot be granted to groups
+  if (isGroup) {
+    return new PreconditionError(
+      ctx,
+      globalPermissionGranted,
+      "Cannot assign global permissions to groups",
+    );
+  } else {
+    // If the grantee is not a group, he/she is a user
+    const userResult = await repository.getUser(grantee);
+    if (Result.isErr(userResult)) {
+      return new PreconditionError(ctx, globalPermissionGranted, userResult.message);
+    }
+    // Check if grantee and issuer belong to the same organization
+    if (userResult.organization !== issuerOrganization) {
+      return new NotAuthorized({
+        ctx,
+        userId: issuer.id,
+        intent: grantIntent,
+        target: currentGlobalPermissions,
+      });
+    }
+  }
+
   // Check authorization (if not root):
   if (issuer.id !== "root") {
-    const grantIntent = "global.grantPermission";
-    const currentGlobalPermissions = await repository.getGlobalPermissions();
     if (!GlobalPermissions.permits(currentGlobalPermissions, issuer, [grantIntent])) {
-      return {
-        newEvents: [],
-        errors: [
-          new NotAuthorized({
-            ctx,
-            userId: issuer.id,
-            intent: grantIntent,
-            target: currentGlobalPermissions,
-          }),
-        ],
-      };
+      return new NotAuthorized({
+        ctx,
+        userId: issuer.id,
+        intent: grantIntent,
+        target: currentGlobalPermissions,
+      });
     }
   }
 
   // Check that the new event is indeed valid:
   const { errors } = sourceProjects(ctx, [globalPermissionGranted]);
   if (errors.length > 0) {
-    return { newEvents: [], errors: [new InvalidCommand(ctx, globalPermissionGranted, errors)] };
+    return new InvalidCommand(ctx, globalPermissionGranted, errors);
   }
 
-  return { newEvents: [globalPermissionGranted], errors: [] };
+  return [globalPermissionGranted];
 }

--- a/api/src/service/domain/workflow/global_permission_revoke.ts
+++ b/api/src/service/domain/workflow/global_permission_revoke.ts
@@ -1,25 +1,31 @@
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
 import { InvalidCommand } from "../errors/invalid_command";
 import { NotAuthorized } from "../errors/not_authorized";
+import { PreconditionError } from "../errors/precondition_error";
 import { Identity } from "../organization/identity";
 import { ServiceUser } from "../organization/service_user";
+import * as UserRecord from "../organization/user_record";
 import * as GlobalPermissionRevoked from "./global_permission_revoked";
 import * as GlobalPermissions from "./global_permissions";
 import { sourceProjects } from "./project_eventsourcing";
 
 interface Repository {
   getGlobalPermissions(): Promise<GlobalPermissions.GlobalPermissions>;
+  isGroup(revokeeId): Promise<boolean>;
+  getUser(userId): Promise<Result.Type<UserRecord.UserRecord>>;
 }
 
 export async function revokeGlobalPermission(
   ctx: Ctx,
   issuer: ServiceUser,
+  issuerOrganization: string,
   revokee: Identity,
   intent: Intent,
   repository: Repository,
-): Promise<{ newEvents: BusinessEvent[]; errors: Error[] }> {
+): Promise<Result.Type<BusinessEvent[]>> {
   // Create the new event:
   const globalPermissionRevoked = GlobalPermissionRevoked.createEvent(
     ctx.source,
@@ -28,30 +34,53 @@ export async function revokeGlobalPermission(
     revokee,
   );
 
+  const revokeIntent = "global.revokePermission";
+  const currentGlobalPermissions = await repository.getGlobalPermissions();
+
+  // Check if revokee is group
+  const isGroup = await repository.isGroup(revokee);
+
+  // If revokee is group, return an error because global permissions cannot be granted to groups
+  if (isGroup) {
+    return new PreconditionError(
+      ctx,
+      globalPermissionRevoked,
+      "Cannot assign global permissions to groups",
+    );
+  } else {
+    // If the revokee is not a group, he/she is a user
+    const userResult = await repository.getUser(revokee);
+    if (Result.isErr(userResult)) {
+      return new PreconditionError(ctx, globalPermissionRevoked, userResult.message);
+    }
+    // Check if revokee and issuer belong to the same organization
+    if (userResult.organization !== issuerOrganization) {
+      return new NotAuthorized({
+        ctx,
+        userId: issuer.id,
+        intent: revokeIntent,
+        target: currentGlobalPermissions,
+      });
+    }
+  }
+
   // Check authorization (if not root):
   if (issuer.id !== "root") {
-    const revokeIntent = "global.revokePermission";
-    const currentGlobalPermissions = await repository.getGlobalPermissions();
     if (!GlobalPermissions.permits(currentGlobalPermissions, issuer, [revokeIntent])) {
-      return {
-        newEvents: [],
-        errors: [
-          new NotAuthorized({
-            ctx,
-            userId: issuer.id,
-            intent: revokeIntent,
-            target: currentGlobalPermissions,
-          }),
-        ],
-      };
+      return new NotAuthorized({
+        ctx,
+        userId: issuer.id,
+        intent: revokeIntent,
+        target: currentGlobalPermissions,
+      });
     }
   }
 
   // Check that the new event is indeed valid:
   const { errors } = sourceProjects(ctx, [globalPermissionRevoked]);
   if (errors.length > 0) {
-    return { newEvents: [], errors: [new InvalidCommand(ctx, globalPermissionRevoked, errors)] };
+    return new InvalidCommand(ctx, globalPermissionRevoked, errors);
   }
 
-  return { newEvents: [globalPermissionRevoked], errors: [] };
+  return [globalPermissionRevoked];
 }

--- a/api/src/service/domain/workflow/global_permissions_grant.spec.ts
+++ b/api/src/service/domain/workflow/global_permissions_grant.spec.ts
@@ -1,0 +1,117 @@
+import { assert } from "chai";
+
+import Intent from "../../../authz/intents";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { Identity } from "../organization/identity";
+import { ServiceUser } from "../organization/service_user";
+import * as UserRecord from "../organization/user_record";
+import { grantGlobalPermission } from "./global_permission_grant";
+import * as GlobalPermissions from "./global_permissions";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const charlie: ServiceUser = { id: "charlie", groups: ["alice_and_bob_and_charlie"] };
+const orgaA = "orgaA";
+const orgaB = "orgaB";
+const grantIntent: Intent = "global.grantPermission";
+const basePermissions: GlobalPermissions.GlobalPermissions = {
+  permissions: {},
+  log: [],
+};
+const grantPermissions: GlobalPermissions.GlobalPermissions = {
+  permissions: { "global.grantPermission": ["bob"] },
+  log: [],
+};
+const baseUser: UserRecord.UserRecord = {
+  id: "dummy",
+  createdAt: new Date().toISOString(),
+  displayName: "dummy",
+  organization: orgaA,
+  passwordHash: "12345",
+  address: "12345",
+  encryptedPrivKey: "12345",
+  permissions: {},
+  log: [],
+  additionalData: {},
+};
+
+const baseRepository = {
+  getGlobalPermissions: async () => basePermissions,
+  isGroup: async () => false,
+  getUser: async () => baseUser,
+};
+
+describe("Grant global permissions: authorization and conditions", () => {
+  it("The root user can always grant global permissions for users within the same organization", async () => {
+    const grantee: Identity = "alice";
+    const result = await grantGlobalPermission(
+      ctx,
+      root,
+      orgaA,
+      grantee,
+      grantIntent,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isOk(result));
+  });
+
+  it("A user (including root) cannot grant global permissions to users from other organizations", async () => {
+    const grantee: Identity = "alice";
+    const result = await grantGlobalPermission(
+      ctx,
+      root,
+      orgaB,
+      grantee,
+      grantIntent,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("Without the 'global.intent.grantPermission' permission, the user cannot grant global permissions", async () => {
+    const grantee: Identity = "alice";
+    const result = await grantGlobalPermission(
+      ctx,
+      charlie,
+      orgaA,
+      grantee,
+      grantIntent,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it(
+    "When a user has the 'global.intent.grantPermission' permission, " +
+      "he/she can grant global permissions",
+    async () => {
+      const grantee: Identity = "alice";
+      const result = await grantGlobalPermission(ctx, bob, orgaA, grantee, grantIntent, {
+        ...baseRepository,
+        getGlobalPermissions: async () => {
+          return grantPermissions;
+        },
+      });
+
+      assert.isTrue(Result.isOk(result));
+    },
+  );
+
+  it("If the grantee is a group, global permissions cannot be granted", async () => {
+    const grantee: Identity = "alice";
+    const result = await grantGlobalPermission(ctx, bob, orgaA, grantee, grantIntent, {
+      ...baseRepository,
+      isGroup: async () => true,
+    });
+
+    assert.isTrue(Result.isErr(result));
+  });
+});

--- a/api/src/service/domain/workflow/global_permissions_revoke.spec.ts
+++ b/api/src/service/domain/workflow/global_permissions_revoke.spec.ts
@@ -1,0 +1,117 @@
+import { assert } from "chai";
+
+import Intent from "../../../authz/intents";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { Identity } from "../organization/identity";
+import { ServiceUser } from "../organization/service_user";
+import * as UserRecord from "../organization/user_record";
+import { revokeGlobalPermission } from "./global_permission_revoke";
+import * as GlobalPermissions from "./global_permissions";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const charlie: ServiceUser = { id: "charlie", groups: ["alice_and_bob_and_charlie"] };
+const orgaA = "orgaA";
+const orgaB = "orgaB";
+const revokeIntent: Intent = "global.revokePermission";
+const basePermissions: GlobalPermissions.GlobalPermissions = {
+  permissions: {},
+  log: [],
+};
+const revokePermissions: GlobalPermissions.GlobalPermissions = {
+  permissions: { "global.revokePermission": ["bob"] },
+  log: [],
+};
+const baseUser: UserRecord.UserRecord = {
+  id: "dummy",
+  createdAt: new Date().toISOString(),
+  displayName: "dummy",
+  organization: orgaA,
+  passwordHash: "12345",
+  address: "12345",
+  encryptedPrivKey: "12345",
+  permissions: {},
+  log: [],
+  additionalData: {},
+};
+
+const baseRepository = {
+  getGlobalPermissions: async () => basePermissions,
+  isGroup: async () => false,
+  getUser: async () => baseUser,
+};
+
+describe("Revoke global permissions: authorization and conditions", () => {
+  it("The root user can always revoke global permissions for users within the same organization", async () => {
+    const revokee: Identity = "alice";
+    const result = await revokeGlobalPermission(
+      ctx,
+      root,
+      orgaA,
+      revokee,
+      revokeIntent,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isOk(result));
+  });
+
+  it("A user (including root) cannot revoke global permissions to users from other organizations", async () => {
+    const revokee: Identity = "alice";
+    const result = await revokeGlobalPermission(
+      ctx,
+      root,
+      orgaB,
+      revokee,
+      revokeIntent,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("Without the 'global.intent.revokePermission' permission, the user cannot revoke global permissions", async () => {
+    const revokee: Identity = "alice";
+    const result = await revokeGlobalPermission(
+      ctx,
+      charlie,
+      orgaA,
+      revokee,
+      revokeIntent,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it(
+    "When a user has the 'global.intent.revokePermission' permission, " +
+      "he/she can revoke global permissions",
+    async () => {
+      const revokee: Identity = "alice";
+      const result = await revokeGlobalPermission(ctx, bob, orgaA, revokee, revokeIntent, {
+        ...baseRepository,
+        getGlobalPermissions: async () => {
+          return revokePermissions;
+        },
+      });
+
+      assert.isTrue(Result.isOk(result));
+    },
+  );
+
+  it("If the revokee is a group, global permissions cannot be revoked", async () => {
+    const revokee: Identity = "alice";
+    const result = await revokeGlobalPermission(ctx, bob, orgaA, revokee, revokeIntent, {
+      ...baseRepository,
+      isGroup: async () => true,
+    });
+
+    assert.isTrue(Result.isErr(result));
+  });
+});

--- a/api/src/service/global_permission_grant.ts
+++ b/api/src/service/global_permission_grant.ts
@@ -1,34 +1,41 @@
 import Intent from "../authz/intents";
 import { Ctx } from "../lib/ctx";
+import * as Result from "../result";
 import { ConnToken } from "./conn";
 import { Identity } from "./domain/organization/identity";
 import { ServiceUser } from "./domain/organization/service_user";
 import * as GlobalPermissionsGrant from "./domain/workflow/global_permission_grant";
 import { getGlobalPermissions } from "./global_permissions_get";
+import * as GroupQuery from "./group_query";
 import { store } from "./store";
+import * as UserQuery from "./user_query";
 
 export async function grantGlobalPermission(
   conn: ConnToken,
   ctx: Ctx,
   serviceUser: ServiceUser,
+  serviceUserOrganization: string,
   grantee: Identity,
   permission: Intent,
 ): Promise<void> {
-  const { newEvents, errors } = await GlobalPermissionsGrant.grantGlobalPermission(
+  const result = await GlobalPermissionsGrant.grantGlobalPermission(
     ctx,
     serviceUser,
+    serviceUserOrganization,
     grantee,
     permission,
     {
       getGlobalPermissions: async () => getGlobalPermissions(conn, ctx, serviceUser),
+      isGroup: async granteeId => await GroupQuery.groupExists(conn, ctx, serviceUser, granteeId),
+      getUser: async userId => await UserQuery.getUser(conn, ctx, serviceUser, userId),
     },
   );
-  if (errors.length > 0) return Promise.reject(errors);
-  if (!newEvents.length) {
-    return Promise.reject(`Generating events failed: ${JSON.stringify(newEvents)}`);
+  if (Result.isErr(result)) return Promise.reject(result);
+  if (result.length === 0) {
+    return Promise.reject(`Generating events failed: ${JSON.stringify(result)}`);
   }
 
-  for (const event of newEvents) {
+  for (const event of result) {
     await store(conn, ctx, event);
   }
 }

--- a/api/src/service/global_permission_revoke.ts
+++ b/api/src/service/global_permission_revoke.ts
@@ -1,29 +1,37 @@
 import Intent from "../authz/intents";
 import { Ctx } from "../lib/ctx";
+import * as Result from "../result";
 import { ConnToken } from "./conn";
 import { Identity } from "./domain/organization/identity";
 import { ServiceUser } from "./domain/organization/service_user";
 import * as GlobalPermissionsRevoke from "./domain/workflow/global_permission_revoke";
 import { getGlobalPermissions } from "./global_permissions_get";
+import * as GroupQuery from "./group_query";
 import { store } from "./store";
+import * as UserQuery from "./user_query";
 
 export async function revokeGlobalPermission(
   conn: ConnToken,
   ctx: Ctx,
   serviceUser: ServiceUser,
+  serviceUserOrganization: string,
   revokee: Identity,
   permission: Intent,
 ): Promise<void> {
-  const { newEvents, errors } = await GlobalPermissionsRevoke.revokeGlobalPermission(
+  const result = await GlobalPermissionsRevoke.revokeGlobalPermission(
     ctx,
     serviceUser,
+    serviceUserOrganization,
     revokee,
     permission,
     {
       getGlobalPermissions: async () => getGlobalPermissions(conn, ctx, serviceUser),
+      isGroup: async revokeeId => await GroupQuery.groupExists(conn, ctx, serviceUser, revokeeId),
+      getUser: async userId => await UserQuery.getUser(conn, ctx, serviceUser, userId),
     },
   );
-  if (errors.length > 0) return Promise.reject(errors);
+  if (Result.isErr(result)) return Promise.reject(result);
+  const newEvents = result;
   if (!newEvents.length) {
     return Promise.reject(`Generating events failed: ${JSON.stringify(newEvents)}`);
   }

--- a/frontend/src/pages/Users/GroupTable.js
+++ b/frontend/src/pages/Users/GroupTable.js
@@ -1,17 +1,16 @@
-import React from "react";
-import Table from "@material-ui/core/Table";
-import TableHead from "@material-ui/core/TableHead";
-import TableRow from "@material-ui/core/TableRow";
-import TableCell from "@material-ui/core/TableCell";
-import TableBody from "@material-ui/core/TableBody";
 import IconButton from "@material-ui/core/IconButton";
 import Paper from "@material-ui/core/Paper";
-import PermissionIcon from "@material-ui/icons/LockOpen";
-
-import _sortBy from "lodash/sortBy";
-import EditIcon from "@material-ui/icons/Edit";
-import strings from "../../localizeStrings";
 import { withStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import EditIcon from "@material-ui/icons/Edit";
+import _sortBy from "lodash/sortBy";
+import React from "react";
+
+import strings from "../../localizeStrings";
 
 const styles = {
   icon: {
@@ -21,7 +20,7 @@ const styles = {
 const sortGroups = groups => {
   return _sortBy(groups, group => group.id && group.displayName);
 };
-const GroupsTable = ({ groups, permissionIconDisplayed, showDashboardDialog, classes, allowedIntents }) => {
+const GroupsTable = ({ groups, showDashboardDialog, classes, allowedIntents }) => {
   const editGroupDisplayed = allowedIntents.includes("global.createGroup");
 
   const sortedGroups = sortGroups(groups);
@@ -50,11 +49,6 @@ const GroupsTable = ({ groups, permissionIconDisplayed, showDashboardDialog, cla
                   {editGroupDisplayed ? (
                     <IconButton onClick={() => showDashboardDialog("editGroup", group.groupId)}>
                       <EditIcon className={classes.icon} />
-                    </IconButton>
-                  ) : null}
-                  {permissionIconDisplayed ? (
-                    <IconButton onClick={() => showDashboardDialog("editGroupPermissions", group.groupId)}>
-                      <PermissionIcon className={classes.icon} />
                     </IconButton>
                   ) : null}
                 </TableCell>

--- a/frontend/src/pages/Users/Users.js
+++ b/frontend/src/pages/Users/Users.js
@@ -70,7 +70,7 @@ const Users = props => {
           </div>
         ) : null}
         {tabIndex === 0 && <UsersTable permissionIconDisplayed={permissionIconDisplayed} {...props} />}
-        {tabIndex === 1 && <GroupTable permissionIconDisplayed={permissionIconDisplayed} {...props} />}
+        {tabIndex === 1 && <GroupTable {...props} />}
       </div>
       <DialogContainer {...props} />
     </div>


### PR DESCRIPTION
# Changes

Global permissions can now only be granted/revoked to/from users which are in the same organisation as the user granting/revoking the global permissions. Global permissions can not be granted/revkoked to/from groups as this would cause inconsistencies. 
Since global permissions are not available for groups anymore, the permissions button is removed for groups. 

Closes #340 
Closes #345 