### PR TITLE
UI: Change logic when edit button should be shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - The api endpoint "project.intent.listPermissions" checks for the right permission [#393](https://github.com/openkfw/TruBudget/issues/393)
+- The edit button of a project/subproject shouldn't be shown when the user has no permissions to update [#396](https://github.com/openkfw/TruBudget/issues/395)
 
 <!-- ### Security -->
 

--- a/e2e-test/cypress.json
+++ b/e2e-test/cypress.json
@@ -2,5 +2,6 @@
   "video": false,
   "baseUrl": "http://localhost:80",
   "defaultCommandTimeout": 10000,
-  "numTestsKeptInMemory": 0
+  "numTestsKeptInMemory": 0,
+  "projectId": "r4dcjk"
 }

--- a/e2e-test/cypress/integration/overview_spec.js
+++ b/e2e-test/cypress/integration/overview_spec.js
@@ -33,16 +33,4 @@ describe("Overview Page", function() {
         expect($card.find("button")).to.not.have.attr("disabled");
       });
   });
-
-  it("Shows project creation", function() {
-    cy.get("[data-test=project-creation]").should("be.visible");
-    cy.get("[data-test=project-creation] button").should("be.visible");
-  });
-
-  it("Disable project creation for 'root' user", function() {
-    cy.login("root", "root-secret");
-    cy.visit(`/projects`);
-    cy.get("[data-test=project-creation]").should("be.visible");
-    cy.get("[data-test=project-creation] button").should("be.disabled");
-  });
 });

--- a/e2e-test/cypress/integration/project_create_spec.js
+++ b/e2e-test/cypress/integration/project_create_spec.js
@@ -1,0 +1,18 @@
+describe("Overview Page", function() {
+  beforeEach(function() {
+    cy.login();
+    cy.visit(`/projects`);
+  });
+
+  it("Shows project creation", function() {
+    cy.get("[data-test=project-creation]").should("be.visible");
+    cy.get("[data-test=project-creation] button").should("be.visible");
+  });
+
+  it("Disable project creation for 'root' user", function() {
+    cy.login("root", "root-secret");
+    cy.visit(`/projects`);
+    cy.get("[data-test=project-creation]").should("be.visible");
+    cy.get("[data-test=project-creation] button").should("be.disabled");
+  });
+});

--- a/e2e-test/cypress/integration/project_edit_spec.js
+++ b/e2e-test/cypress/integration/project_edit_spec.js
@@ -1,0 +1,81 @@
+describe("Project Edit", function() {
+  let projectId;
+
+  before(() => {
+    cy.login();
+    cy.createProject("p-subp-edit", "subproject edit test").then(({ id }) => {
+      projectId = id;
+    });
+  });
+
+  beforeEach(function() {
+    cy.login();
+    cy.visit(`/projects`);
+  });
+
+  it("Editing the title is possible", function() {
+    cy.server();
+    cy.get(`[data-test=project-card-${projectId}]`).within(() => {
+      cy.get(`[data-test=pe-button]`).click();
+    });
+    cy.get("[data-test=nameinput] input")
+      .invoke("val")
+      .then(title => {
+        // Modify title
+        cy.get("[data-test=nameinput] input").type("-changed");
+        cy.get("[data-test=submit]").click();
+        // Check if title has changed
+        cy.get(`[data-test=project-card-${projectId}]`).within(() => {
+          cy.get("[data-test=project-title] span")
+            .invoke("text")
+            .should("not.eq", title);
+          // Change title back to original
+          cy.get("[data-test=pe-button]").click();
+        });
+        cy.get("[data-test=nameinput] input")
+          .clear()
+          .type(title);
+        cy.get("[data-test=submit]").click();
+        cy.get(`[data-test=project-card-${projectId}]`).within(() => {
+          cy.get("[data-test=project-title] span")
+            .invoke("text")
+            .should("eq", title);
+        });
+      });
+  });
+
+  it("Editing without a change isn't possible", function() {
+    cy.server();
+    cy.get(`[data-test=project-card-${projectId}]`).within(() => {
+      cy.get(`[data-test=pe-button]`).click();
+    });
+    cy.get("[data-test=submit]").should("be.disabled");
+    cy.get("[data-test=nameinput] input")
+      .invoke("val")
+      .then(title => {
+        cy.get("[data-test=nameinput] input").type("-");
+        cy.get("[data-test=submit]").should("be.enabled");
+        cy.get("[data-test=nameinput] input")
+          .clear()
+          .type(title);
+        cy.get("[data-test=submit]").should("be.disabled");
+      });
+  });
+
+  it("The edit button isn't visible without edit permissions", function() {
+    cy.server();
+    cy.get(`[data-test=project-card-${projectId}]`).within(() => {
+      cy.get(`[data-test=pe-button]`).should("be.enabled");
+    });
+    cy.login("root", "root-secret");
+    cy.revokeProjectPermission(projectId, "project.update", "mstein");
+    cy.login();
+    cy.visit(`/projects`);
+    cy.get(`[data-test=project-card-${projectId}]`).within(() => {
+      cy.get("[data-test=pe-button]")
+        .should("have.css", "opacity", "0")
+        .should("be.disabled");
+    });
+    cy.grantProjectPermission(projectId, "project.update", "mstein");
+  });
+});

--- a/e2e-test/cypress/integration/subproject_edit_spec.js
+++ b/e2e-test/cypress/integration/subproject_edit_spec.js
@@ -1,0 +1,61 @@
+describe("Subproject Edit", function() {
+  let projectId;
+  let subprojectId;
+  before(() => {
+    cy.login();
+    cy.createProject("p-subp-edit", "subproject edit test").then(({ id }) => {
+      projectId = id;
+      cy.createSubproject(projectId, "subproject edit test").then(({ id }) => {
+        subprojectId = id;
+      });
+    });
+  });
+
+  beforeEach(function() {
+    cy.login();
+    cy.visit(`/projects/${projectId}`);
+  });
+
+  it("Editing the title is possible", function() {
+    cy.server();
+    cy.get("[data-test=subproject-edit-button-0]").click();
+    cy.get("[data-test=nameinput] input")
+      .invoke("val")
+      .then(title => {
+        cy.get("[data-test=nameinput] input").type("-changed");
+        cy.get("[data-test=submit]").click();
+        cy.get("[data-test=subproject-title-0]")
+          .invoke("text")
+          .should("not.eq", title);
+      });
+  });
+
+  it("Editing without a change isn't possible", function() {
+    cy.server();
+    cy.get("[data-test=subproject-edit-button-0]").click();
+    cy.get("[data-test=submit]").should("be.disabled");
+    cy.get("[data-test=nameinput] input")
+      .invoke("val")
+      .then(title => {
+        cy.get("[data-test=nameinput] input").type("-");
+        cy.get("[data-test=submit]").should("be.enabled");
+        cy.get("[data-test=nameinput] input")
+          .clear()
+          .type(title);
+        cy.get("[data-test=submit]").should("be.disabled");
+      });
+  });
+
+  it("The edit button isn't visible without edit permissions", function() {
+    cy.server();
+    cy.get("[data-test=subproject-edit-button-0]").should("be.enabled");
+    cy.login("root", "root-secret");
+    cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.update", "mstein");
+    cy.login();
+    cy.visit(`/projects/${projectId}`);
+    cy.get("[data-test=subproject-edit-button-0]")
+      .should("have.css", "opacity", "0")
+      .should("be.disabled");
+    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.update", "mstein");
+  });
+});

--- a/e2e-test/cypress/integration/workflowitem_edit_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_edit_spec.js
@@ -113,33 +113,3 @@ describe("Workflowitem edit", function() {
     }
   );
 });
-
-describe("Workflowitem create", function() {
-  let projectId;
-  let subprojectId;
-
-  before(() => {
-    cy.login();
-
-    cy.createProject("workflowitem create test project", "workflowitem create test", [])
-      .then(({ id }) => {
-        projectId = id;
-        return cy.createSubproject(projectId, "workflowitem create test", "EUR");
-      })
-      .then(({ id }) => {
-        subprojectId = id;
-      });
-    cy.login();
-    cy.visit(`/projects/${projectId}/${subprojectId}`);
-  });
-
-  it("Root can not create a Workflowitem", function() {
-    cy.login("root", "root-secret");
-    cy.visit(`/projects/${projectId}/${subprojectId}`);
-
-    // When root is logged in the create workflow item button
-    // is disabled
-    cy.get("[data-test=createWorkflowitem]").should("be.visible");
-    cy.get("[data-test=createWorkflowitem]").should("be.disabled");
-  });
-});

--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -211,6 +211,7 @@ Cypress.Commands.add("grantProjectPermission", (projectId, intent, identity) => 
     .its("body")
     .then(body => Promise.resolve(body.data));
 });
+
 Cypress.Commands.add("revokeProjectPermission", (projectId, intent, identity) => {
   cy.request({
     url: `${baseUrl}/api/project.intent.revokePermission`,
@@ -222,6 +223,48 @@ Cypress.Commands.add("revokeProjectPermission", (projectId, intent, identity) =>
       apiVersion: "1.0",
       data: {
         projectId: projectId,
+        identity: identity,
+        intent: intent
+      }
+    }
+  })
+    .its("body")
+    .then(body => Promise.resolve(body.data));
+});
+
+Cypress.Commands.add("grantSubprojectPermission", (projectId, subprojectId, intent, identity) => {
+  cy.request({
+    url: `${baseUrl}/api/subproject.intent.grantPermission`,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: {
+      apiVersion: "1.0",
+      data: {
+        projectId: projectId,
+        subprojectId: subprojectId,
+        identity: identity,
+        intent: intent
+      }
+    }
+  })
+    .its("body")
+    .then(body => Promise.resolve(body.data));
+});
+
+Cypress.Commands.add("revokeSubprojectPermission", (projectId, subprojectId, intent, identity) => {
+  cy.request({
+    url: `${baseUrl}/api/subproject.intent.revokePermission`,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: {
+      apiVersion: "1.0",
+      data: {
+        projectId: projectId,
+        subprojectId: subprojectId,
         identity: identity,
         intent: intent
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6581,9 +6581,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
+      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/frontend/src/pages/Common/ActionButton.js
+++ b/frontend/src/pages/Common/ActionButton.js
@@ -16,6 +16,7 @@ const ActionButton = ({
   onClick,
   icon,
   title,
+  id,
   // eslint-disable-next-line no-useless-computed-key
   ["data-test"]: dataTest,
   iconButtonStyle
@@ -36,6 +37,7 @@ const ActionButton = ({
             style={notVisible ? { ...styles.hide } : iconButtonStyle}
             disabled={disabled}
             data-test={dataTest}
+            id={id}
           >
             {icon}
           </IconButton>

--- a/frontend/src/pages/Overview/ProjectCard.js
+++ b/frontend/src/pages/Overview/ProjectCard.js
@@ -144,7 +144,7 @@ const ProjectCard = ({
               iconButtonStyle={styles.editIcon}
             />
             <ActionButton
-              notVisible={!isOpen && editDisabled}
+              notVisible={!isOpen || editDisabled}
               onClick={() => {
                 showEditDialog(id, displayName, description, thumbnail, projectedBudgets, tags);
               }}

--- a/frontend/src/pages/Overview/ProjectCard.js
+++ b/frontend/src/pages/Overview/ProjectCard.js
@@ -87,7 +87,7 @@ const ProjectCard = ({
           data-test="project-header"
           className={classes.cardHeader}
           title={
-            <div className={classes.cardTitle}>
+            <div className={classes.cardTitle} id={`project-title-${index}`} data-test={`project-title`}>
               <span>{displayName}</span>
             </div>
           }
@@ -150,6 +150,7 @@ const ProjectCard = ({
               }}
               title={strings.common.edit}
               icon={<EditIcon />}
+              id={`pe-button-${index}`}
               data-test={`pe-button`}
               iconButtonStyle={styles.editIcon}
             />

--- a/frontend/src/pages/SubProjects/SubProjectTable.js
+++ b/frontend/src/pages/SubProjects/SubProjectTable.js
@@ -140,7 +140,7 @@ const getTableEntries = (
               </div>
               <div className={classes.button}>
                 <ActionButton
-                  notVisible={!isOpen && editDisabled}
+                  notVisible={!isOpen || editDisabled}
                   onClick={() => showEditDialog(id, displayName, description, currency, projectedBudgets)}
                   title={strings.common.edit}
                   icon={<EditIcon />}

--- a/frontend/src/pages/SubProjects/SubProjectTable.js
+++ b/frontend/src/pages/SubProjects/SubProjectTable.js
@@ -122,7 +122,9 @@ const getTableEntries = (
       const amountString = displaySubprojectBudget(projectedBudgets);
       return (
         <TableRow key={index}>
-          <TableCell className={classes.displayName}>{displayName}</TableCell>
+          <TableCell className={classes.displayName} data-test={`subproject-title-${index}`}>
+            {displayName}
+          </TableCell>
           <TableCell className={classes.projectdBudget}>{amountString}</TableCell>
           <TableCell className={classes.status}>{statusMapping(status)}</TableCell>
           <TableCell className={classes.actions}>


### PR DESCRIPTION
## Description
It shouldn't be able to view nor click the edit button without update permissions. Currently it is possible to view/click the edit button, but it's not possible to edit on submit.

## Solution

- [x] Change view logic of project and subproject edit action button
- [x] Create an e2e-test

Closes #395 