### PR TITLE
ui: New Search feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-<!-- ### Added-->
+### Added
+
+- Added search feature for overview page [#347](https://github.com/openkfw/TruBudget/issues/347)
 
 ### Changed
 

--- a/doc/wiki/User-Guide/Projects/Project.md
+++ b/doc/wiki/User-Guide/Projects/Project.md
@@ -46,6 +46,20 @@ View all projects where the current user has view-permissions on.
 
 ![show projects](../../uploads/Screenshots/view_projects.jpg)
 
+## Filter projects
+
+**Description:**
+
+Filter projects based on name, description and tag in the overview page.
+
+**Instructions:**
+
+1. Navigate to the overview page
+2. Click the "Quick Search" button on the top right
+3. After the search bar appears, type in the term by which you want to filter the projects
+4. The projects are now filtered by your search term
+5. If you want to clear the search field, click on the "X" button next to the text
+
 ## View project details
 
 **Description:**

--- a/e2e-test/cypress/integration/currencies_spec.js
+++ b/e2e-test/cypress/integration/currencies_spec.js
@@ -60,10 +60,8 @@ describe("Overview Page", function() {
     //Fetch projects to get newest one
     cy.reload();
 
-    cy.get("[aria-label=project]")
-      .contains("Test")
-      .parents()
-      .filter("[aria-label=project]")
+    cy.get("[data-test*=projectcard]")
+      .last()
       .find("[data-test=projectbudget]")
       .should("contain", currencies.EUR.symbol);
   });

--- a/e2e-test/cypress/integration/navigation_spec.js
+++ b/e2e-test/cypress/integration/navigation_spec.js
@@ -1,0 +1,164 @@
+describe("Navigation", function() {
+  beforeEach(function() {
+    cy.login();
+    cy.visit(`/projects`);
+  });
+
+  it("The hambuger menu opens the navigation menu", function() {
+    cy.get("[data-test=openSideNavbar]").click();
+    cy.get("[data-test=side-navigation]").should("be.visible");
+  });
+
+  it("The 'Projects' button redirects to the project overview", function() {
+    cy.get("[data-test=openSideNavbar]").click();
+    cy.get("[data-test=side-navigation]").should("be.visible");
+
+    cy.get("[data-test=side-navigation-projects]").click();
+    cy.location("pathname").should("eq", "/projects");
+  });
+  it("The 'Notifications' button redirects to the notifications page", function() {
+    cy.get("[data-test=openSideNavbar]").click();
+    cy.get("[data-test=side-navigation]").should("be.visible");
+
+    cy.get("[data-test=side-navigation-notifications]").click();
+    cy.location("pathname").should("eq", "/notifications");
+  });
+  it("The 'Users' button redirects to the user overview", function() {
+    cy.get("[data-test=openSideNavbar]").click();
+    cy.get("[data-test=side-navigation]").should("be.visible");
+
+    cy.get("[data-test=side-navigation-users]").click();
+    cy.location("pathname").should("eq", "/users");
+  });
+  it("The 'Nodes' button redirects to the nodes overview", function() {
+    cy.get("[data-test=openSideNavbar]").click();
+    cy.get("[data-test=side-navigation]").should("be.visible");
+
+    cy.get("[data-test=side-navigation-nodes]").click();
+    cy.location("pathname").should("eq", "/nodes");
+  });
+
+  it("Navigate via bredcrumbs", function() {
+    let projectId;
+    let subprojectId;
+    // Caution: If name is too long, it will be shortened with ellipses
+    let projectDisplayName = "Project";
+    let subprojectDisplayName = "Subproject";
+    cy.createProject(projectDisplayName, projectDisplayName, [])
+      .then(({ id }) => {
+        projectId = id;
+        return cy.createSubproject(projectId, subprojectDisplayName);
+      })
+      .then(({ id }) => {
+        subprojectId = id;
+      })
+      .then(() => {
+        cy.visit(`/projects/${projectId}/${subprojectId}`);
+        cy.get("[data-test*=breadcrumb]").should("have.length", 4);
+
+        cy.get(`[data-test=breadcrumb-${subprojectDisplayName}]`).should("be.disabled");
+
+        cy.get(`[data-test=breadcrumb-${projectDisplayName}]`).click();
+        cy.location("pathname").should("eq", `/projects/${projectId}`);
+        cy.get(`[data-test=breadcrumb-${projectDisplayName}]`).should("be.disabled");
+
+        cy.get(`[data-test=breadcrumb-Projects]`).click();
+        cy.location("pathname").should("eq", `/projects`);
+        cy.get(`[data-test=breadcrumb-Projects]`).should("be.disabled");
+      });
+  });
+
+  it("Filter projects by display name", function() {
+    // Set a unique project name
+    const projectDisplayName = Math.floor(Math.random() * 10000000000);
+
+    // Create project which will then be displayed after filtering
+    cy.createProject(projectDisplayName, projectDisplayName, [])
+      .then(() => cy.visit(`/projects`))
+      .then(() => {
+        cy.get("[data-test=toggle-project-search]").click();
+        cy.get("[data-test=project-search-field]").should("be.visible");
+        cy.get("[data-test=project-search-field] input").type(projectDisplayName);
+        // Since project name is unique, there can only be one match
+        cy.get("[data-test*=projectcard]").then(res => assert.equal(res.length, 1));
+
+        // Check the functionality of the clear button
+        cy.get("[data-test=clear-project-search]").click();
+        cy.get("[data-test=project-search-field] input").should("have.value", "");
+
+        cy.get("[data-test=toggle-project-search]").click();
+        cy.get("[data-test=project-search-field]").should("not.be.visible");
+      });
+  });
+
+  it("Search bar is closed and reset when viewing project details", function() {
+    // Set a unique project name
+    const projectDisplayName = Math.floor(Math.random() * 10000000000);
+
+    // Create project which will then be displayed after filtering
+    cy.createProject(projectDisplayName, projectDisplayName, [])
+      .then(() => cy.visit(`/projects`))
+      .then(() => {
+        cy.get("[data-test=toggle-project-search]").click();
+        cy.get("[data-test=project-search-field]").should("be.visible");
+        cy.get("[data-test=project-search-field] input").type(projectDisplayName);
+        // Since project name is unique, there can only be one match
+        cy.get("[data-test*=projectcard]").then(res => assert.equal(res.length, 1));
+
+        // Go to project
+        cy.get("[data-test*=project-view-button]")
+          .first()
+          .click();
+
+        cy.get("[data-test=project-search-field]").should("not.be.visible");
+        cy.get("[data-test=toggle-project-search]").should("be.disabled");
+
+        cy.visit("/projects");
+        // Search field should be empty
+        cy.get("[data-test=toggle-project-search]").click();
+        cy.get("[data-test=project-search-field] input").should("have.value", "");
+      });
+  });
+
+  it("Search bar is closed and reset when clicking on 'Main' breadcrumb", function() {
+    // Set a unique project name
+    const projectDisplayName = Math.floor(Math.random() * 10000000000);
+
+    // Create project which will then be displayed after filtering
+    cy.createProject(projectDisplayName, projectDisplayName, [])
+      .then(() => cy.visit(`/projects`))
+      .then(() => {
+        cy.get("[data-test=toggle-project-search]").click();
+        cy.get("[data-test=project-search-field]").should("be.visible");
+        cy.get("[data-test=project-search-field] input").type(projectDisplayName);
+        // Since project name is unique, there can only be one match
+        cy.get("[data-test*=projectcard]").then(res => assert.equal(res.length, 1));
+
+        // Go to project
+        cy.get("[data-test=breadcrumb-Main]").click();
+
+        cy.get("[data-test=project-search-field]").should("not.be.visible");
+        cy.get("[data-test=toggle-project-search]").should("be.enabled");
+        // TODO: Test what happens when you click on a project
+      });
+  });
+
+  it("The notification button redirects to the notification page", function() {
+    cy.get("[data-test=navbar-notification-button]").should("be.visible");
+    cy.get("[data-test=navbar-notification-button]").click();
+    cy.location("pathname").should("eq", "/notifications");
+
+    cy.visit("/projects");
+  });
+
+  it("Logs out the user", function() {
+    cy.get("[data-test=navbar-logout-button]").should("be.visible");
+    cy.get("[data-test=navbar-logout-button]").click();
+    cy.location("pathname").should("eq", "/login");
+
+    cy.get("[data-test=loginpage]").should("be.visible");
+
+    cy.login();
+    cy.visit("/projects");
+  });
+});

--- a/e2e-test/cypress/integration/navigation_spec.js
+++ b/e2e-test/cypress/integration/navigation_spec.js
@@ -84,9 +84,6 @@ describe("Navigation", function() {
 
         // Check the functionality of the clear button
         cy.get("[data-test=clear-project-search]").click();
-        cy.get("[data-test=project-search-field] input").should("have.value", "");
-
-        cy.get("[data-test=toggle-project-search]").click();
         cy.get("[data-test=project-search-field]").should("not.be.visible");
       });
   });

--- a/e2e-test/cypress/integration/overview_spec.js
+++ b/e2e-test/cypress/integration/overview_spec.js
@@ -15,13 +15,8 @@ describe("Overview Page", function() {
     cy.get("[data-test=projectcard-0]")
       .eq(0)
       .then($card => {
-        console.log($card.find("[data-test=projectheader] span"));
-        expect(
-          $card.find("[data-test=projectheader] span").eq(0)
-        ).to.contains.text(this.data.displayName);
-        expect($card.find("[data-test=projectheader] span").eq(2)).to.have.text(
-          "Status: Open"
-        );
+        expect($card.find("[data-test=projectheader] span").eq(0)).to.contains.text(this.data.displayName);
+        expect($card.find("[data-test=projectheader] span").eq(2)).to.have.text("Status: Open");
         expect(
           $card
             .find("[data-test=projectbudget]")

--- a/frontend/src/pages/Login/LoginPage.js
+++ b/frontend/src/pages/Login/LoginPage.js
@@ -30,6 +30,7 @@ const LoginPage = ({
   const connectedToAdminNode = -1;
   return (
     <div
+      data-test="loginpage"
       id="loginpage"
       style={{
         backgroundImage: 'url("/welcome.jpg")',

--- a/frontend/src/pages/Navbar/LogoutIcon.js
+++ b/frontend/src/pages/Navbar/LogoutIcon.js
@@ -9,6 +9,7 @@ const LogoutIcon = ({ history, logout }) => {
   return (
     <IconButton
       id="logoutbutton"
+      data-test="navbar-logout-button"
       tooltip={strings.navigation.logout}
       onClick={() => {
         logout();

--- a/frontend/src/pages/Navbar/MainNavbarNavigation.js
+++ b/frontend/src/pages/Navbar/MainNavbarNavigation.js
@@ -1,8 +1,7 @@
-import React from "react";
-
 import Button from "@material-ui/core/Button";
-import ChevronRight from "@material-ui/icons/ChevronRight";
 import Typography from "@material-ui/core/Typography";
+import ChevronRight from "@material-ui/icons/ChevronRight";
+import React from "react";
 
 import strings from "../../localizeStrings";
 
@@ -65,7 +64,14 @@ const getPathName = (name, index, currentProject, currentSubProject) => {
   }
 };
 
-const createBreadcrumb = ({ pathname }, history, currentProject, currentSubProject) => {
+const createBreadcrumb = (
+  { pathname },
+  history,
+  currentProject,
+  currentSubProject,
+  storeSearchTerm,
+  storeSearchBarDisplayed
+) => {
   //if currentProject or currentSubProject are null the user has no permission to see the displayName
   //null will be displayed as an empty string
   if (!currentProject) currentProject = "";
@@ -82,22 +88,37 @@ const createBreadcrumb = ({ pathname }, history, currentProject, currentSubProje
     const pathName = getPathName(path, index, currentProject, currentSubProject);
     const formattedPathName = pathName === "" ? redacted : pathName;
     const isLastItem = index === paths.length - 1;
+    const displayedName = index ? formattedPathName : strings.navigation.main_site;
     return (
       <div key={index} style={styles.breadcrumb}>
         <div>{index ? <ChevronRight color="primary" style={{ height: "16px" }} /> : null}</div>
         <Button
           disabled={isLastItem || pathName === ""}
+          data-test={`breadcrumb-${displayedName}`}
           color="primary"
-          onClick={() => history.push(accumulatedPath[index])}
+          onClick={() => {
+            storeSearchBarDisplayed(false);
+            storeSearchTerm("");
+            history.push(accumulatedPath[index]);
+          }}
         >
-          {index ? formattedPathName : strings.navigation.main_site}
+          {displayedName}
         </Button>
       </div>
     );
   });
 };
 
-const MainNavbarNavigation = ({ toggleSidebar, history, route, environment, currentProject, currentSubProject }) => {
+const MainNavbarNavigation = ({
+  toggleSidebar,
+  history,
+  route,
+  environment,
+  currentProject,
+  currentSubProject,
+  storeSearchTerm,
+  storeSearchBarDisplayed
+}) => {
   const productionActive = environment === "Prod";
   const navbarTitle = productionActive ? "TruBudget" : "TruBudget (Test)";
   return (
@@ -105,7 +126,9 @@ const MainNavbarNavigation = ({ toggleSidebar, history, route, environment, curr
       <Typography variant="button" color={productionActive ? "primary" : "secondary"}>
         {navbarTitle}
       </Typography>
-      <div style={styles.breadcrumbs}>{createBreadcrumb(route, history, currentProject, currentSubProject)}</div>
+      <div style={styles.breadcrumbs}>
+        {createBreadcrumb(route, history, currentProject, currentSubProject, storeSearchTerm, storeSearchBarDisplayed)}
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/Navbar/Navbar.js
+++ b/frontend/src/pages/Navbar/Navbar.js
@@ -1,13 +1,12 @@
+import AppBar from "@material-ui/core/AppBar";
+import { withStyles } from "@material-ui/core/styles";
+import Toolbar from "@material-ui/core/Toolbar";
 import React from "react";
 
-import AppBar from "@material-ui/core/AppBar";
-import Toolbar from "@material-ui/core/Toolbar";
-import { withStyles } from "@material-ui/core/styles";
-
-import SideNav from "./SideNav";
 import LeftNavbarNavigation from "./LeftNavbarNavigation";
 import MainNavbarNavigation from "./MainNavbarNavigation";
 import RightNavbarNavigation from "./RightNavbarNavigation";
+import SideNav from "./SideNav";
 
 const styles = {
   root: {
@@ -41,48 +40,60 @@ const Navbar = ({
   restoreBackup,
   classes,
   versions,
-  exportData
-}) => (
-  <div>
-    <AppBar classes={classes} position="absolute">
-      <Toolbar>
-        <LeftNavbarNavigation toggleSidebar={toggleSidebar} />
-        <MainNavbarNavigation
-          productionActive={productionActive}
-          history={history}
-          route={route}
-          currentProject={currentProject}
-          currentSubProject={currentSubProject}
-          environment={environment}
-        />
-        <RightNavbarNavigation
-          organization={organization}
-          unreadNotificationCount={unreadNotificationCount}
-          numberOfActivePeers={numberOfActivePeers}
-          peers={peers}
-          history={history}
-          logout={logout}
-        />
-      </Toolbar>
-    </AppBar>
-    <SideNav
-      toggleSidebar={toggleSidebar}
-      showSidebar={showSidebar}
-      history={history}
-      logout={logout}
-      allowedIntents={allowedIntents}
-      displayName={displayName}
-      organization={organization}
-      avatar={avatar}
-      avatarBackground={avatarBackground}
-      groups={groups}
-      userId={userId}
-      createBackup={createBackup}
-      restoreBackup={restoreBackup}
-      versions={versions}
-      exportData={exportData}
-    />
-  </div>
-);
+  exportData,
+  storeSearchTerm,
+  searchTerm,
+  storeSearchBarDisplayed,
+  searchBarDisplayed
+}) => {
+  return (
+    <div>
+      <AppBar classes={classes} position="absolute">
+        <Toolbar>
+          <LeftNavbarNavigation toggleSidebar={toggleSidebar} />
+          <MainNavbarNavigation
+            productionActive={productionActive}
+            history={history}
+            route={route}
+            currentProject={currentProject}
+            currentSubProject={currentSubProject}
+            environment={environment}
+            storeSearchBarDisplayed={storeSearchBarDisplayed}
+            storeSearchTerm={storeSearchTerm}
+          />
+          <RightNavbarNavigation
+            organization={organization}
+            unreadNotificationCount={unreadNotificationCount}
+            numberOfActivePeers={numberOfActivePeers}
+            peers={peers}
+            history={history}
+            logout={logout}
+            storeSearchTerm={storeSearchTerm}
+            storeSearchBarDisplayed={storeSearchBarDisplayed}
+            searchTerm={searchTerm}
+            searchBarDisplayed={searchBarDisplayed}
+          />
+        </Toolbar>
+      </AppBar>
+      <SideNav
+        toggleSidebar={toggleSidebar}
+        showSidebar={showSidebar}
+        history={history}
+        logout={logout}
+        allowedIntents={allowedIntents}
+        displayName={displayName}
+        organization={organization}
+        avatar={avatar}
+        avatarBackground={avatarBackground}
+        groups={groups}
+        userId={userId}
+        createBackup={createBackup}
+        restoreBackup={restoreBackup}
+        versions={versions}
+        exportData={exportData}
+      />
+    </div>
+  );
+};
 
 export default withStyles(styles)(Navbar);

--- a/frontend/src/pages/Navbar/NavbarContainer.js
+++ b/frontend/src/pages/Navbar/NavbarContainer.js
@@ -2,7 +2,16 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import isEmpty from "lodash/isEmpty";
 
-import { toggleSidebar, fetchActivePeers, createBackup, restoreBackup, fetchVersions, exportData } from "./actions";
+import {
+  toggleSidebar,
+  fetchActivePeers,
+  createBackup,
+  restoreBackup,
+  fetchVersions,
+  exportData,
+  storeSearchTerm,
+  storeSearchBarDisplayed
+} from "./actions";
 import { logout } from "../Login/actions";
 
 import FlyInNotifications from "../Notifications/FlyInNotifications";
@@ -38,7 +47,9 @@ const mapDispatchToProps = {
   createBackup,
   restoreBackup,
   fetchVersions,
-  exportData
+  exportData,
+  storeSearchTerm,
+  storeSearchBarDisplayed
 };
 
 const mapStateToProps = state => {
@@ -62,7 +73,9 @@ const mapStateToProps = state => {
     allowedIntents: state.getIn(["login", "allowedIntents"]),
     groups: state.getIn(["login", "groups"]),
     unreadNotificationCount: state.getIn(["notifications", "unreadNotificationCount"]),
-    latestFlyInId: state.getIn(["notifications", "latestFlyInId"])
+    latestFlyInId: state.getIn(["notifications", "latestFlyInId"]),
+    searchTerm: state.getIn(["navbar", "searchTerm"]),
+    searchBarDisplayed: state.getIn(["navbar", "searchBarDisplayed"])
   };
 };
 

--- a/frontend/src/pages/Navbar/NotificationIcon.js
+++ b/frontend/src/pages/Navbar/NotificationIcon.js
@@ -35,14 +35,22 @@ const NotificationIcon = ({ unreadNotificationCount, history, classes }) => {
         }
         color="secondary"
       >
-        <IconButton tooltip={strings.navigation.unread_notifications} onClick={() => history.push("/notifications")}>
+        <IconButton
+          data-test="navbar-notification-button"
+          tooltip={strings.navigation.unread_notifications}
+          onClick={() => history.push("/notifications")}
+        >
           <BubbleIcon color="primary" />
         </IconButton>
       </Badge>
     );
   } else {
     return (
-      <IconButton tooltip={strings.navigation.unread_notifications} onClick={() => history.push("/notifications")}>
+      <IconButton
+        data-test="navbar-notification-button"
+        tooltip={strings.navigation.unread_notifications}
+        onClick={() => history.push("/notifications")}
+      >
         <BubbleIcon color="primary" />
       </IconButton>
     );

--- a/frontend/src/pages/Navbar/ProjectSearch.js
+++ b/frontend/src/pages/Navbar/ProjectSearch.js
@@ -1,0 +1,73 @@
+import ButtonBase from "@material-ui/core/ButtonBase";
+import FormControl from "@material-ui/core/FormControl";
+import IconButton from "@material-ui/core/IconButton";
+import InputBase from "@material-ui/core/InputBase";
+import Paper from "@material-ui/core/Paper";
+import Tooltip from "@material-ui/core/Tooltip";
+import CancelIcon from "@material-ui/icons/Cancel";
+import SearchIcon from "@material-ui/icons/Search";
+import AwesomeDebouncePromise from "awesome-debounce-promise";
+import React from "react";
+
+const inputDebounced = asyncFunction => AwesomeDebouncePromise(asyncFunction, 500);
+
+const ProjectSearch = ({
+  searchBarDisplayed,
+  searchDisabled,
+  searchTerm,
+  storeSearchBarDisplayed,
+  storeSearchTerm
+}) => {
+  return (
+    <div style={{ display: "flex" }}>
+      <div>
+        {searchBarDisplayed && !searchDisabled ? (
+          <Paper style={{ padding: "2px", margin: "5px", width: "270px", display: "flex", flexDirection: "row" }}>
+            <form onSubmit={e => e.preventDefault()} style={{ width: "90%" }}>
+              <FormControl style={{ width: "97%", paddingLeft: "5px" }} data-test="project-search-field">
+                <InputBase
+                  onChange={event => inputDebounced(storeSearchTerm(event.target.value))}
+                  onKeyDown={e => {
+                    if (e.key === "Escape" || e.key === "Esc") {
+                      storeSearchTerm("");
+                      storeSearchBarDisplayed(false);
+                    }
+                  }}
+                  style={{ width: "100%" }}
+                  value={searchTerm}
+                  autoFocus={true}
+                />
+              </FormControl>
+            </form>
+            <ButtonBase
+              data-test="clear-project-search"
+              onClick={() => {
+                storeSearchBarDisplayed(false);
+                storeSearchTerm("");
+              }}
+            >
+              <CancelIcon color="action" />
+            </ButtonBase>
+          </Paper>
+        ) : null}
+      </div>
+      <div>
+        <Tooltip title="Quick search">
+          <IconButton
+            color="primary"
+            onClick={() => {
+              storeSearchTerm("");
+              storeSearchBarDisplayed(!searchBarDisplayed);
+            }}
+            disabled={searchDisabled}
+            data-test="toggle-project-search"
+          >
+            <SearchIcon />
+          </IconButton>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectSearch;

--- a/frontend/src/pages/Navbar/ProjectSearch.js
+++ b/frontend/src/pages/Navbar/ProjectSearch.js
@@ -6,10 +6,7 @@ import Paper from "@material-ui/core/Paper";
 import Tooltip from "@material-ui/core/Tooltip";
 import CancelIcon from "@material-ui/icons/Cancel";
 import SearchIcon from "@material-ui/icons/Search";
-import AwesomeDebouncePromise from "awesome-debounce-promise";
 import React from "react";
-
-const inputDebounced = asyncFunction => AwesomeDebouncePromise(asyncFunction, 500);
 
 const ProjectSearch = ({
   searchBarDisplayed,
@@ -26,7 +23,7 @@ const ProjectSearch = ({
             <form onSubmit={e => e.preventDefault()} style={{ width: "90%" }}>
               <FormControl style={{ width: "97%", paddingLeft: "5px" }} data-test="project-search-field">
                 <InputBase
-                  onChange={event => inputDebounced(storeSearchTerm(event.target.value))}
+                  onChange={event => storeSearchTerm(event.target.value)}
                   onKeyDown={e => {
                     if (e.key === "Escape" || e.key === "Esc") {
                       storeSearchTerm("");
@@ -52,18 +49,25 @@ const ProjectSearch = ({
         ) : null}
       </div>
       <div>
-        <Tooltip title="Quick search">
-          <IconButton
-            color="primary"
-            onClick={() => {
-              storeSearchTerm("");
-              storeSearchBarDisplayed(!searchBarDisplayed);
-            }}
-            disabled={searchDisabled}
-            data-test="toggle-project-search"
-          >
-            <SearchIcon />
-          </IconButton>
+        <Tooltip
+          title="Quick search"
+          disableHoverListener={searchDisabled}
+          disableFocusListener={searchDisabled}
+          disableTouchListener={searchDisabled}
+        >
+          <div>
+            <IconButton
+              color="primary"
+              onClick={() => {
+                storeSearchTerm("");
+                storeSearchBarDisplayed(!searchBarDisplayed);
+              }}
+              disabled={searchDisabled}
+              data-test="toggle-project-search"
+            >
+              <SearchIcon />
+            </IconButton>
+          </div>
         </Tooltip>
       </div>
     </div>

--- a/frontend/src/pages/Navbar/RightNavbarNavigation.js
+++ b/frontend/src/pages/Navbar/RightNavbarNavigation.js
@@ -1,8 +1,8 @@
+import Typography from "@material-ui/core/Typography";
 import React from "react";
 
-import Typography from "@material-ui/core/Typography";
-
 import NavbarIcons from "./NavbarIcons";
+import ProjectSearch from "./ProjectSearch";
 
 const styles = {
   container: {
@@ -17,13 +17,38 @@ const styles = {
   }
 };
 
-const RightNavbarNavigations = ({  peers, numberOfActivePeers, unreadNotificationCount, history, logout, organization }) => {
+const RightNavbarNavigations = ({
+  peers,
+  numberOfActivePeers,
+  unreadNotificationCount,
+  history,
+  logout,
+  organization,
+  storeSearchTerm,
+  searchTerm,
+  searchBarDisplayed,
+  storeSearchBarDisplayed
+}) => {
+  const searchDisabled = history.location.pathname !== "/projects";
   return (
     <div style={styles.container}>
+      <ProjectSearch
+        searchBarDisplayed={searchBarDisplayed}
+        searchTerm={searchTerm}
+        searchDisabled={searchDisabled}
+        storeSearchBarDisplayed={storeSearchBarDisplayed}
+        storeSearchTerm={storeSearchTerm}
+      />
       <Typography variant="button" color="primary" style={styles.organization}>
         {organization}
       </Typography>
-      <NavbarIcons  unreadNotificationCount={unreadNotificationCount} numberOfActivePeers={numberOfActivePeers} peers={peers} history={history} logout={logout} />
+      <NavbarIcons
+        unreadNotificationCount={unreadNotificationCount}
+        numberOfActivePeers={numberOfActivePeers}
+        peers={peers}
+        history={history}
+        logout={logout}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Navbar/SideNavCard.js
+++ b/frontend/src/pages/Navbar/SideNavCard.js
@@ -39,6 +39,7 @@ const SideNavCard = ({
       flexDirection: "column",
       overflowY: "auto"
     }}
+    data-test="side-navigation"
   >
     <div
       style={{
@@ -74,33 +75,33 @@ const SideNavCard = ({
     </div>
     <List>
       <Subheader>{strings.navigation.selections}</Subheader>
-      <ListItem button onClick={() => history.push("/")}>
+      <ListItem button onClick={() => history.push("/")} data-test="side-navigation-projects">
         <ListItemIcon>
           <ProjectIcon />
         </ListItemIcon>
         <ListItemText primary={strings.navigation.menu_item_projects} />
       </ListItem>
-      <ListItem button onClick={() => history.push("/notifications")}>
+      <ListItem button onClick={() => history.push("/notifications")} data-test="side-navigation-notifications">
         <ListItemIcon>
           <SocialNotificationIcon />
         </ListItemIcon>
         <ListItemText primary={strings.navigation.menu_item_notifications} />
       </ListItem>
-      <ListItem button onClick={() => history.push("/users")}>
+      <ListItem button onClick={() => history.push("/users")} data-test="side-navigation-users">
         <ListItemIcon>
           <UsersIcon />
         </ListItemIcon>
         <ListItemText primary={strings.navigation.menu_item_users} />
       </ListItem>
       {nodeDashboardEnabled ? (
-        <ListItem button onClick={() => history.push("/nodes")}>
+        <ListItem button onClick={() => history.push("/nodes")} data-test="side-navigation-nodes">
           <ListItemIcon>
             <NodesIcon />
           </ListItemIcon>
           <ListItemText primary={strings.nodesDashboard.nodes} />
         </ListItem>
       ) : null}
-      <ListItem button onClick={exportData}>
+      <ListItem button onClick={exportData} data-test="side-navigation-export">
         <ListItemIcon>
           <ExportIcon />
         </ListItemIcon>

--- a/frontend/src/pages/Navbar/actions.js
+++ b/frontend/src/pages/Navbar/actions.js
@@ -18,6 +18,9 @@ export const EXPORT_DATA = "EXPORT_DATA";
 export const EXPORT_DATA_SUCCESS = "EXPORT_DATA_SUCCESS";
 export const EXPORT_DATA_FAILED = "EXPORT_DATA_FAILED";
 
+export const SEARCH_TERM = "SEARCH_TERM";
+export const SEARCH_BAR_DISPLAYED = "SEARCH_BAR_DISPLAYED";
+
 export function toggleSidebar() {
   return {
     type: TOGGLE_SIDEBAR
@@ -64,5 +67,19 @@ export function fetchVersions() {
 export function exportData() {
   return {
     type: EXPORT_DATA
+  };
+}
+
+export function storeSearchTerm(searchTerm) {
+  return {
+    type: SEARCH_TERM,
+    searchTerm
+  };
+}
+
+export function storeSearchBarDisplayed(searchBarDisplayed) {
+  return {
+    type: SEARCH_BAR_DISPLAYED,
+    searchBarDisplayed
   };
 }

--- a/frontend/src/pages/Navbar/reducer.js
+++ b/frontend/src/pages/Navbar/reducer.js
@@ -5,7 +5,9 @@ import {
   FETCH_STREAM_NAMES_SUCCESS,
   SET_SELECTED_VIEW,
   FETCH_ACTIVE_PEERS_SUCCESS,
-  FETCH_VERSIONS_SUCCESS
+  FETCH_VERSIONS_SUCCESS,
+  SEARCH_TERM,
+  SEARCH_BAR_DISPLAYED
 } from "./actions";
 import { LOGOUT } from "../Login/actions";
 import { FETCH_ALL_PROJECT_DETAILS_SUCCESS } from "../SubProjects/actions";
@@ -20,7 +22,9 @@ const defaultState = fromJS({
   selectedSection: "",
   currentProject: " ",
   currentSubProject: " ",
-  versions: null
+  versions: null,
+  searchTerm: "",
+  searchBarDisplayed: false
 });
 
 export default function navbarReducer(state = defaultState, action) {
@@ -45,6 +49,10 @@ export default function navbarReducer(state = defaultState, action) {
       });
     case FETCH_VERSIONS_SUCCESS:
       return state.set("versions", action.versions);
+    case SEARCH_TERM:
+      return state.set("searchTerm", action.searchTerm);
+    case SEARCH_BAR_DISPLAYED:
+      return state.set("searchBarDisplayed", action.searchBarDisplayed);
     case LOGOUT:
       return defaultState;
     default:

--- a/frontend/src/pages/Overview/OverviewContainer.js
+++ b/frontend/src/pages/Overview/OverviewContainer.js
@@ -10,6 +10,8 @@ import {
   hideProjectAdditionalData
 } from "./actions";
 
+import { storeSearchBarDisplayed, storeSearchTerm } from "../Navbar/actions";
+
 import Overview from "./Overview";
 import globalStyles from "../../styles";
 import { toJS } from "../../helper";
@@ -51,7 +53,11 @@ const mapDispatchToProps = dispatch => {
     fetchAllProjects: showLoading => dispatch(fetchAllProjects(showLoading)),
     showProjectPermissions: id => dispatch(showProjectPermissions(id)),
     showProjectAdditionalData: id => dispatch(showProjectAdditionalData(id)),
-    hideProjectAdditionalData: () => dispatch(hideProjectAdditionalData())
+    hideProjectAdditionalData: () => dispatch(hideProjectAdditionalData()),
+    closeSearchBar: () => {
+      dispatch(storeSearchTerm(""));
+      dispatch(storeSearchBarDisplayed(false));
+    }
   };
 };
 
@@ -62,7 +68,8 @@ const mapStateToProps = state => {
     loggedInUser: state.getIn(["login", "loggedInUser"]),
     roles: state.getIn(["login", "roles"]),
     idForInfo: state.getIn(["overview", "idForInfo"]),
-    isProjectAdditionalDataShown: state.getIn(["overview", "isProjectAdditionalDataShown"])
+    isProjectAdditionalDataShown: state.getIn(["overview", "isProjectAdditionalDataShown"]),
+    searchTerm: state.getIn(["navbar", "searchTerm"])
   };
 };
 

--- a/frontend/src/pages/Overview/OverviewTable.js
+++ b/frontend/src/pages/Overview/OverviewTable.js
@@ -94,9 +94,19 @@ const getTableEntries = ({
   classes,
   showEditDialog,
   showProjectPermissions,
-  showProjectAdditionalData
+  showProjectAdditionalData,
+  searchTerm,
+  closeSearchBar
 }) => {
-  return projects.map(({ data, allowedIntents }, index) => {
+  const filteredProjects = projects.filter(
+    project =>
+      project.data.displayName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      project.data.status.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      project.data.description.toLowerCase().includes(searchTerm.toLowerCase())
+    // TODO: If tags are added, search them as well
+    // project.data.tags.some(tag => tag.toLowerCase().includes(searchTerm.toLowerCase()))
+  );
+  return filteredProjects.map(({ data, allowedIntents }, index) => {
     const {
       displayName,
       id,
@@ -133,7 +143,10 @@ const getTableEntries = ({
                 className={classes.button}
                 disabled={!canViewProjectDetails(allowedIntents)}
                 color="primary"
-                onClick={() => history.push("/projects/" + id)}
+                onClick={() => {
+                  closeSearchBar();
+                  history.push("/projects/" + id);
+                }}
                 data-test={`project-view-button-${index}`}
               >
                 <ViewIcon />


### PR DESCRIPTION
# Changes

A new feature is added which lets the user filter the projects in the overview page. 

The button "Quick Search" can be used to toggle the search bar. The term entered in the search bar is used for filtering the projects. When the user navigates to the project details page of a project or clicks on the breadcrumb menu "Main", the search field is cleared and the search bar is no longer displayed.

Closes #347  

# How to test

Go to the overview page, click the "Quick Search" button and enter a term to filter the projects in the overview page.