### PR TITLE
ui: Improve subproject details layout and display of display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Disallow root to create subprojects [#378](https://github.com/openkfw/TruBudget/issues/378)
 - Allow user 'root' to change the passwords of all users [#366](https://github.com/openkfw/TruBudget/issues/366)
 - Rework the editing of project/subproject/workflowitem/global permissions [#245](https://github.com/openkfw/TruBudget/issues/245)
-- Improve layout and handling of long names [#274](https://github.com/openkfw/TruBudget/issues/274)
+- Improve project/subproject details-layout and handling of long names [#274](https://github.com/openkfw/TruBudget/issues/274)
 
 <!-- ### Deprecated -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Disallow root to create subprojects [#378](https://github.com/openkfw/TruBudget/issues/378)
 - Allow user 'root' to change the passwords of all users [#366](https://github.com/openkfw/TruBudget/issues/366)
 - Rework the editing of project/subproject/workflowitem/global permissions [#245](https://github.com/openkfw/TruBudget/issues/245)
+- Improve layout and handling of long names [#274](https://github.com/openkfw/TruBudget/issues/274)
 
 <!-- ### Deprecated -->
 

--- a/e2e-test/cypress/integration/subproject_displayname_spec.js
+++ b/e2e-test/cypress/integration/subproject_displayname_spec.js
@@ -1,0 +1,28 @@
+const veryLongDisplayName = "Thisisaverylongdisplaynamethatcausesthetextboxtooverflowandwillbeusedfortestingthedisplay";
+describe("Subproject display name", function() {
+  beforeEach(function() {
+    cy.login();
+    cy.visit(`/projects`);
+  });
+
+  it("If the subproject name is very long, the table is still displayed correctly", function() {
+    // Create subproject with very long display name
+    cy.get("[data-test=project-view-button-0]").click();
+    cy.get("[data-test=subproject-create-button]").click();
+    cy.get("[data-test=nameinput] input").type(veryLongDisplayName);
+    cy.get("[data-test=dropdown-sp-dialog-currencies]").click();
+    cy.get("[data-value=EUR]").click();
+    cy.get("[data-test=submit]").click();
+
+    // Check if projected budget, status and action buttons are still visible
+    cy.get("[data-test*=subproject-edit-button]")
+      .last()
+      .should("be.visible");
+    cy.get("[data-test*=spp-button]")
+      .last()
+      .should("be.visible");
+    cy.get("[data-test*=subproject-view-details]")
+      .last()
+      .should("be.visible");
+  });
+});

--- a/frontend/src/helper.js
+++ b/frontend/src/helper.js
@@ -132,3 +132,11 @@ export const preselectCurrency = (parentCurrency, setCurrency) => {
 export const formattedTag = tag => {
   return tag.toLowerCase().replace(/[\s#]/g, "");
 };
+
+export const shortenedDisplayName = displayName => {
+  const maxLength = 50;
+  if (displayName.length > maxLength) {
+    return displayName.slice(0, maxLength) + "...";
+  }
+  return displayName;
+};

--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -25,6 +25,7 @@ const en = {
     completion: "Completion",
     create: "Create",
     created: "Created",
+    currency: "Currency",
     disbursed_budget: "Disbursed Budget",
     disbursement: "Projected",
     disconnected: "Offline",
@@ -135,7 +136,7 @@ const en = {
     project_budget_authority_role_description: "The authority enabled to modify the budget line of the project",
     project_close_info: "At least one subproject item has not been closed yet.",
     project_comment: "Comment",
-    project_currency: "Currency",
+    project_currency: "Project currency",
     project_details: "Details",
     project_disbursement_authority_role: "Select disbursement authority role",
     project_disbursement_authority_role_description: "The authorities enabled to approve financial transactions",
@@ -152,21 +153,21 @@ const en = {
   },
 
   subproject: {
-    subproject_add_title: "Add new Subproject",
-    subproject_assigned_organization: "Assigned Organization",
-    subproject_budget_amount: "Sub-project  budget amount",
+    subproject_add_title: "Add new subproject",
+    subproject_assigned_organization: "Assigned organization",
+    subproject_budget_amount: "Subproject  budget amount",
     subproject_budget_amount_description: "e.g.",
     subproject_close_info: "At least one workflow item has not been closed yet",
     subproject_close_not_allowed: "You are not allowed to close the subproject",
-    subproject_comment: "Sub-project Comment",
+    subproject_comment: "Subproject comment",
     subproject_completion_string: "{0} of {1} done",
-    subproject_currency: "Sub-project Currency",
-    subproject_edit_title: "Edit Subproject",
+    subproject_currency: "Subproject currency",
+    subproject_edit_title: "Edit subproject",
     subproject_permissions_title: "Set permissions for subproject",
-    subproject_preview: "Subproject Preview",
+    subproject_preview: "Subproject preview",
     subproject_select_button: "Select",
-    subproject_title: "Sub-Project title",
-    subproject_title_description: "Name of the sub-project"
+    subproject_title: "Subproject title",
+    subproject_title_description: "Name of the subproject"
   },
 
   workflow: {
@@ -214,7 +215,7 @@ const en = {
     workflow_type_workflow: "Workflow",
     workflow_type: "Type",
     workflow_upload_document: "Upload",
-    workflowitem_details: "Workflowitem item details",
+    workflowitem_details: "Workflowitem details",
     workflowitem_details_documents: "Documents",
     workflowitem_details_history: "History",
     workflowitem_details_overview: "Overview"

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -25,6 +25,7 @@ const fr = {
     completion: "Achèvement",
     create: "Créer",
     created: "Créé",
+    currency: "Devise",
     disbursed_budget: "Budget décaissé",
     disbursement: "Décaissements prévus",
     disconnected: "Déconnecté",

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -25,6 +25,7 @@ const de = {
     completion: "German: Completion",
     create: "German: Create",
     created: "Created",
+    currency: "Währung",
     disbursed_budget: "Disbursed Budget",
     disbursement: "Disbursement",
     disconnected: "Offline",

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -25,6 +25,7 @@ const pt = {
     completion: "Conclusão",
     create: "Criar",
     created: "Data de criação",
+    currency: "Moeda",
     disbursed_budget: "Desembolsado",
     disbursement: "Projetado",
     disconnected: "Desligada",

--- a/frontend/src/pages/Common/Budget.js
+++ b/frontend/src/pages/Common/Budget.js
@@ -210,7 +210,7 @@ export default class Budget extends React.Component {
                   <DropDown
                     style={styles.dropdown}
                     value={this.state.currency}
-                    floatingLabel={strings.project.project_currency}
+                    floatingLabel={strings.common.currency}
                     onChange={e => this.setCurrency(e)}
                     id="currencies"
                     disabled={

--- a/frontend/src/pages/Dashboard/DashboardContainer.js
+++ b/frontend/src/pages/Dashboard/DashboardContainer.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React, { Component } from "react";
+import { connect } from "react-redux";
 
-import { fetchNodeInformation } from './actions';
-import Dashboard from './Dashboard';
-import globalStyles from '../../styles.js';
+import { fetchNodeInformation } from "./actions";
+import Dashboard from "./Dashboard";
+import globalStyles from "../../styles.js";
 
 class DashboardContainer extends Component {
   componentWillMount() {
@@ -14,20 +14,20 @@ class DashboardContainer extends Component {
       <div style={globalStyles.innerContainer}>
         <Dashboard {...this.props} />
       </div>
-    )
+    );
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     fetchNodeInformation: () => dispatch(fetchNodeInformation())
   };
-}
+};
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
-    nodeInformation: state.getIn(['dashboard', 'nodeInformation']).toJS()
-  }
-}
+    nodeInformation: state.getIn(["dashboard", "nodeInformation"]).toJS()
+  };
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(DashboardContainer);

--- a/frontend/src/pages/Notifications/NotificationsSnackbar.js
+++ b/frontend/src/pages/Notifications/NotificationsSnackbar.js
@@ -30,7 +30,8 @@ const styles = theme => ({
   },
   message: {
     display: "flex",
-    alignItems: "center"
+    alignItems: "center",
+    maxWidth: "100%"
   }
 });
 

--- a/frontend/src/pages/Overview/ProjectDialog.js
+++ b/frontend/src/pages/Overview/ProjectDialog.js
@@ -1,7 +1,7 @@
 import _isEmpty from "lodash/isEmpty";
 import React from "react";
 
-import { compareObjects, fromAmountString } from "../../helper";
+import { compareObjects, fromAmountString, shortenedDisplayName } from "../../helper";
 import strings from "../../localizeStrings";
 import CreationDialog from "../Common/CreationDialog";
 import ProjectDialogContent from "./ProjectDialogContent";
@@ -17,7 +17,7 @@ const handleCreate = props => {
     tags
   );
   onDialogCancel();
-  storeSnackbarMessage(strings.common.added + " " + strings.common.project + " " + displayName);
+  storeSnackbarMessage(strings.common.added + " " + strings.common.project + " " + shortenedDisplayName(displayName));
 };
 
 const handleEdit = props => {
@@ -39,7 +39,9 @@ const handleEdit = props => {
       },
       changes.deletedProjectedBudgets
     );
-    storeSnackbarMessage(strings.common.edited + " " + strings.common.project + " " + projectToAdd.displayName);
+    storeSnackbarMessage(
+      strings.common.edited + " " + strings.common.project + " " + shortenedDisplayName(projectToAdd.displayName)
+    );
   }
   onDialogCancel();
 };

--- a/frontend/src/pages/SubProjects/ProjectDetails.js
+++ b/frontend/src/pages/SubProjects/ProjectDetails.js
@@ -53,7 +53,8 @@ const styles = {
     flexDirection: "column",
     alignItems: "center",
     paddingTop: "18px",
-    width: "31%"
+    width: "31%",
+    overflowWrap: "break-word"
   },
   projectAssignee: {
     display: "flex",

--- a/frontend/src/pages/SubProjects/ProjectDetails.js
+++ b/frontend/src/pages/SubProjects/ProjectDetails.js
@@ -129,7 +129,7 @@ const ProjectDetails = props => {
         </List>
         <div style={styles.projectedBudget}>
           <Typography variant="body1">{strings.common.projected_budget}</Typography>
-          <Table>
+          <Table padding="none">
             <TableHead>
               <TableRow>
                 <TableCell>{strings.common.organization}</TableCell>

--- a/frontend/src/pages/SubProjects/SubProjectTable.js
+++ b/frontend/src/pages/SubProjects/SubProjectTable.js
@@ -22,8 +22,29 @@ import { canEditSubProject, canViewSubProjectDetails, canViewSubProjectPermissio
 import ActionButton from "../Common/ActionButton";
 
 const styles = {
+  subprojectTable: {
+    tableLayout: "fixed"
+  },
   tableText: {
     fontSize: "14px"
+  },
+  displayName: {
+    fontSize: "14px",
+    width: "40%",
+    overflow: "hidden",
+    textOverflow: "ellipsis"
+  },
+  projectdBudget: {
+    fontSize: "14px",
+    width: "20%"
+  },
+  status: {
+    fontSize: "14px",
+    width: "20%"
+  },
+  actions: {
+    fontSize: "14px",
+    width: "20%"
   },
   buttonContainer: {
     display: "flex",
@@ -101,10 +122,10 @@ const getTableEntries = (
       const amountString = displaySubprojectBudget(projectedBudgets);
       return (
         <TableRow key={index}>
-          <TableCell className={classes.tableText}>{displayName}</TableCell>
-          <TableCell className={classes.tableText}>{amountString}</TableCell>
-          <TableCell className={classes.tableText}>{statusMapping(status)}</TableCell>
-          <TableCell>
+          <TableCell className={classes.displayName}>{displayName}</TableCell>
+          <TableCell className={classes.projectdBudget}>{amountString}</TableCell>
+          <TableCell className={classes.status}>{statusMapping(status)}</TableCell>
+          <TableCell className={classes.actions}>
             <div className={classes.buttonContainer}>
               <div className={classes.button}>
                 <ActionButton
@@ -176,13 +197,13 @@ const SubProjectTable = ({
   return (
     <Card>
       <CardHeader title={strings.common.subprojects} />
-      <Table data-test="ssp-table">
+      <Table data-test="ssp-table" className={classes.subprojectTable}>
         <TableHead>
           <TableRow>
-            <TableCell className={classes.tableText}>{strings.common.subproject}</TableCell>
-            <TableCell className={classes.tableText}>{strings.common.projected_budget}</TableCell>
-            <TableCell className={classes.tableText}>{strings.common.status}</TableCell>
-            <TableCell className={classes.tableText}> </TableCell>
+            <TableCell className={classes.displayName}>{strings.common.subproject}</TableCell>
+            <TableCell className={classes.projectdBudget}>{strings.common.projected_budget}</TableCell>
+            <TableCell className={classes.status}>{strings.common.status}</TableCell>
+            <TableCell className={classes.actions}> </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>{tableEntries}</TableBody>

--- a/frontend/src/pages/SubProjects/SubprojectDialog.js
+++ b/frontend/src/pages/SubProjects/SubprojectDialog.js
@@ -5,7 +5,7 @@ import _isEmpty from "lodash/isEmpty";
 import CreationDialog from "../Common/CreationDialog";
 import strings from "../../localizeStrings";
 import SubprojectDialogContent from "./SubprojectDialogContent";
-import { compareObjects, fromAmountString } from "../../helper";
+import { compareObjects, fromAmountString, shortenedDisplayName } from "../../helper";
 
 const handleCreate = props => {
   const { createSubProject, onDialogCancel, subprojectToAdd, location, storeSnackbarMessage } = props;
@@ -18,7 +18,9 @@ const handleCreate = props => {
     projectedBudgets.map(b => ({ ...b, value: fromAmountString(b.value).toString(10) }))
   );
   onDialogCancel();
-  storeSnackbarMessage(strings.common.added + " " + strings.common.subproject + " " + displayName);
+  storeSnackbarMessage(
+    strings.common.added + " " + strings.common.subproject + " " + shortenedDisplayName(displayName)
+  );
 };
 
 const handleEdit = props => {
@@ -36,7 +38,9 @@ const handleEdit = props => {
       },
       changes.deletedProjectedBudgets
     );
-    storeSnackbarMessage(strings.common.edited + " " + strings.common.subproject + " " + subprojectToAdd.displayName);
+    storeSnackbarMessage(
+      strings.common.edited + " " + strings.common.subproject + " " + shortenedDisplayName(subprojectToAdd.displayName)
+    );
   }
 
   onDialogCancel();
@@ -67,10 +71,7 @@ const SubprojectDialog = props => {
     {
       title: strings.project.project_details,
       content: <SubprojectDialogContent {...props} />,
-      nextDisabled:
-        _isEmpty(subprojectToAdd.displayName) ||
-        _isEmpty(subprojectToAdd.currency) ||
-        _isEmpty(changes)
+      nextDisabled: _isEmpty(subprojectToAdd.displayName) || _isEmpty(subprojectToAdd.currency) || _isEmpty(changes)
     }
   ];
   return (

--- a/frontend/src/pages/Workflows/SubProjectDetails.js
+++ b/frontend/src/pages/Workflows/SubProjectDetails.js
@@ -130,7 +130,7 @@ const SubProjectDetails = ({
         </List>
         <div style={styles.projectedBudget}>
           <Typography variant="body1">{strings.common.projected_budget}</Typography>
-          <Table>
+          <Table padding="none">
             <TableHead>
               <TableRow>
                 <TableCell>{strings.common.organization}</TableCell>

--- a/frontend/src/pages/Workflows/SubProjectDetails.js
+++ b/frontend/src/pages/Workflows/SubProjectDetails.js
@@ -33,7 +33,8 @@ const styles = {
     flexDirection: "row",
     width: "100%",
     marginBottom: "24px",
-    justifyContent: "space-between"
+    justifyContent: "space-between",
+    alignItems: "center"
   },
   card: {
     width: "100%",
@@ -44,7 +45,23 @@ const styles = {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    paddingTop: "18px"
+    paddingTop: "18px",
+    width: "32%"
+  },
+  subprojectDetails: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    paddingTop: "18px",
+    width: "31%",
+    overflowWrap: "break-word"
+  },
+  subprojectAssignee: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    paddingTop: "18px",
+    width: "31%"
   },
   analytics: {
     padding: "12px 0 "
@@ -93,7 +110,7 @@ const SubProjectDetails = ({
   return (
     <div style={styles.container}>
       <Card style={styles.card}>
-        <List>
+        <List style={styles.subprojectDetails}>
           <ListItem data-test="subproject-details-displayname">
             {displayName ? <Avatar>{displayName[0]}</Avatar> : null}
             <ListItemText primary={displayName} secondary={description} />
@@ -138,7 +155,7 @@ const SubProjectDetails = ({
             </Button>
           </div>
         </div>
-        <List>
+        <List style={styles.subprojectAssignee}>
           <ListItem>
             <Avatar>{statusIcon}</Avatar>
             <ListItemText primary={mappedStatus} secondary={strings.common.status} />

--- a/frontend/src/pages/Workflows/WorkflowDialog.js
+++ b/frontend/src/pages/Workflows/WorkflowDialog.js
@@ -8,7 +8,7 @@ import strings from "../../localizeStrings";
 import WorkflowDialogAmount from "./WorkflowDialogAmount";
 import DocumentUpload from "../Documents/DocumentUpload";
 import Identifier from "../Common/Identifier";
-import { compareObjects, fromAmountString } from "../../helper";
+import { compareObjects, fromAmountString, shortenedDisplayName } from "../../helper";
 import _isEmpty from "lodash/isEmpty";
 
 const styles = {
@@ -29,7 +29,9 @@ const handleCreate = props => {
     status,
     documents
   );
-  storeSnackbarMessage(strings.common.created + " " + strings.common.workflowItem + " " + displayName);
+  storeSnackbarMessage(
+    strings.common.created + " " + strings.common.workflowItem + " " + shortenedDisplayName(displayName)
+  );
   onDialogCancel();
 };
 
@@ -57,7 +59,9 @@ const handleEdit = props => {
     }
     editWorkflowItem(projectId, subprojectId, workflowToAdd.id, changes);
   }
-  storeSnackbarMessage(strings.common.edited + " " + strings.common.workflowItem + " " + workflowToAdd.displayName);
+  storeSnackbarMessage(
+    strings.common.edited + " " + strings.common.workflowItem + " " + shortenedDisplayName(workflowToAdd.displayName)
+  );
   onDialogCancel();
 };
 

--- a/frontend/src/pages/Workflows/WorkflowDialogAmount.js
+++ b/frontend/src/pages/Workflows/WorkflowDialogAmount.js
@@ -112,7 +112,7 @@ class WorkflowDialogAmount extends Component {
       >
         <DropwDown
           style={{ minWidth: 160 }}
-          floatingLabel={strings.project.project_currency}
+          floatingLabel={strings.common.currency}
           value={workflowCurrency}
           onChange={value => {
             if (value === this.props.subProjectCurrency) {


### PR DESCRIPTION
# Changes
* Improve layout of subproject details page by setting each section on
the top to a width of about 32%
* Improve layout of subproject table to include overflow ellipses for
long subproject display names
* Introduce a word wrap for long display names on the project and
subproject details page
* Shorten the project, subproject and workflow item display names for
the snackbar messages
* Add an e2e test which checks that the action buttons are available on
the subproject table even for long display names
* Adapt the projected budget table on project/subproject details page to avoid an
overflow into the next section
* Rename "Workflowitem item details" to "Workflowitem details"

Closes #274 
Closes #233 