### PR TITLE
ui: Change analytics access without permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Added -->
 
-<!-- ### Changed -->
+### Changed
+
+- The analytics total budget is shown whether the user has insufficient permissions or not [#410](https://github.com/openkfw/TruBudget/pull/410)
 
 <!-- ### Deprecated -->
 

--- a/e2e-test/cypress/integration/project_analytics_spec.js
+++ b/e2e-test/cypress/integration/project_analytics_spec.js
@@ -1,0 +1,222 @@
+import { toAmountString } from "../support/helper";
+
+describe("Project Analytics", function() {
+  const executingUser = "mstein";
+  let project = {
+    id: "",
+    displayName: "p-analytics",
+    description: "project analytics test",
+    projectedBudgets: [
+      {
+        organization: "Test",
+        value: "200000",
+        currencyCode: "EUR"
+      }
+    ]
+  };
+
+  let subproject = {
+    id: "",
+    displayName: "sp-analytics",
+    description: "project analytics test",
+    currency: "EUR",
+    projectedBudgets: [
+      {
+        organization: "Test",
+        value: "100000",
+        currencyCode: "EUR"
+      }
+    ]
+  };
+
+  let allocatedWorkflowitem = {
+    id: "",
+    displayName: "w-analytics",
+    description: "project analytics test",
+    amountType: "allocated",
+    currency: "EUR",
+    amount: "50000",
+    exchangeRate: "1"
+  };
+
+  let disbursedWorkflowitem = {
+    id: "",
+    displayName: "w2-analytics",
+    description: "project analytics test",
+    amountType: "disbursed",
+    currency: "EUR",
+    amount: "10000",
+    exchangeRate: "1"
+  };
+
+  before(() => {
+    cy.login();
+    cy.createProject(project.displayName, project.description, project.projectedBudgets).then(({ id }) => {
+      project.id = id;
+      cy.createSubproject(project.id, subproject.displayName, subproject.currency, {
+        projectedBudgets: subproject.projectedBudgets
+      }).then(({ id }) => {
+        subproject.id = id;
+        cy.createWorkflowitem(project.id, subproject.id, allocatedWorkflowitem.displayName, {
+          ...allocatedWorkflowitem
+        }).then(({ id }) => {
+          allocatedWorkflowitem.id = id;
+          cy.createWorkflowitem(project.id, subproject.id, disbursedWorkflowitem.displayName, {
+            ...disbursedWorkflowitem
+          }).then(({ id }) => {
+            disbursedWorkflowitem.id = id;
+            // Create the workflowitem with status "closed" instead (currently bugged)
+            cy.closeWorkflowitem(
+              project.id,
+              subproject.id,
+              allocatedWorkflowitem.id,
+              allocatedWorkflowitem.exchangeRate
+            );
+            cy.closeWorkflowitem(
+              project.id,
+              subproject.id,
+              disbursedWorkflowitem.id,
+              disbursedWorkflowitem.exchangeRate
+            );
+          });
+        });
+      });
+    });
+  });
+
+  beforeEach(function() {
+    cy.login();
+    cy.visit(`/projects/${project.id}`);
+  });
+
+  function calcProjectedBudgetRatio(totalBudget, projectedBudget) {
+    return (projectedBudget / totalBudget) * 100;
+  }
+
+  it("The analytics-screen can be opened and closed", function() {
+    // Open dialog
+    cy.get("[data-test=details-analytics-button]")
+      .should("be.visible")
+      .click();
+    cy.get("[data-test=close-analytics-button]").should("be.visible");
+  });
+
+  it("The analytics-charts are calculated correctly", function() {
+    // Open dialog
+    cy.get("[data-test=details-analytics-button]")
+      .should("be.visible")
+      .click();
+    // Total Budget
+    cy.get("[data-test=number-chart-total-budget]").should(
+      "have.text",
+      toAmountString(project.projectedBudgets[0].value, subproject.currency)
+    );
+    // Projected Budget
+    cy.get("[data-test=number-chart-projected-budget]").should(
+      "have.text",
+      toAmountString(subproject.projectedBudgets[0].value, subproject.currency)
+    );
+    cy.get("[data-test=ratio-chart-projected-budget]").should(
+      "have.text",
+      calcProjectedBudgetRatio(project.projectedBudgets[0].value, subproject.projectedBudgets[0].value).toFixed(2) + "%"
+    );
+    // Assigned Budget
+    cy.get("[data-test=number-chart-assigned-budget]").should(
+      "have.text",
+      toAmountString(allocatedWorkflowitem.amount, allocatedWorkflowitem.currency)
+    );
+    cy.get("[data-test=ratio-chart-assigned-budget]").should(
+      "have.text",
+      calcProjectedBudgetRatio(subproject.projectedBudgets[0].value, allocatedWorkflowitem.amount).toFixed(2) + "%"
+    );
+    // Disbursed Budget
+    cy.get("[data-test=number-chart-disbursed-budget]").should(
+      "have.text",
+      toAmountString(disbursedWorkflowitem.amount, disbursedWorkflowitem.currency)
+    );
+    cy.get("[data-test=ratio-chart-disbursed-budget]").should(
+      "have.text",
+      calcProjectedBudgetRatio(allocatedWorkflowitem.amount, disbursedWorkflowitem.amount).toFixed(2) + "%"
+    );
+  });
+
+  it("Without view permission of every workflowitem of all subprojects the user can see the analytics-charts are not visible", function() {
+    // Setup permissions
+    cy.revokeWorkflowitemPermission(
+      project.id,
+      subproject.id,
+      allocatedWorkflowitem.id,
+      "workflowitem.view",
+      executingUser
+    );
+
+    // Open dialog
+    cy.get("[data-test=details-analytics-button]")
+      .should("be.visible")
+      .click();
+
+    cy.get("[data-test=number-chart-total-budget]").should("not.be.visible");
+    cy.get("[data-test=projected-budget-table]").should("be.visible");
+    cy.get("[data-test=redacted-warning]").should("be.visible");
+
+    // Reset permissions
+    cy.login("root", "root-secret");
+    cy.grantWorkflowitemPermission(
+      project.id,
+      subproject.id,
+      allocatedWorkflowitem.id,
+      "workflowitem.view",
+      executingUser
+    );
+  });
+
+  it("Without view permission of every subproject the analytics calculate all budgets using all subprojects seen", function() {
+    let notListedSubprojectId;
+    // Create subproject
+    cy.createSubproject(project.id, "test", "EUR", {
+      projectedBudgets: [
+        {
+          organization: "Test",
+          value: "50000",
+          currencyCode: "EUR"
+        }
+      ]
+    }).then(({ id }) => {
+      notListedSubprojectId = id;
+      // Revoke subproject view permissions
+      cy.revokeSubprojectPermission(project.id, notListedSubprojectId, "subproject.viewSummary", executingUser);
+      cy.revokeSubprojectPermission(project.id, notListedSubprojectId, "subproject.viewDetails", executingUser);
+
+      // Open dialog
+      cy.get("[data-test=details-analytics-button]")
+        .should("be.visible")
+        .click();
+
+      // Projected Budget must be unchanged
+      cy.get("[data-test=number-chart-projected-budget]").should(
+        "have.text",
+        toAmountString(subproject.projectedBudgets[0].value, subproject.currency)
+      );
+      cy.get("[data-test=ratio-chart-projected-budget]").should(
+        "have.text",
+        calcProjectedBudgetRatio(project.projectedBudgets[0].value, subproject.projectedBudgets[0].value).toFixed(2) +
+          "%"
+      );
+    });
+  });
+
+  it("Changing the currency converts all calculated amounts into the new currency", function() {
+    // Open dialog
+    cy.get("[data-test=details-analytics-button]")
+      .should("be.visible")
+      .click();
+    cy.get("[data-test=select-currencies]")
+      .should("be.visible")
+      .click();
+    cy.get("[data-test=currency-menuitem-USD]")
+      .should("be.visible")
+      .click();
+    cy.get("[data-test=number-chart-projected-budget]").contains("$");
+    cy.get("[data-test=table-total-budget]").contains("$");
+  });
+});

--- a/e2e-test/cypress/integration/subproject_analytics_spec.js
+++ b/e2e-test/cypress/integration/subproject_analytics_spec.js
@@ -1,0 +1,209 @@
+import { toAmountString } from "../support/helper";
+
+describe("Subproject Analytics", function() {
+  const executingUser = "mstein";
+  const description = "subproject analytics test";
+  let project = {
+    id: "",
+    displayName: "p-analytics",
+    description,
+    projectedBudgets: [
+      {
+        organization: "Test",
+        value: "200000",
+        currencyCode: "EUR"
+      }
+    ]
+  };
+
+  let subproject = {
+    id: "",
+    displayName: "sp-analytics",
+    description,
+    currency: "EUR",
+    projectedBudgets: [
+      {
+        organization: "Test",
+        value: "100000",
+        currencyCode: "EUR"
+      }
+    ]
+  };
+
+  let allocatedWorkflowitem = {
+    id: "",
+    displayName: "w-analytics",
+    description,
+    amountType: "allocated",
+    currency: "EUR",
+    amount: "50000",
+    exchangeRate: "1"
+  };
+
+  let disbursedWorkflowitem = {
+    id: "",
+    displayName: "w2-analytics",
+    description,
+    amountType: "disbursed",
+    currency: "EUR",
+    amount: "10000",
+    exchangeRate: "1"
+  };
+
+  before(() => {
+    cy.login();
+    cy.createProject(project.displayName, project.description, project.projectedBudgets).then(({ id }) => {
+      project.id = id;
+      cy.createSubproject(project.id, subproject.displayName, subproject.currency, {
+        projectedBudgets: subproject.projectedBudgets
+      }).then(({ id }) => {
+        subproject.id = id;
+        cy.createWorkflowitem(project.id, subproject.id, allocatedWorkflowitem.displayName, {
+          ...allocatedWorkflowitem
+        }).then(({ id }) => {
+          allocatedWorkflowitem.id = id;
+          cy.createWorkflowitem(project.id, subproject.id, disbursedWorkflowitem.displayName, {
+            ...disbursedWorkflowitem
+          }).then(({ id }) => {
+            disbursedWorkflowitem.id = id;
+            // Create the workflowitem with status "closed" instead (currently bugged)
+            cy.closeWorkflowitem(
+              project.id,
+              subproject.id,
+              allocatedWorkflowitem.id,
+              allocatedWorkflowitem.exchangeRate
+            );
+            cy.closeWorkflowitem(
+              project.id,
+              subproject.id,
+              disbursedWorkflowitem.id,
+              disbursedWorkflowitem.exchangeRate
+            );
+          });
+        });
+      });
+    });
+  });
+
+  beforeEach(function() {
+    cy.login();
+    cy.visit(`/projects/${project.id}/${subproject.id}`);
+  });
+
+  function calcProjectedBudgetRatio(totalBudget, projectedBudget) {
+    return (projectedBudget / totalBudget) * 100;
+  }
+
+  it("The analytics-screen can be opened and closed", function() {
+    // Open dialog
+    cy.get("[data-test=details-analytics-button]")
+      .should("be.visible")
+      .click();
+    cy.get("[data-test=close-analytics-button]").should("be.visible");
+  });
+
+  it("The analytics-charts are calculated correctly", function() {
+    // Open dialog
+    cy.get("[data-test=details-analytics-button]")
+      .should("be.visible")
+      .click();
+    // Projected Budget
+    cy.get("[data-test=number-chart-projected-budget]").should(
+      "have.text",
+      toAmountString(subproject.projectedBudgets[0].value, subproject.currency)
+    );
+    // Assigned Budget
+    cy.get("[data-test=number-chart-assigned-budget]").should(
+      "have.text",
+      toAmountString(allocatedWorkflowitem.amount, allocatedWorkflowitem.currency)
+    );
+    cy.get("[data-test=ratio-chart-assigned-budget]").should(
+      "have.text",
+      calcProjectedBudgetRatio(subproject.projectedBudgets[0].value, allocatedWorkflowitem.amount).toFixed(2) + "%"
+    );
+    // Disbursed Budget
+    cy.get("[data-test=number-chart-disbursed-budget]").should(
+      "have.text",
+      toAmountString(disbursedWorkflowitem.amount, disbursedWorkflowitem.currency)
+    );
+    cy.get("[data-test=ratio-chart-disbursed-budget]").should(
+      "have.text",
+      calcProjectedBudgetRatio(allocatedWorkflowitem.amount, disbursedWorkflowitem.amount).toFixed(2) + "%"
+    );
+  });
+
+  it("Without view permission of every workflowitem of all subprojects the user can see the analytics-charts are not visible", function() {
+    // Setup permissions
+    cy.revokeWorkflowitemPermission(
+      project.id,
+      subproject.id,
+      allocatedWorkflowitem.id,
+      "workflowitem.view",
+      executingUser
+    );
+
+    // Open dialog
+    cy.get("[data-test=details-analytics-button]")
+      .should("be.visible")
+      .click();
+
+    cy.get("[data-test=number-chart-total-budget]").should("not.be.visible");
+    cy.get("[data-test=projected-budget-table]").should("be.visible");
+    cy.get("[data-test=redacted-warning]").should("be.visible");
+
+    // Reset permissions
+    cy.login("root", "root-secret");
+    cy.grantWorkflowitemPermission(
+      project.id,
+      subproject.id,
+      allocatedWorkflowitem.id,
+      "workflowitem.view",
+      executingUser
+    );
+  });
+
+  it("Without view permission of every subproject the analytics calculate all budgets using all subprojects seen", function() {
+    let notListedSubprojectId;
+    // Create subproject
+    cy.createSubproject(project.id, "test", "EUR", {
+      projectedBudgets: [
+        {
+          organization: "Test",
+          value: "50000",
+          currencyCode: "EUR"
+        }
+      ]
+    }).then(({ id }) => {
+      notListedSubprojectId = id;
+      // Revoke subproject view permissions
+      cy.revokeSubprojectPermission(project.id, notListedSubprojectId, "subproject.viewSummary", executingUser);
+      cy.revokeSubprojectPermission(project.id, notListedSubprojectId, "subproject.viewDetails", executingUser);
+
+      // Open dialog
+      cy.get("[data-test=details-analytics-button]")
+        .should("be.visible")
+        .click();
+
+      // Projected Budget must be unchanged
+      cy.get("[data-test=number-chart-projected-budget]").should(
+        "have.text",
+        toAmountString(subproject.projectedBudgets[0].value, subproject.currency)
+      );
+    });
+  });
+
+  it("Changing the currency converts all calculated amounts into the new currency", function() {
+    // Open dialog
+    cy.get("[data-test=details-analytics-button]")
+      .should("be.visible")
+      .click();
+    cy.get("[data-test=select-currencies]")
+      .should("be.visible")
+      .click();
+    cy.get("[data-test=currency-menuitem-USD]")
+      .should("be.visible")
+      .click();
+    cy.get("[data-test=number-chart-projected-budget]").contains("$");
+    cy.get("[data-test=table-total-budget]").contains("$");
+  });
+});

--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -404,6 +404,25 @@ Cypress.Commands.add("closeProject", projectId => {
     .its("body")
     .then(body => Promise.resolve(body.data));
 });
+Cypress.Commands.add("closeWorkflowitem", (projectId, subprojectId, workflowitemId) => {
+  cy.request({
+    url: `${baseUrl}/api/workflowitem.close`,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: {
+      apiVersion: "1.0",
+      data: {
+        projectId,
+        subprojectId,
+        workflowitemId
+      }
+    }
+  })
+    .its("body")
+    .then(body => Promise.resolve(body.data));
+});
 
 Cypress.Commands.add("getUserList", () => {
   cy.request({

--- a/e2e-test/cypress/support/helper.js
+++ b/e2e-test/cypress/support/helper.js
@@ -1,0 +1,33 @@
+import _isString from "lodash/isString";
+
+import accounting from "accounting";
+
+const numberFormat = {
+  decimal: ".",
+  thousand: ",",
+  precision: 2
+};
+
+const currencies = {
+  EUR: { symbol: "€", format: "%v %s" },
+  USD: { symbol: "$", format: "%s %v" },
+  BRL: { symbol: "R$", format: "%s %v" },
+  XOF: { symbol: "CFA", format: "%s %v" },
+  DKK: { symbol: "kr.", format: "%v %s" }
+};
+
+const getCurrencyFormat = currency => ({
+  ...numberFormat,
+  ...currencies[currency]
+});
+
+export function toAmountString(amount, currency) {
+  if (_isString(amount) && amount.trim().length <= 0) {
+    return "";
+  }
+  if (!currency) {
+    return accounting.formatNumber(amount, numberFormat.precision, numberFormat.thousand, numberFormat.decimal);
+  }
+
+  return accounting.formatMoney(amount, getCurrencyFormat(currency));
+}

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trubudget-e2e-test",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -66,6 +66,12 @@
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
       }
+    },
+    "accounting": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/accounting/-/accounting-0.4.1.tgz",
+      "integrity": "sha1-h91BA+/39EYPHhhvXGd+1s9WaIM=",
+      "dev": true
     },
     "acorn": {
       "version": "6.1.1",

--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -18,6 +18,7 @@
   ],
   "main": "index.js",
   "devDependencies": {
+    "accounting": "^0.4.1",
     "cypress": "^3.4.1",
     "cypress-file-upload": "^3.1.1",
     "eslint": "^5.16.0",

--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -274,6 +274,8 @@ const en = {
     available_unspent_budget: "Available Unspent Budget",
     converted_amount: "Converted Amount",
     disbursed_budget_ratio: "Disbursed Budget Ratio",
+    insufficient_permissions_text:
+      "One or more workflowitem are redacted. The analytics are hidden because they would be falsified.",
     project_analytics: "Project Analytics",
     projected_budget_ratio: "Projected Budget Ratio",
     projected_budgets_distribution: "Projected Budgets Distribution",

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -277,6 +277,8 @@ const fr = {
     available_unspent_budget: "Budget non dépensé disponible",
     converted_amount: "Montant converti",
     disbursed_budget_ratio: "Taux de décaissement(décaissé/alloué)",
+    insufficient_permissions_text:
+      "Un ou plusieurs flux de travaux sont rédigés. Les analyses sont masquées car elles seraient falsifiées.",
     project_analytics: "Analyse de projet",
     projected_budget_ratio: "Taux d’estimation du budget(estimé/total)",
     projected_budgets_distribution: "Répartition du budget total",

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -275,6 +275,8 @@ const de = {
     available_unspent_budget: "Verfügbares Budget",
     converted_amount: "Umgerechneter Betrag",
     disbursed_budget_ratio: "Ausgezahlte Budgetquote",
+    insufficient_permissions_text:
+      "Ein oder mehrere Workflowitems sind zensiert. Die Analysen werden ausgeblendet, weil sie verfälscht würden.",
     project_analytics: "Projekt Analyse",
     projected_budget_ratio: "Projezierte Budgetquote",
     projected_budgets_distribution: "Verteilung des geplanten Budgets",

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -276,6 +276,8 @@ const pt = {
     available_unspent_budget: "Orçamento Disponível",
     converted_amount: "Valor convertido",
     disbursed_budget_ratio: "% do Orçamento Desembolsado",
+    insufficient_permissions_text:
+      "Um ou mais itens do fluxo de trabalho são editados. As análises são ocultas porque seriam falsificadas.",
     project_analytics: "Dashboard do Projeto",
     projected_budget_ratio: "% do Orçamento Projetado",
     projected_budgets_distribution: "Distribuição dos orçamentos projetados",

--- a/frontend/src/pages/Analytics/ProjectAnalytics.js
+++ b/frontend/src/pages/Analytics/ProjectAnalytics.js
@@ -112,7 +112,7 @@ class ProjectAnalytics extends React.Component {
         <div style={styles.container}>
           <div style={styles.topContainer}>
             <div style={styles.table}>
-              <Table>
+              <Table data-test="projected-budget-table">
                 <TableHead>
                   <TableRow>
                     <TableCell>{strings.common.organization}</TableCell>
@@ -139,7 +139,7 @@ class ProjectAnalytics extends React.Component {
                     <TableCell />
                     <TableCell />
                     <TableCell align="right">{strings.analytics.total}</TableCell>
-                    <TableCell align="right">{toAmountString(totalBudget, indicatedCurrency)}</TableCell>
+                    <TableCell data-test="table-total-budget" align="right">{toAmountString(totalBudget, indicatedCurrency)}</TableCell>
                   </TableRow>
                 </TableBody>
               </Table>
@@ -155,7 +155,9 @@ class ProjectAnalytics extends React.Component {
               assignedBudget={assignedBudget}
             />
           ) : (
-            <Typography style={styles.warning}>{strings.analytics.insufficient_permissions_text}</Typography>
+            <Typography style={styles.warning} data-test="redacted-warning">
+              {strings.analytics.insufficient_permissions_text}
+            </Typography>
           )}
         </div>
       </>
@@ -196,25 +198,25 @@ const dashboardStyles = {
 
 const onlyPositive = number => (number < 0 ? 0 : number);
 
-const NumberChart = ({ title, budget, currency }) => (
+const NumberChart = ({ title, budget, currency, dataTest }) => (
   <Card style={dashboardStyles.card}>
     <CardContent style={dashboardStyles.numberContent}>
       <Typography style={{ flex: 1 }} variant="overline">
         {title}
       </Typography>
-      <Typography style={{ flex: 1 }} variant="h6">
+      <Typography style={{ flex: 1 }} variant="h6" data-test={dataTest}>
         {toAmountString(budget, currency)}
       </Typography>
     </CardContent>
   </Card>
 );
-const RatioChart = ({ title, budget }) => (
+const RatioChart = ({ title, budget, dataTest }) => (
   <Card style={dashboardStyles.card}>
     <CardContent style={dashboardStyles.ratioContent}>
       <Typography style={{ flex: 1 }} variant="overline">
         {title}
       </Typography>
-      <Typography style={{ flex: 1 }} variant="h6">
+      <Typography style={{ flex: 1 }} data-test={dataTest} variant="h6">
         {budget ? `${(budget * 100).toFixed(2)}%` : "-"}
       </Typography>
     </CardContent>
@@ -240,10 +242,30 @@ const Dashboard = ({
 }) => {
   return (
     <div style={dashboardStyles.container}>
-      <NumberChart title={strings.common.total_budget} budget={totalBudget} currency={indicatedCurrency} />
-      <NumberChart title={strings.common.projected_budget} budget={projectedBudget} currency={indicatedCurrency} />
-      <NumberChart title={strings.common.assigned_budget} budget={assignedBudget} currency={indicatedCurrency} />
-      <NumberChart title={strings.common.disbursed_budget} budget={disbursedBudget} currency={indicatedCurrency} />
+      <NumberChart
+        title={strings.common.total_budget}
+        budget={totalBudget}
+        dataTest="number-chart-total-budget"
+        currency={indicatedCurrency}
+      />
+      <NumberChart
+        title={strings.common.projected_budget}
+        budget={projectedBudget}
+        dataTest="number-chart-projected-budget"
+        currency={indicatedCurrency}
+      />
+      <NumberChart
+        title={strings.common.assigned_budget}
+        budget={assignedBudget}
+        dataTest="number-chart-assigned-budget"
+        currency={indicatedCurrency}
+      />
+      <NumberChart
+        title={strings.common.disbursed_budget}
+        budget={disbursedBudget}
+        dataTest="number-chart-disbursed-budget"
+        currency={indicatedCurrency}
+      />
       <Chart
         title={strings.analytics.total_budget_distribution}
         chart={
@@ -276,9 +298,21 @@ const Dashboard = ({
           />
         }
       />
-      <RatioChart title={strings.analytics.projected_budget_ratio} budget={projectedBudget / totalBudget} />
-      <RatioChart title={strings.analytics.assigned_budget_ratio} budget={assignedBudget / projectedBudget} />
-      <RatioChart title={strings.analytics.disbursed_budget_ratio} budget={disbursedBudget / assignedBudget} />
+      <RatioChart
+        title={strings.analytics.projected_budget_ratio}
+        dataTest="ratio-chart-projected-budget"
+        budget={projectedBudget / totalBudget}
+      />
+      <RatioChart
+        title={strings.analytics.assigned_budget_ratio}
+        dataTest="ratio-chart-assigned-budget"
+        budget={assignedBudget / projectedBudget}
+      />
+      <RatioChart
+        title={strings.analytics.disbursed_budget_ratio}
+        dataTest="ratio-chart-disbursed-budget"
+        budget={disbursedBudget / assignedBudget}
+      />
       <Chart
         title={strings.analytics.available_unspent_budget}
         chart={

--- a/frontend/src/pages/Analytics/ProjectAnalyticsDialog.js
+++ b/frontend/src/pages/Analytics/ProjectAnalyticsDialog.js
@@ -9,14 +9,13 @@ import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import CloseIcon from "@material-ui/icons/Close";
-import React, { lazy, Suspense } from "react";
+import React from "react";
 import { connect } from "react-redux";
 
 import { getCurrencies } from "../../helper";
 import { closeAnalyticsDialog, getExchangeRates, storeDisplayCurrency } from "./actions";
 import strings from "../../localizeStrings";
-
-const ProjectAnalytics = lazy(() => import("./ProjectAnalytics"));
+import ProjectAnalytics from "./ProjectAnalytics";
 
 const styles = {
   container: {
@@ -28,13 +27,18 @@ const styles = {
   dropdown: {
     marginLeft: "auto",
     marginTop: "0"
+  },
+  loadingCharts: {
+    marginTop: "16px",
+    display: "flex",
+    justifyContent: "center"
   }
 };
 
 function getMenuItems(currencies) {
   return currencies.map((currency, index) => {
     return (
-      <MenuItem key={index} value={currency.value}>
+      <MenuItem key={index} data-test={`currency-menuitem-${currency.value}`} value={currency.value}>
         {currency.primaryText}
       </MenuItem>
     );
@@ -63,7 +67,12 @@ const ProjectAnalyticsDialog = ({
   >
     <AppBar>
       <Toolbar style={styles.toolbar}>
-        <IconButton color="inherit" onClick={closeAnalyticsDialog} aria-label="Close">
+        <IconButton
+          color="inherit"
+          onClick={closeAnalyticsDialog}
+          data-test="close-analytics-button"
+          aria-label="Close"
+        >
           <CloseIcon />
         </IconButton>
         <Typography variant="h6" color="inherit">
@@ -81,6 +90,7 @@ const ProjectAnalyticsDialog = ({
                 name: "currencies",
                 id: "currencies"
               }}
+              data-test="select-currencies"
               IconComponent={props => <ArrowDropDownIcon {...props} style={{ color: "white" }} />}
               style={{ color: "white" }}
             >
@@ -91,13 +101,11 @@ const ProjectAnalyticsDialog = ({
       </Toolbar>
     </AppBar>
     <div style={styles.container}>
-      <Suspense fallback={<div>Loading...</div>}>
-        <ProjectAnalytics
-          projectId={projectId}
-          totalBudget={projectProjectedBudgets}
-          getExchangeRates={getExchangeRates}
-        />
-      </Suspense>
+      <ProjectAnalytics
+        projectId={projectId}
+        totalBudget={projectProjectedBudgets}
+        getExchangeRates={getExchangeRates}
+      />
     </div>
   </Dialog>
 );

--- a/frontend/src/pages/Analytics/ProjectAnalyticsDialog.js
+++ b/frontend/src/pages/Analytics/ProjectAnalyticsDialog.js
@@ -51,7 +51,8 @@ const ProjectAnalyticsDialog = ({
   displayCurrency,
   closeAnalyticsDialog,
   storeDisplayCurrency,
-  getExchangeRates
+  getExchangeRates,
+  projectProjectedBudgets
 }) => (
   <Dialog
     fullScreen
@@ -91,7 +92,11 @@ const ProjectAnalyticsDialog = ({
     </AppBar>
     <div style={styles.container}>
       <Suspense fallback={<div>Loading...</div>}>
-        <ProjectAnalytics projectId={projectId} />
+        <ProjectAnalytics
+          projectId={projectId}
+          totalBudget={projectProjectedBudgets}
+          getExchangeRates={getExchangeRates}
+        />
       </Suspense>
     </div>
   </Dialog>

--- a/frontend/src/pages/Analytics/SubProjectAnalytics.js
+++ b/frontend/src/pages/Analytics/SubProjectAnalytics.js
@@ -96,7 +96,7 @@ class SubprojectAnalytics extends React.Component {
         <div style={styles.container}>
           <div style={styles.topContainer}>
             <div style={styles.table}>
-              <Table>
+              <Table data-test="projected-budget-table">
                 <TableHead>
                   <TableRow>
                     <TableCell>{strings.common.organization}</TableCell>
@@ -122,8 +122,10 @@ class SubprojectAnalytics extends React.Component {
                     <TableCell />
                     <TableCell />
                     <TableCell />
-                    <TableCell />
-                    <TableCell align="right">{toAmountString(projectedBudget, indicatedCurrency)}</TableCell>
+                    <TableCell align="right">{strings.analytics.total}</TableCell>
+                    <TableCell data-test="table-total-budget" align="right">
+                      {toAmountString(projectedBudget, indicatedCurrency)}
+                    </TableCell>
                   </TableRow>
                 </TableBody>
               </Table>
@@ -138,7 +140,9 @@ class SubprojectAnalytics extends React.Component {
               assignedBudget={convertedAssignedBudget}
             />
           ) : (
-            <Typography style={styles.warning}>{strings.analytics.insufficient_permissions_text}</Typography>
+            <Typography style={styles.warning} data-test="redacted-warning">
+              {strings.analytics.insufficient_permissions_text}
+            </Typography>
           )}
         </div>
       </>
@@ -177,35 +181,37 @@ const dashboardStyles = {
   }
 };
 
-const NumberChart = ({ title, budget, currency }) => (
+const NumberChart = ({ title, budget, currency, dataTest }) => (
   <Card style={dashboardStyles.card}>
     <CardContent style={dashboardStyles.numberContent}>
       <Typography style={{ flex: 1 }} variant="overline">
         {title}
       </Typography>
-      <Typography style={{ flex: 1 }} variant="h6">
+      <Typography style={{ flex: 1 }} data-test={dataTest} variant="h6">
         {toAmountString(budget, currency)}
       </Typography>
     </CardContent>
   </Card>
 );
-const RatioChart = ({ title, budget }) => (
+const RatioChart = ({ title, budget, dataTest }) => (
   <Card style={dashboardStyles.card}>
     <CardContent style={dashboardStyles.ratioContent}>
       <Typography style={{ flex: 1 }} variant="overline">
         {title}
       </Typography>
-      <Typography style={{ flex: 1 }} variant="h6">
+      <Typography style={{ flex: 1 }} data-test={dataTest} variant="h6">
         {budget ? `${(budget * 100).toFixed(2)}%` : "-"}
       </Typography>
     </CardContent>
   </Card>
 );
 
-const Chart = ({ title, chart }) => (
+const Chart = ({ title, chart, dataTest }) => (
   <Card style={dashboardStyles.card}>
     <CardContent style={dashboardStyles.chartContent}>
-      <Typography variant="overline">{title}</Typography>
+      <Typography data-test={dataTest} variant="overline">
+        {title}
+      </Typography>
       <div style={{ flex: 1 }}>{chart}</div>
     </CardContent>
   </Card>
@@ -246,11 +252,34 @@ const Dashboard = ({ indicatedCurrency, projectedBudgets, projectedBudget, assig
           />
         }
       />
-      <NumberChart title={strings.common.projected_budget} budget={projectedBudget} currency={indicatedCurrency} />
-      <NumberChart title={strings.common.assigned_budget} budget={assignedBudget} currency={indicatedCurrency} />
-      <NumberChart title={strings.common.disbursed_budget} budget={disbursedBudget} currency={indicatedCurrency} />
-      <RatioChart title={strings.analytics.assigned_budget_ratio} budget={assignedBudget / projectedBudget} />
-      <RatioChart title={strings.analytics.disbursed_budget_ratio} budget={disbursedBudget / assignedBudget} />
+      <NumberChart
+        title={strings.common.projected_budget}
+        budget={projectedBudget}
+        dataTest="number-chart-projected-budget"
+        currency={indicatedCurrency}
+      />
+      <NumberChart
+        title={strings.common.assigned_budget}
+        budget={assignedBudget}
+        dataTest="number-chart-assigned-budget"
+        currency={indicatedCurrency}
+      />
+      <NumberChart
+        title={strings.common.disbursed_budget}
+        budget={disbursedBudget}
+        dataTest="number-chart-disbursed-budget"
+        currency={indicatedCurrency}
+      />
+      <RatioChart
+        title={strings.analytics.assigned_budget_ratio}
+        dataTest="ratio-chart-assigned-budget"
+        budget={assignedBudget / projectedBudget}
+      />
+      <RatioChart
+        title={strings.analytics.disbursed_budget_ratio}
+        dataTest="ratio-chart-disbursed-budget"
+        budget={disbursedBudget / assignedBudget}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Analytics/SubProjectAnalyticsDialog.js
+++ b/frontend/src/pages/Analytics/SubProjectAnalyticsDialog.js
@@ -52,7 +52,8 @@ const SubProjectAnalyticsDialog = ({
   displayCurrency,
   closeAnalyticsDialog,
   storeDisplayCurrency,
-  getExchangeRates
+  getExchangeRates,
+  projectedBudgets
 }) => (
   <Dialog
     fullScreen
@@ -92,7 +93,12 @@ const SubProjectAnalyticsDialog = ({
     </AppBar>
     <div style={styles.container}>
       <Suspense fallback={<div>Loading...</div>}>
-        <SubProjectAnalytics projectId={projectId} subProjectId={subProjectId} />{" "}
+        <SubProjectAnalytics
+          projectId={projectId}
+          subProjectId={subProjectId}
+          projectedBudgets={projectedBudgets}
+          getExchangeRates={getExchangeRates}
+        />
       </Suspense>
     </div>
   </Dialog>

--- a/frontend/src/pages/Analytics/SubProjectAnalyticsDialog.js
+++ b/frontend/src/pages/Analytics/SubProjectAnalyticsDialog.js
@@ -9,14 +9,13 @@ import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import CloseIcon from "@material-ui/icons/Close";
-import React, { lazy, Suspense } from "react";
+import React from "react";
 import { connect } from "react-redux";
 
 import { getCurrencies } from "../../helper";
 import { closeAnalyticsDialog, getExchangeRates, storeDisplayCurrency } from "./actions";
 import strings from "../../localizeStrings";
-
-const SubProjectAnalytics = lazy(() => import("./SubProjectAnalytics"));
+import SubProjectAnalytics from "./SubProjectAnalytics";
 
 const styles = {
   container: {
@@ -28,13 +27,18 @@ const styles = {
   dropdown: {
     marginLeft: "auto",
     marginTop: "0"
+  },
+  loadingCharts: {
+    marginTop: "16px",
+    display: "flex",
+    justifyContent: "center"
   }
 };
 
 function getMenuItems(currencies) {
   return currencies.map((currency, index) => {
     return (
-      <MenuItem key={index} value={currency.value}>
+      <MenuItem key={index} data-test={`currency-menuitem-${currency.value}`} value={currency.value}>
         {currency.primaryText}
       </MenuItem>
     );
@@ -64,7 +68,12 @@ const SubProjectAnalyticsDialog = ({
   >
     <AppBar>
       <Toolbar>
-        <IconButton color="inherit" onClick={closeAnalyticsDialog} aria-label="Close">
+        <IconButton
+          data-test="close-analytics-button"
+          color="inherit"
+          onClick={closeAnalyticsDialog}
+          aria-label="Close"
+        >
           <CloseIcon />
         </IconButton>
         <Typography variant="h6" color="inherit">
@@ -82,6 +91,7 @@ const SubProjectAnalyticsDialog = ({
                 name: "currencies",
                 id: "currencies"
               }}
+              data-test="select-currencies"
               IconComponent={props => <ArrowDropDownIcon {...props} style={{ color: "white" }} />}
               style={{ color: "white" }}
             >
@@ -92,14 +102,12 @@ const SubProjectAnalyticsDialog = ({
       </Toolbar>
     </AppBar>
     <div style={styles.container}>
-      <Suspense fallback={<div>Loading...</div>}>
-        <SubProjectAnalytics
-          projectId={projectId}
-          subProjectId={subProjectId}
-          projectedBudgets={projectedBudgets}
-          getExchangeRates={getExchangeRates}
-        />
-      </Suspense>
+      <SubProjectAnalytics
+        projectId={projectId}
+        subProjectId={subProjectId}
+        projectedBudgets={projectedBudgets}
+        getExchangeRates={getExchangeRates}
+      />
     </div>
   </Dialog>
 );

--- a/frontend/src/pages/Analytics/reducer.js
+++ b/frontend/src/pages/Analytics/reducer.js
@@ -11,7 +11,8 @@ import {
   OPEN_ANALYTICS_DIALOG,
   RESET_KPIS,
   STORE_DISPLAY_CURRENCY,
-  GET_SUBPROJECT_KPIS_FAIL
+  GET_SUBPROJECT_KPIS_FAIL,
+  GET_SUBPROJECT_KPIS
 } from "./actions";
 
 /**
@@ -45,16 +46,22 @@ const defaultState = fromJS({
   },
   dialogOpen: false,
   exchangeRates: {},
-  canShowAnalytics: false
+  canShowAnalytics: false,
+  isFetchingKPIs: false
 });
 
 export default function detailviewReducer(state = defaultState, action) {
   switch (action.type) {
     case GET_PROJECT_KPIS:
-      return state.set("canShowAnalytics", undefined);
+    case GET_SUBPROJECT_KPIS:
+      return state.set("isFetchingKPIs", true);
+    case GET_PROJECT_KPIS_FAIL:
+    case GET_SUBPROJECT_KPIS_FAIL:
+      return state.merge({ canShowAnalytics: false, isFetchingKPIs: false });
     case GET_PROJECT_KPIS_SUCCESS:
       return state.merge({
         canShowAnalytics: true,
+        isFetchingKPIs: false,
         project: {
           totalBudget: fromJS(action.totalBudget),
           projectedBudget: fromJS(action.projectedBudget),
@@ -62,12 +69,10 @@ export default function detailviewReducer(state = defaultState, action) {
           disbursedBudget: fromJS(action.disbursedBudget)
         }
       });
-    case GET_PROJECT_KPIS_FAIL:
-    case GET_SUBPROJECT_KPIS_FAIL:
-      return state.set("canShowAnalytics", false);
     case GET_SUBPROJECT_KPIS_SUCCESS:
       return state.merge({
         canShowAnalytics: true,
+        isFetchingKPIs: false,
         subproject: {
           currency: action.subProjectCurrency,
           projectedBudgets: fromJS(action.projectedBudgets),

--- a/frontend/src/pages/SubProjects/ProjectDetails.js
+++ b/frontend/src/pages/SubProjects/ProjectDetails.js
@@ -184,7 +184,7 @@ const ProjectDetails = props => {
           </ListItem>
         </List>
       </Card>
-      <ProjectAnalyticsDialog projectId={projectId} />
+      <ProjectAnalyticsDialog projectId={projectId} projectProjectedBudgets={projectProjectedBudgets} />
     </div>
   );
 };

--- a/frontend/src/pages/SubProjects/ProjectDetails.js
+++ b/frontend/src/pages/SubProjects/ProjectDetails.js
@@ -148,7 +148,12 @@ const ProjectDetails = props => {
             </TableBody>
           </Table>
           <div style={styles.analytics}>
-            <Button variant="outlined" color="primary" onClick={openAnalyticsDialog}>
+            <Button
+              variant="outlined"
+              color="primary"
+              data-test="details-analytics-button"
+              onClick={openAnalyticsDialog}
+            >
               <BarChartIcon />
               {strings.project.project_details}
             </Button>

--- a/frontend/src/pages/Workflows/SubProjectDetails.js
+++ b/frontend/src/pages/Workflows/SubProjectDetails.js
@@ -100,7 +100,7 @@ const SubProjectDetails = ({
   closeSubproject,
   canCloseSubproject,
   openAnalyticsDialog,
-  ...props
+  projectedBudgets
 }) => {
   const mappedStatus = statusMapping(status);
   const statusIcon = statusIconMapping[status];
@@ -139,7 +139,7 @@ const SubProjectDetails = ({
               </TableRow>
             </TableHead>
             <TableBody>
-              {props.projectedBudgets.map(budget => (
+              {projectedBudgets.map(budget => (
                 <TableRow key={budget.organization + budget.currencyCode}>
                   <TableCell>{budget.organization}</TableCell>
                   <TableCell align="right">{toAmountString(budget.value)}</TableCell>
@@ -196,7 +196,7 @@ const SubProjectDetails = ({
           </ListItem>
         </List>
       </Card>
-      <SubProjectAnalyticsDialog projectId={parentProject.id} subProjectId={id} />
+      <SubProjectAnalyticsDialog projectId={parentProject.id} subProjectId={id} projectedBudgets={projectedBudgets} />
     </div>
   );
 };

--- a/frontend/src/pages/Workflows/SubProjectDetails.js
+++ b/frontend/src/pages/Workflows/SubProjectDetails.js
@@ -149,7 +149,12 @@ const SubProjectDetails = ({
             </TableBody>
           </Table>
           <div style={styles.analytics}>
-            <Button variant="outlined" color="primary" onClick={openAnalyticsDialog}>
+            <Button
+              variant="outlined"
+              color="primary"
+              data-test="details-analytics-button"
+              onClick={openAnalyticsDialog}
+            >
               <BarChartIcon />
               {strings.project.project_details}
             </Button>

--- a/frontend/src/pages/Workflows/SubProjectDetails.js
+++ b/frontend/src/pages/Workflows/SubProjectDetails.js
@@ -85,18 +85,14 @@ const SubProjectDetails = ({
   displayName,
   description,
   currency,
-  id,
+  subprojectId,
   status,
-  roles,
   assignee,
   workflowItems,
   created,
-  budgetEditEnabled,
-  canViewPermissions,
   canAssignSubproject,
-  parentProject,
+  projectId,
   users,
-  showSubProjectAssignee,
   closeSubproject,
   canCloseSubproject,
   openAnalyticsDialog,
@@ -189,8 +185,8 @@ const SubProjectDetails = ({
             <ListItemText
               primary={
                 <SubProjectAssigneeContainer
-                  projectId={parentProject ? parentProject.id : ""}
-                  subprojectId={id}
+                  projectId={projectId}
+                  subprojectId={subprojectId}
                   users={users}
                   disabled={!canAssignSubproject}
                   assignee={assignee}
@@ -201,7 +197,11 @@ const SubProjectDetails = ({
           </ListItem>
         </List>
       </Card>
-      <SubProjectAnalyticsDialog projectId={parentProject.id} subProjectId={id} projectedBudgets={projectedBudgets} />
+      <SubProjectAnalyticsDialog
+        projectId={projectId}
+        subProjectId={subprojectId}
+        projectedBudgets={projectedBudgets}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Workflows/WorkflowContainer.js
+++ b/frontend/src/pages/Workflows/WorkflowContainer.js
@@ -48,12 +48,12 @@ class WorkflowContainer extends Component {
     super(props);
     const path = props.location.pathname.split("/");
     this.projectId = path[2];
-    this.subProjectId = path[3];
+    this.subprojectId = path[3];
   }
 
   componentDidMount() {
-    this.props.setSelectedView(this.subProjectId, "subProject");
-    this.props.fetchAllSubprojectDetails(this.projectId, this.subProjectId, true);
+    this.props.setSelectedView(this.subprojectId, "subProject");
+    this.props.fetchAllSubprojectDetails(this.projectId, this.subprojectId, true);
     this.props.fetchUser();
   }
 
@@ -66,16 +66,16 @@ class WorkflowContainer extends Component {
   closeSubproject = () => {
     const openWorkflowItems = this.props.workflowItems.find(wItem => wItem.data.status === "open");
     if (!openWorkflowItems) {
-      this.props.closeSubproject(this.projectId, this.subProjectId);
+      this.props.closeSubproject(this.projectId, this.subprojectId);
     }
   };
 
-  closeWorkflowItem = wId => this.props.closeWorkflowItem(this.projectId, this.subProjectId, wId);
+  closeWorkflowItem = wId => this.props.closeWorkflowItem(this.projectId, this.subprojectId, wId);
 
-  closeSubproject = () => this.props.closeSubproject(this.projectId, this.subProjectId, true);
+  closeSubproject = () => this.props.closeSubproject(this.projectId, this.subprojectId, true);
 
   update = () => {
-    this.props.updateSubProject(this.projectId, this.subProjectId);
+    this.props.updateSubProject(this.projectId, this.subprojectId);
   };
 
   addLiveUpdates = () => {
@@ -92,6 +92,8 @@ class WorkflowContainer extends Component {
         <div style={globalStyles.innerContainer}>
           <SubProjectDetails
             {...this.props}
+            projectId={this.projectId}
+            subprojectId={this.subprojectId}
             canViewPermissions={canViewPermissions}
             canAssignSubproject={canAssignSubproject}
             closeSubproject={this.closeSubproject}
@@ -99,12 +101,12 @@ class WorkflowContainer extends Component {
           />
 
           {this.props.permissionDialogShown ? (
-            <WorkflowItemPermissionsContainer projectId={this.projectId} subProjectId={this.subProjectId} />
+            <WorkflowItemPermissionsContainer projectId={this.projectId} subProjectId={this.subprojectId} />
           ) : null}
           <Workflow
             {...this.props}
             projectId={this.projectId}
-            subProjectId={this.subProjectId}
+            subProjectId={this.subprojectId}
             closeWorkflowItem={this.closeWorkflowItem}
           />
           <WorkflowDialogContainer location={this.props.location} />
@@ -114,8 +116,8 @@ class WorkflowContainer extends Component {
             hideAdditionalData={this.props.hideWorkflowitemAdditionalData}
             {...this.props}
           />
-          <SubprojectHistoryDrawer projectId={this.projectId} subprojectId={this.subProjectId} />
-          <WorkflowBatchEditContainer projectId={this.projectId} subProjectId={this.subProjectId} />
+          <SubprojectHistoryDrawer projectId={this.projectId} subprojectId={this.subprojectId} />
+          <WorkflowBatchEditContainer projectId={this.projectId} subProjectId={this.subprojectId} />
         </div>
       </div>
     );


### PR DESCRIPTION
### Description
If a user does not have the permission to see all workflowitems for all subprojects, the project analytics screen displays the message "Insufficient permissions". This is somewhat correct, since in this case the allocated and disbursed amount cannot be calculated. Since there are other values available on the permissions screen it would be a better UI experience if only the values that cannot be calculated are disabled or "redacted".

### Solution
- If the user has insufficient permission (redaceted workflowitems) only the total budget will be displayed. 
- The feature to convert the budget into the different currencies is also available without these permissions. 
- The insufficient permissions warning is shown below the total budget with an improved style.