### PR TITLE
api: Create domain layer for project.intent.listPermissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- The api endpoint "project.intent.listPermissions" checks for the right permission [#393](https://github.com/openkfw/TruBudget/issues/393)
 
 <!-- ### Security -->
 

--- a/api/src/service/domain/workflow/project_permissions_list.spec.ts
+++ b/api/src/service/domain/workflow/project_permissions_list.spec.ts
@@ -1,0 +1,52 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import * as Project from "./project";
+import { getProjectPermissions } from "./project_permissions_list";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const bob: ServiceUser = { id: "bob", groups: [] };
+const projectId = "unitTestId";
+const permissions: Permissions = {
+  "project.intent.listPermissions": ["bob"],
+};
+const baseProject: Project.Project = {
+  id: projectId,
+  createdAt: new Date().toString(),
+  status: "open",
+  displayName: "unitTestName",
+  description: "",
+  projectedBudgets: [],
+  permissions,
+  log: [],
+  additionalData: {},
+  tags: [],
+};
+
+const repository = returnedProject => {
+  return { getProject: async () => returnedProject };
+};
+
+describe("List project permissions: authorization", () => {
+  it("With the 'project.intent.listPermissions' permission, the user can list project permissions", async () => {
+    const result = await getProjectPermissions(ctx, bob, projectId, repository(baseProject));
+
+    assert.equal(Result.unwrap(result), permissions);
+  });
+  it("Without the 'project.intent.listPermissions' permission, the user cannot list project permissions", async () => {
+    const projectWithoutPermissions = { ...baseProject, permissions: {} };
+
+    const result = await getProjectPermissions(
+      ctx,
+      bob,
+      projectId,
+      repository(projectWithoutPermissions),
+    );
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+});

--- a/api/src/service/domain/workflow/project_permissions_list.ts
+++ b/api/src/service/domain/workflow/project_permissions_list.ts
@@ -1,0 +1,34 @@
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import * as Project from "./project";
+
+interface Repository {
+  getProject(projectId: Project.Id): Promise<Result.Type<Project.Project>>;
+}
+
+export async function getProjectPermissions(
+  ctx: Ctx,
+  user: ServiceUser,
+  projectId: Project.Id,
+  repository: Repository,
+): Promise<Result.Type<Permissions>> {
+  const projectResult = await repository.getProject(projectId);
+
+  if (Result.isErr(projectResult)) {
+    return new NotFound(ctx, "project", projectId);
+  }
+
+  const project: Project.Project = projectResult;
+
+  if (user.id !== "root") {
+    const intent = "project.intent.listPermissions";
+    if (!Project.permits(project, user, [intent])) {
+      return new NotAuthorized({ ctx, userId: user.id, intent, target: project });
+    }
+  }
+  return project.permissions;
+}

--- a/api/src/service/project_permissions_list.ts
+++ b/api/src/service/project_permissions_list.ts
@@ -5,7 +5,7 @@ import { ConnToken } from "./conn";
 import { ServiceUser } from "./domain/organization/service_user";
 import { Permissions } from "./domain/permissions";
 import * as Project from "./domain/workflow/project";
-import * as ProjectGet from "./domain/workflow/project_get";
+import * as ProjectPermissionsList from "./domain/workflow/project_permissions_list";
 
 export async function getProjectPermissions(
   conn: ConnToken,
@@ -13,20 +13,17 @@ export async function getProjectPermissions(
   serviceUser: ServiceUser,
   projectId: Project.Id,
 ): Promise<Result.Type<Permissions>> {
-  // TODO This should be modeled on the domain layer, similar to global_permissions_get.
-  // TODO There, authorization for project.intent.listPermissions should be checked.
-  const projectResult = await Cache.withCache(conn, ctx, async cache =>
-    ProjectGet.getProject(ctx, serviceUser, projectId, {
-      getProject: async projectId => {
-        return cache.getProject(projectId);
+  const projectPermissionsResult = await Cache.withCache(conn, ctx, async cache =>
+    ProjectPermissionsList.getProjectPermissions(ctx, serviceUser, projectId, {
+      getProject: async pId => {
+        return cache.getProject(pId);
       },
     }),
   );
-
-  if (Result.isErr(projectResult)) {
-    projectResult.message = `could not fetch project permissions: ${projectResult.message}`;
-    return projectResult;
+  if (Result.isErr(projectPermissionsResult)) {
+    projectPermissionsResult.message = `could not fetch project permissions: ${projectPermissionsResult.message}`;
+    return projectPermissionsResult;
   }
 
-  return projectResult.permissions;
+  return projectPermissionsResult;
 }


### PR DESCRIPTION
### Description
The domain layer of project.intent.listPermissions is missing, so we should add it with the permission check. Currently the endpoint checks the project.viewSummary permission instead of project.intent.listPermissions.

### Test
User without project.intent.listPermissions cannot list project permissions
User without project.viewSummary but with project.intent.listPermissions can list project permissions

Closes #393 