### PR TITLE
Prohibit root from creating projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - A new user called 'root' cannot be added [#369](https://github.com/openkfw/TruBudget/issues/369)
 - If a user changes his/her password, the new password has to follow security guidelines [#370](https://github.com/openkfw/TruBudget/issues/370)
+- Allow user 'root' to change the passwords of all users[#366](https://github.com/openkfw/TruBudget/issues/366)
+- Disallow root to create projects [#375](https://github.com/openkfw/TruBudget/issues/375)
+- Allow user 'root' to change the passwords of all users[#366](https://github.com/openkfw/TruBudget/issues/366)
 
 <!-- ### Deprecated -->
 

--- a/api/src/service/domain/workflow/project_create.ts
+++ b/api/src/service/domain/workflow/project_create.ts
@@ -106,6 +106,13 @@ export async function createProject(
         errors: [new NotAuthorized({ ctx, userId: creatingUser.id, intent, target: permissions })],
       };
     }
+  } else {
+    return {
+      newEvents: [],
+      errors: [
+        new PreconditionError(ctx, createEvent, "user 'root' is not allowed to create projects"),
+      ],
+    };
   }
 
   // Check that the event is valid:

--- a/e2e-test/cypress/integration/change_user_password_spec.js
+++ b/e2e-test/cypress/integration/change_user_password_spec.js
@@ -130,7 +130,7 @@ describe("Users/Groups Dashboard", function() {
 
   it("Root can edit all user passwords", function() {
     // Log in as root
-    cy.login("root", "root-user");
+    cy.login("root", "root-secret");
     cy.visit("/users");
 
     // Check if the button is indeed visible
@@ -140,7 +140,6 @@ describe("Users/Groups Dashboard", function() {
     cy.get("[data-test=edit-user-jxavier]").should("be.visible");
     cy.get("[data-test=edit-user-mstein]").should("be.visible");
     cy.get("[data-test=edit-user-pkleffmann]").should("be.visible");
-    cy.get("[data-test=edit-user-testuser]").should("be.visible");
     cy.get("[data-test=edit-user-thouse]").should("be.visible");
   });
 });

--- a/e2e-test/cypress/integration/change_user_password_spec.js
+++ b/e2e-test/cypress/integration/change_user_password_spec.js
@@ -127,4 +127,20 @@ describe("Users/Groups Dashboard", function() {
       .should("be.visible")
       .contains("Password successfully changed");
   });
+
+  it("Root can edit all user passwords", function() {
+    // Log in as root
+    cy.login("root", "root-user");
+    cy.visit("/users");
+
+    // Check if the button is indeed visible
+    cy.get("[data-test=edit-user-auditUser]").should("be.visible");
+    cy.get("[data-test=edit-user-dviolin]").should("be.visible");
+    cy.get("[data-test=edit-user-jdoe]").should("be.visible");
+    cy.get("[data-test=edit-user-jxavier]").should("be.visible");
+    cy.get("[data-test=edit-user-mstein]").should("be.visible");
+    cy.get("[data-test=edit-user-pkleffmann]").should("be.visible");
+    cy.get("[data-test=edit-user-testuser]").should("be.visible");
+    cy.get("[data-test=edit-user-thouse]").should("be.visible");
+  });
 });

--- a/e2e-test/cypress/integration/overview_spec.js
+++ b/e2e-test/cypress/integration/overview_spec.js
@@ -38,4 +38,11 @@ describe("Overview Page", function() {
     cy.get("[data-test=project-creation]").should("be.visible");
     cy.get("[data-test=project-creation] button").should("be.visible");
   });
+
+  it("Don't show project creation for 'root' user", function() {
+    cy.login("root", "root-secret");
+    cy.visit(`/projects`);
+    cy.get("[data-test=project-creation]").should("be.visible");
+    cy.get("[data-test=project-creation] button").should("be.disabled");
+  });
 });

--- a/e2e-test/cypress/integration/overview_spec.js
+++ b/e2e-test/cypress/integration/overview_spec.js
@@ -39,7 +39,7 @@ describe("Overview Page", function() {
     cy.get("[data-test=project-creation] button").should("be.visible");
   });
 
-  it("Don't show project creation for 'root' user", function() {
+  it("Disable project creation for 'root' user", function() {
     cy.login("root", "root-secret");
     cy.visit(`/projects`);
     cy.get("[data-test=project-creation]").should("be.visible");

--- a/frontend/src/pages/Navbar/Navbar.js
+++ b/frontend/src/pages/Navbar/Navbar.js
@@ -43,10 +43,8 @@ const Navbar = ({
   storeSearchTerm,
   searchTerm,
   storeSearchBarDisplayed,
-  searchBarDisplayed,
-  setIsRoot
+  searchBarDisplayed
 }) => {
-  setIsRoot(userId === "root");
   return (
     <div>
       <AppBar classes={classes} position="absolute">

--- a/frontend/src/pages/Navbar/Navbar.js
+++ b/frontend/src/pages/Navbar/Navbar.js
@@ -43,8 +43,10 @@ const Navbar = ({
   storeSearchTerm,
   searchTerm,
   storeSearchBarDisplayed,
-  searchBarDisplayed
+  searchBarDisplayed,
+  setIsRoot
 }) => {
+  setIsRoot(userId === "root");
   return (
     <div>
       <AppBar classes={classes} position="absolute">

--- a/frontend/src/pages/Navbar/NavbarContainer.js
+++ b/frontend/src/pages/Navbar/NavbarContainer.js
@@ -10,7 +10,8 @@ import {
   fetchVersions,
   exportData,
   storeSearchTerm,
-  storeSearchBarDisplayed
+  storeSearchBarDisplayed,
+  setIsRoot
 } from "./actions";
 import { logout } from "../Login/actions";
 
@@ -49,7 +50,8 @@ const mapDispatchToProps = {
   fetchVersions,
   exportData,
   storeSearchTerm,
-  storeSearchBarDisplayed
+  storeSearchBarDisplayed,
+  setIsRoot
 };
 
 const mapStateToProps = state => {
@@ -75,7 +77,8 @@ const mapStateToProps = state => {
     unreadNotificationCount: state.getIn(["notifications", "unreadNotificationCount"]),
     latestFlyInId: state.getIn(["notifications", "latestFlyInId"]),
     searchTerm: state.getIn(["navbar", "searchTerm"]),
-    searchBarDisplayed: state.getIn(["navbar", "searchBarDisplayed"])
+    searchBarDisplayed: state.getIn(["navbar", "searchBarDisplayed"]),
+    isRoot: state.getIn(["login", "isRoot"])
   };
 };
 

--- a/frontend/src/pages/Navbar/NavbarContainer.js
+++ b/frontend/src/pages/Navbar/NavbarContainer.js
@@ -24,6 +24,9 @@ class NavbarContainer extends Component {
   componentDidMount() {
     this.props.fetchActivePeers();
     this.props.fetchVersions();
+    if (this.props.userId === "root") {
+      this.props.setIsRoot(this.props.userId === "root");
+    }
   }
 
   render() {

--- a/frontend/src/pages/Navbar/actions.js
+++ b/frontend/src/pages/Navbar/actions.js
@@ -21,6 +21,8 @@ export const EXPORT_DATA_FAILED = "EXPORT_DATA_FAILED";
 export const SEARCH_TERM = "SEARCH_TERM";
 export const SEARCH_BAR_DISPLAYED = "SEARCH_BAR_DISPLAYED";
 
+export const SET_IS_ROOT = "SET_IS_ROOT";
+
 export function toggleSidebar() {
   return {
     type: TOGGLE_SIDEBAR
@@ -81,5 +83,12 @@ export function storeSearchBarDisplayed(searchBarDisplayed) {
   return {
     type: SEARCH_BAR_DISPLAYED,
     searchBarDisplayed
+  };
+}
+
+export function setIsRoot(isRoot) {
+  return {
+    type: SET_IS_ROOT,
+    isRoot
   };
 }

--- a/frontend/src/pages/Navbar/reducer.js
+++ b/frontend/src/pages/Navbar/reducer.js
@@ -7,7 +7,8 @@ import {
   FETCH_ACTIVE_PEERS_SUCCESS,
   FETCH_VERSIONS_SUCCESS,
   SEARCH_TERM,
-  SEARCH_BAR_DISPLAYED
+  SEARCH_BAR_DISPLAYED,
+  SET_IS_ROOT
 } from "./actions";
 import { LOGOUT } from "../Login/actions";
 import { FETCH_ALL_PROJECT_DETAILS_SUCCESS } from "../SubProjects/actions";
@@ -24,7 +25,8 @@ const defaultState = fromJS({
   currentSubProject: " ",
   versions: null,
   searchTerm: "",
-  searchBarDisplayed: false
+  searchBarDisplayed: false,
+  isRoot: false
 });
 
 export default function navbarReducer(state = defaultState, action) {
@@ -55,6 +57,8 @@ export default function navbarReducer(state = defaultState, action) {
       return state.set("searchBarDisplayed", action.searchBarDisplayed);
     case LOGOUT:
       return defaultState;
+    case SET_IS_ROOT:
+      return state.set("isRoot", action.isRoot);
     default:
       return state;
   }

--- a/frontend/src/pages/Overview/OverviewContainer.js
+++ b/frontend/src/pages/Overview/OverviewContainer.js
@@ -69,7 +69,8 @@ const mapStateToProps = state => {
     roles: state.getIn(["login", "roles"]),
     idForInfo: state.getIn(["overview", "idForInfo"]),
     isProjectAdditionalDataShown: state.getIn(["overview", "isProjectAdditionalDataShown"]),
-    searchTerm: state.getIn(["navbar", "searchTerm"])
+    searchTerm: state.getIn(["navbar", "searchTerm"]),
+    isRoot: state.getIn(["navbar", "isRoot"])
   };
 };
 

--- a/frontend/src/pages/Overview/OverviewTable.js
+++ b/frontend/src/pages/Overview/OverviewTable.js
@@ -199,7 +199,7 @@ const OverviewTable = props => {
                 <Fab
                   className={props.classes.button}
                   aria-label="create"
-                  disabled={!canCreateProject(props.allowedIntents)}
+                  disabled={!canCreateProject(props.allowedIntents) || props.isRoot}
                   onClick={() => props.showCreationDialog()}
                   color="primary"
                   data-test="create-project-button"

--- a/frontend/src/pages/Users/UserManagementContainer.js
+++ b/frontend/src/pages/Users/UserManagementContainer.js
@@ -56,7 +56,8 @@ const mapStateToProps = state => {
     groupToAdd: state.getIn(["users", "groupToAdd"]),
     editMode: state.getIn(["users", "editMode"]),
     editDialogShown: state.getIn(["users", "editDialogShown"]),
-    editId: state.getIn(["users", "editId"])
+    editId: state.getIn(["users", "editId"]),
+    isRoot: state.getIn(["navbar", "isRoot"])
   };
 };
 

--- a/frontend/src/pages/Users/UsersTable.js
+++ b/frontend/src/pages/Users/UsersTable.js
@@ -22,7 +22,15 @@ const sortUsers = users => {
   return _sortBy(users, user => user.organization && user.id);
 };
 
-const UsersTable = ({ classes, users, permissionIconDisplayed, showDashboardDialog, showPasswordDialog, userId }) => {
+const UsersTable = ({
+  classes,
+  users,
+  permissionIconDisplayed,
+  showDashboardDialog,
+  showPasswordDialog,
+  userId,
+  isRoot
+}) => {
   const sortedUsers = sortUsers(users.filter(u => u.isGroup !== true));
 
   return (
@@ -62,8 +70,8 @@ const UsersTable = ({ classes, users, permissionIconDisplayed, showDashboardDial
                       data-test={`edit-user-permissions-${user.id}`}
                     />
                     <ActionButton
-                      notVisible={!canEditPassword}
                       onClick={() => showPasswordDialog(user.id)}
+                      notVisible={!canEditPassword && !isRoot}
                       title={strings.common.edit}
                       icon={<EditIcon />}
                       data-test={`edit-user-${user.id}`}


### PR DESCRIPTION
# Changes

* ui: Disable create-project-button  for 'root' user
* ui: Enable edit-user-{user id}-button of all users if 'root' is logged in, thus allow 'root' to change all users passwords
* api: Throw preconditionError if user 'root' tries to create a project

# How to test

Unit tests for creating projects an editing passwords have been added
Use postman to try and create a project as 'root' user

Closes #366
Closes #379 