### PR TITLE
Danger: Add check for .only keyword in e2e-tests

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -98,6 +98,14 @@ if (
     warn("There are new console logs in the API!");
   }
 
+  // Warn if there were only keyword added in the e2e-test
+  const e2etestChanges = await getChanges("e2e-test/cypress/integration/*.js");
+  const { additions: e2etestAdditions } = getContentByType(e2etestChanges);
+
+  if (e2etestAdditions.some(addition => addition.includes(".only"))) {
+    warn("The '.only' keyword was added to the e2e-tests");
+  }
+
   const allChanges = await getChanges("**/*");
   const { additions: allAdditions } = getContentByType(allChanges);
 

--- a/e2e-test/cypress/integration/project_permissions_spec.js
+++ b/e2e-test/cypress/integration/project_permissions_spec.js
@@ -16,7 +16,7 @@ describe("Project Permissions", function() {
   beforeEach(function() {
     cy.login();
     cy.visit(`/projects`);
-    permissionsBeforeTesting = { project: {}, subproject: {} };
+    permissionsBeforeTesting = { project: {} };
     cy.listProjectPermissions(projectId).then(permissions => {
       permissionsBeforeTesting.project = permissions;
       resetUser(testUser.id, permissions);
@@ -283,16 +283,6 @@ describe("Project Permissions", function() {
     changePermissionInGui("project.intent.revokePermission", testUser.id);
     cy.get("[data-test=permission-submit]").click();
     actionTableIncludes("view permissions");
-
-    // Reset permissions
-    Cypress.Promise.all([
-      cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.intent.revokePermission", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.intent.grantPermission", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.intent.listPermissions", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.assign", testUser.id)
-    ]);
   });
 
   it("Confirmation of multiple grant permission changes grants permissions correctly", function() {
@@ -307,7 +297,7 @@ describe("Project Permissions", function() {
     cy.get("[data-test=actions-table-body]").should("be.visible");
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
-      .should("be.not.disabled")
+      .should("be.not.disabled", { timeout: 30000 })
       .click();
     cy.get("[data-test=permission-submit]").should("not.be.visible");
     cy.get("[data-test=loading-indicator]")

--- a/e2e-test/cypress/integration/project_permissions_spec.js
+++ b/e2e-test/cypress/integration/project_permissions_spec.js
@@ -251,7 +251,7 @@ describe("Project Permissions", function() {
       .should("have.length", 3);
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
-      .should("be.not.disabled")
+      .should("not.be.disabled", { timeout: 30000 })
       .then(() => {
         checkPermissionsEquality(addViewPermissions(permissionsBeforeTesting, testUser.id), projectId);
       });
@@ -311,7 +311,8 @@ describe("Project Permissions", function() {
       .click();
     cy.get("[data-test=permission-submit]").should("not.be.visible");
     cy.get("[data-test=loading-indicator]")
-      .should("not.be.visible")
+      // Wait until all permissions are granted
+      .should("not.be.visible", { timeout: 30000 })
       .then(() => {
         let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
         permissions.project["project.update"].push(testUser.id);
@@ -352,7 +353,8 @@ describe("Project Permissions", function() {
         cy.get("[data-test=confirmation-dialog-confirm]").click();
         cy.get("[data-test=permission-submit]").should("not.be.visible");
         cy.get("[data-test=loading-indicator]")
-          .should("not.be.visible")
+          // Wait until all permissions are granted
+          .should("not.be.visible", { timeout: 30000 })
           .then(() => {
             // Equal permissions
             permissionsCopy.project = removePermission(permissionsCopy.project, "project.update", testUser.id);

--- a/e2e-test/cypress/integration/project_permissions_spec.js
+++ b/e2e-test/cypress/integration/project_permissions_spec.js
@@ -308,20 +308,23 @@ describe("Project Permissions", function() {
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
       .should("be.not.disabled")
-      .click()
+      .click();
+    cy.get("[data-test=permission-submit]").should("not.be.visible");
+    cy.get("[data-test=loading-indicator]")
+      .should("not.be.visible")
       .then(() => {
         let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
         permissions.project["project.update"].push(testUser.id);
         checkPermissionsEquality(permissions, projectId);
-      });
 
-    // Reset permissions
-    Cypress.Promise.all([
-      cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.update", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.intent.listPermissions", testUser.id)
-    ]);
+        // Reset permissions
+        Cypress.Promise.all([
+          cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
+          cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
+          cy.revokeProjectPermission(projectId, "project.update", testUser.id),
+          cy.revokeProjectPermission(projectId, "project.intent.listPermissions", testUser.id)
+        ]);
+      });
   });
 
   it("Confirmation of multiple revoke permission changes grants permissions correctly", function() {
@@ -348,18 +351,21 @@ describe("Project Permissions", function() {
         cy.get("[data-test=permission-submit]").click();
         cy.get("[data-test=confirmation-dialog-confirm]").click();
         cy.get("[data-test=permission-submit]").should("not.be.visible");
+        cy.get("[data-test=loading-indicator]")
+          .should("not.be.visible")
+          .then(() => {
+            // Equal permissions
+            permissionsCopy.project = removePermission(permissionsCopy.project, "project.update", testUser.id);
+            permissionsCopy.project = removePermission(permissionsCopy.project, "project.viewSummary", testUser.id);
+            permissionsCopy.project = removePermission(permissionsCopy.project, "project.viewDetails", testUser.id);
+            permissionsCopy.project = removePermission(
+              permissionsCopy.project,
+              "project.intent.listPermissions",
+              testUser.id
+            );
 
-        // Equal permissions
-        permissionsCopy.project = removePermission(permissionsCopy.project, "project.update", testUser.id);
-        permissionsCopy.project = removePermission(permissionsCopy.project, "project.viewSummary", testUser.id);
-        permissionsCopy.project = removePermission(permissionsCopy.project, "project.viewDetails", testUser.id);
-        permissionsCopy.project = removePermission(
-          permissionsCopy.project,
-          "project.intent.listPermissions",
-          testUser.id
-        );
-
-        checkPermissionsEquality(permissionsCopy, projectId);
+            checkPermissionsEquality(permissionsCopy, projectId);
+          });
       });
     });
   });

--- a/e2e-test/cypress/integration/subproject_permissions_spec.js
+++ b/e2e-test/cypress/integration/subproject_permissions_spec.js
@@ -295,22 +295,26 @@ describe("Subproject Permissions", function() {
       .click()
       .should("be.not.disabled")
       .click();
+    cy.get("[data-test=permission-submit]").should("not.be.visible");
+    cy.get("[data-test=loading-indicator]")
+      .should("not.be.visible")
+      .then(() => {
+        let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
+        permissions.subproject["subproject.update"].push(testUser.id);
+        permissions.subproject["subproject.createWorkflowitem"].push(testUser.id);
+        checkPermissionsEquality(permissions, projectId, subprojectId);
 
-    let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
-    permissions.subproject["subproject.update"].push(testUser.id);
-    permissions.subproject["subproject.createWorkflowitem"].push(testUser.id);
-    checkPermissionsEquality(permissions, projectId, subprojectId);
-
-    // Reset permissions
-    Cypress.Promise.all([
-      cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.update", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.createWorkflowitem", testUser.id)
-    ]);
+        // Reset permissions
+        Cypress.Promise.all([
+          cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
+          cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
+          cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id),
+          cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id),
+          cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testUser.id),
+          cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.update", testUser.id),
+          cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.createWorkflowitem", testUser.id)
+        ]);
+      });
   });
 
   it("Confirmation of multiple revoke permission changes grants permissions correctly", function() {
@@ -341,35 +345,39 @@ describe("Subproject Permissions", function() {
         changePermissionInGui("subproject.intent.listPermissions", testUser.id);
         cy.get("[data-test=permission-submit]").click();
         cy.get("[data-test=confirmation-dialog-confirm]").click();
+        cy.get("[data-test=permission-submit]").should("not.be.visible");
+        cy.get("[data-test=loading-indicator]")
+          .should("not.be.visible")
+          .then(() => {
+            // Equal permissions
+            permissionsCopy.subproject = removePermission(permissionsCopy.subproject, "subproject.update", testUser.id);
+            permissionsCopy.subproject = removePermission(
+              permissionsCopy.subproject,
+              "subproject.createWorkflowitem",
+              testUser.id
+            );
+            permissionsCopy.subproject = removePermission(
+              permissionsCopy.subproject,
+              "subproject.viewSummary",
+              testUser.id
+            );
+            permissionsCopy.subproject = removePermission(
+              permissionsCopy.subproject,
+              "subproject.viewDetails",
+              testUser.id
+            );
+            permissionsCopy.subproject = removePermission(
+              permissionsCopy.subproject,
+              "subproject.intent.listPermissions",
+              testUser.id
+            );
 
-        // Equal permissions
-        permissionsCopy.subproject = removePermission(permissionsCopy.subproject, "subproject.update", testUser.id);
-        permissionsCopy.subproject = removePermission(
-          permissionsCopy.subproject,
-          "subproject.createWorkflowitem",
-          testUser.id
-        );
-        permissionsCopy.subproject = removePermission(
-          permissionsCopy.subproject,
-          "subproject.viewSummary",
-          testUser.id
-        );
-        permissionsCopy.subproject = removePermission(
-          permissionsCopy.subproject,
-          "subproject.viewDetails",
-          testUser.id
-        );
-        permissionsCopy.subproject = removePermission(
-          permissionsCopy.subproject,
-          "subproject.intent.listPermissions",
-          testUser.id
-        );
+            checkPermissionsEquality(permissionsCopy, projectId, subprojectId);
 
-        checkPermissionsEquality(permissionsCopy, projectId, subprojectId);
-
-        // Reset permissions
-        cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id);
-        cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id);
+            // Reset permissions
+            cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id);
+            cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id);
+          });
       });
     });
   });

--- a/e2e-test/cypress/integration/subproject_permissions_spec.js
+++ b/e2e-test/cypress/integration/subproject_permissions_spec.js
@@ -247,7 +247,7 @@ describe("Subproject Permissions", function() {
       .should("have.length", 5);
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
-      .should("be.not.disabled");
+      .should("not.be.disabled", { timeout: 30000 })
 
     checkPermissionsEquality(addViewPermissions(permissionsBeforeTesting, testUser.id), projectId, subprojectId);
 
@@ -297,7 +297,8 @@ describe("Subproject Permissions", function() {
       .click();
     cy.get("[data-test=permission-submit]").should("not.be.visible");
     cy.get("[data-test=loading-indicator]")
-      .should("not.be.visible")
+      .// Wait until all permissions are granted
+      .should("not.be.visible", { timeout: 30000 })
       .then(() => {
         let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
         permissions.subproject["subproject.update"].push(testUser.id);
@@ -347,7 +348,8 @@ describe("Subproject Permissions", function() {
         cy.get("[data-test=confirmation-dialog-confirm]").click();
         cy.get("[data-test=permission-submit]").should("not.be.visible");
         cy.get("[data-test=loading-indicator]")
-          .should("not.be.visible")
+          // Wait until all permissions are granted
+          .should("not.be.visible", { timeout: 30000 })
           .then(() => {
             // Equal permissions
             permissionsCopy.subproject = removePermission(permissionsCopy.subproject, "subproject.update", testUser.id);

--- a/e2e-test/cypress/integration/subproject_permissions_spec.js
+++ b/e2e-test/cypress/integration/subproject_permissions_spec.js
@@ -248,8 +248,9 @@ describe("Subproject Permissions", function() {
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
       .should("not.be.disabled", { timeout: 30000 })
-
-    checkPermissionsEquality(addViewPermissions(permissionsBeforeTesting, testUser.id), projectId, subprojectId);
+      .then(() => {
+        checkPermissionsEquality(addViewPermissions(permissionsBeforeTesting, testUser.id), projectId, subprojectId);
+      });
 
     // Reset permissions
     Cypress.Promise.all([
@@ -293,11 +294,11 @@ describe("Subproject Permissions", function() {
     cy.get("[data-test=actions-table-body]").should("be.visible");
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
-      .should("be.not.disabled")
+      .should("be.not.disabled", { timeout: 30000 })
       .click();
     cy.get("[data-test=permission-submit]").should("not.be.visible");
     cy.get("[data-test=loading-indicator]")
-      .// Wait until all permissions are granted
+      // Wait until all permissions are granted
       .should("not.be.visible", { timeout: 30000 })
       .then(() => {
         let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);

--- a/e2e-test/cypress/integration/workflowitem_permissions_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_permissions_spec.js
@@ -291,14 +291,15 @@ describe("Workflowitem Permissions", function() {
       .should("have.length", 6);
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
-      .should("not.be.disabled", { timeout: 30000 });
-
-    assertUnchangedPermissions(
-      addViewPermissions(permissionsBeforeTesting, testUser.id),
-      projectId,
-      subprojectId,
-      workflowitemId
-    );
+      .should("not.be.disabled", { timeout: 30000 })
+      .then(() => {
+        assertUnchangedPermissions(
+          addViewPermissions(permissionsBeforeTesting, testUser.id),
+          projectId,
+          subprojectId,
+          workflowitemId
+        );
+      });
 
     // Reset permissions
     Cypress.Promise.all([
@@ -347,7 +348,7 @@ describe("Workflowitem Permissions", function() {
     cy.get("[data-test=actions-table-body]").should("be.visible");
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
-      .should("be.not.disabled")
+      .should("be.not.disabled", { timeout: 30000 })
       .click();
     cy.get("[data-test=permission-submit]").should("not.be.visible");
     cy.get("[data-test=loading-indicator]")

--- a/e2e-test/cypress/integration/workflowitem_permissions_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_permissions_spec.js
@@ -349,20 +349,24 @@ describe("Workflowitem Permissions", function() {
       .click()
       .should("be.not.disabled")
       .click();
+    cy.get("[data-test=permission-submit]").should("not.be.visible");
+    cy.get("[data-test=loading-indicator]")
+      .should("not.be.visible")
+      .then(() => {
+        let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
+        permissions.workflowitem["workflowitem.update"].push(testUser.id);
+        assertUnchangedPermissions(permissions, projectId, subprojectId, workflowitemId);
 
-    let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
-    permissions.workflowitem["workflowitem.update"].push(testUser.id);
-    assertUnchangedPermissions(permissions, projectId, subprojectId, workflowitemId);
-
-    // Reset permissions
-    Cypress.Promise.all([
-      cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id),
-      cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, listPermIntent, testUser.id),
-      cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.update", testUser.id)
-    ]);
+        // Reset permissions
+        Cypress.Promise.all([
+          cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
+          cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
+          cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id),
+          cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id),
+          cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, listPermIntent, testUser.id),
+          cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.update", testUser.id)
+        ]);
+      });
   });
 
   it("Confirmation of multiple revoke permission changes grants permissions correctly", function() {
@@ -397,23 +401,31 @@ describe("Workflowitem Permissions", function() {
         changePermissionInGui(listPermIntent, testUser.id);
         cy.get("[data-test=permission-submit]").click();
         cy.get("[data-test=confirmation-dialog-confirm]").click();
+        cy.get("[data-test=permission-submit]").should("not.be.visible");
+        cy.get("[data-test=loading-indicator]")
+          .should("not.be.visible")
+          .then(() => {
+            // Equal permissions
+            permissionsCopy.workflowitem = removePermission(
+              permissionsCopy.workflowitem,
+              "workflowitem.update",
+              testUser.id
+            );
+            permissionsCopy.workflowitem = removePermission(
+              permissionsCopy.workflowitem,
+              "workflowitem.view",
+              testUser.id
+            );
+            permissionsCopy.workflowitem = removePermission(permissionsCopy.workflowitem, listPermIntent, testUser.id);
 
-        // Equal permissions
-        permissionsCopy.workflowitem = removePermission(
-          permissionsCopy.workflowitem,
-          "workflowitem.update",
-          testUser.id
-        );
-        permissionsCopy.workflowitem = removePermission(permissionsCopy.workflowitem, "workflowitem.view", testUser.id);
-        permissionsCopy.workflowitem = removePermission(permissionsCopy.workflowitem, listPermIntent, testUser.id);
+            assertUnchangedPermissions(permissionsCopy, projectId, subprojectId, workflowitemId);
 
-        assertUnchangedPermissions(permissionsCopy, projectId, subprojectId, workflowitemId);
-
-        // Reset permissions
-        cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id);
-        cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id);
-        cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id);
-        cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id);
+            // Reset permissions
+            cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id);
+            cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id);
+            cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id);
+            cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id);
+          });
       });
     });
   });

--- a/e2e-test/cypress/integration/workflowitem_permissions_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_permissions_spec.js
@@ -291,7 +291,7 @@ describe("Workflowitem Permissions", function() {
       .should("have.length", 6);
     cy.get("[data-test=confirmation-dialog-confirm]")
       .click()
-      .should("be.not.disabled");
+      .should("not.be.disabled", { timeout: 30000 });
 
     assertUnchangedPermissions(
       addViewPermissions(permissionsBeforeTesting, testUser.id),
@@ -351,7 +351,8 @@ describe("Workflowitem Permissions", function() {
       .click();
     cy.get("[data-test=permission-submit]").should("not.be.visible");
     cy.get("[data-test=loading-indicator]")
-      .should("not.be.visible")
+      // Wait until all permissions are granted
+      .should("not.be.visible", { timeout: 30000 })
       .then(() => {
         let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
         permissions.workflowitem["workflowitem.update"].push(testUser.id);
@@ -403,7 +404,8 @@ describe("Workflowitem Permissions", function() {
         cy.get("[data-test=confirmation-dialog-confirm]").click();
         cy.get("[data-test=permission-submit]").should("not.be.visible");
         cy.get("[data-test=loading-indicator]")
-          .should("not.be.visible")
+          // Wait until all permissions are granted
+          .should("not.be.visible", { timeout: 30000 })
           .then(() => {
             // Equal permissions
             permissionsCopy.workflowitem = removePermission(

--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -72,7 +72,7 @@ Cypress.Commands.add("addUser", (username, userId, password, organization = "KfW
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body));
+    .then(body => Cypress.Promise.resolve(body));
 });
 
 Cypress.Commands.add("fetchProjects", () => {
@@ -84,7 +84,7 @@ Cypress.Commands.add("fetchProjects", () => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data.items));
+    .then(body => Cypress.Promise.resolve(body.data.items));
 });
 
 Cypress.Commands.add("fetchSubprojects", projectId => {
@@ -96,7 +96,7 @@ Cypress.Commands.add("fetchSubprojects", projectId => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data.subprojects));
+    .then(body => Cypress.Promise.resolve(body.data.subprojects));
 });
 
 Cypress.Commands.add("createWorkflowitem", (projectId, subprojectId, displayName, opts = { amountType: "N/A" }) => {
@@ -118,7 +118,7 @@ Cypress.Commands.add("createWorkflowitem", (projectId, subprojectId, displayName
   })
     .its("body")
     .then(body =>
-      Promise.resolve({
+      Cypress.Promise.resolve({
         id: body.data.workflowitem.id
       })
     );
@@ -147,7 +147,7 @@ Cypress.Commands.add(
     })
       .its("body")
       .then(body =>
-        Promise.resolve({
+        Cypress.Promise.resolve({
           id: body.data.project.id
         })
       );
@@ -170,7 +170,7 @@ Cypress.Commands.add("updateProjectAssignee", (projectId, identity) => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("createSubproject", (projectId, displayName, currency = "EUR", opts = {}) => {
@@ -194,7 +194,7 @@ Cypress.Commands.add("createSubproject", (projectId, displayName, currency = "EU
   })
     .its("body")
     .then(body =>
-      Promise.resolve({
+      Cypress.Promise.resolve({
         id: body.data.subproject.id
       })
     );
@@ -217,7 +217,7 @@ Cypress.Commands.add("grantProjectPermission", (projectId, intent, identity) => 
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("revokeProjectPermission", (projectId, intent, identity) => {
@@ -237,7 +237,7 @@ Cypress.Commands.add("revokeProjectPermission", (projectId, intent, identity) =>
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("grantSubprojectPermission", (projectId, subprojectId, intent, identity) => {
@@ -258,7 +258,7 @@ Cypress.Commands.add("grantSubprojectPermission", (projectId, subprojectId, inte
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("revokeSubprojectPermission", (projectId, subprojectId, intent, identity) => {
@@ -279,7 +279,7 @@ Cypress.Commands.add("revokeSubprojectPermission", (projectId, subprojectId, int
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("grantWorkflowitemPermission", (projectId, subprojectId, workflowitemId, intent, identity) => {
@@ -301,7 +301,7 @@ Cypress.Commands.add("grantWorkflowitemPermission", (projectId, subprojectId, wo
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("revokeWorkflowitemPermission", (projectId, subprojectId, workflowitemId, intent, identity) => {
@@ -323,7 +323,7 @@ Cypress.Commands.add("revokeWorkflowitemPermission", (projectId, subprojectId, w
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("updateSubprojectPermissions", (projectId, subprojectId, intent, identity) => {
@@ -344,7 +344,7 @@ Cypress.Commands.add("updateSubprojectPermissions", (projectId, subprojectId, in
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("grantUserPermissions", (userId, intent, identity) => {
@@ -364,7 +364,7 @@ Cypress.Commands.add("grantUserPermissions", (userId, intent, identity) => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("revokeUserPermissions", (userId, intent, identity) => {
@@ -384,7 +384,7 @@ Cypress.Commands.add("revokeUserPermissions", (userId, intent, identity) => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("closeProject", projectId => {
@@ -402,7 +402,7 @@ Cypress.Commands.add("closeProject", projectId => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 Cypress.Commands.add("closeWorkflowitem", (projectId, subprojectId, workflowitemId) => {
   cy.request({
@@ -421,7 +421,7 @@ Cypress.Commands.add("closeWorkflowitem", (projectId, subprojectId, workflowitem
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 
 Cypress.Commands.add("getUserList", () => {
@@ -433,7 +433,7 @@ Cypress.Commands.add("getUserList", () => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data.items));
+    .then(body => Cypress.Promise.resolve(body.data.items));
 });
 
 Cypress.Commands.add("listProjectPermissions", projectId => {
@@ -445,7 +445,7 @@ Cypress.Commands.add("listProjectPermissions", projectId => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 Cypress.Commands.add("listSubprojectPermissions", (projectId, subprojectId) => {
   cy.request({
@@ -456,7 +456,7 @@ Cypress.Commands.add("listSubprojectPermissions", (projectId, subprojectId) => {
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });
 Cypress.Commands.add("listWorkflowitemPermissions", (projectId, subprojectId, workflowitemId) => {
   cy.request({
@@ -467,5 +467,5 @@ Cypress.Commands.add("listWorkflowitemPermissions", (projectId, subprojectId, wo
     }
   })
     .its("body")
-    .then(body => Promise.resolve(body.data));
+    .then(body => Cypress.Promise.resolve(body.data));
 });

--- a/frontend/src/pages/Loading/RefreshIndicator.js
+++ b/frontend/src/pages/Loading/RefreshIndicator.js
@@ -33,7 +33,15 @@ const styles = {
 const Refresh = props => (
   <div style={styles.container}>
     <div style={styles.refreshContainer}>
-      <CircularProgress size={50} left={0} top={0} percentage={50} color="primary" style={styles.refresh} />
+      <CircularProgress
+        data-test="loading-indicator"
+        size={50}
+        left={0}
+        top={0}
+        percentage={50}
+        color="primary"
+        style={styles.refresh}
+      />
     </div>
   </div>
 );


### PR DESCRIPTION
### Description
During creation of e2e tests it is common to use the keyword it.only to run one specific test. To avoid that this it.only is not pushed into the repository there should be a warning if the keyword is part of an e2e-test file.

### Additional Changes
Currently the icons of the e2e-test message in every PR are not suitable.

#### Current:

:warning: e2e tests started
:heavy_check_mark: e2e tests successful
:x: e2e tests failed

#### Suggestion:

:grey_exclamation: e2e tests started
:white_check_mark: e2e tests successful
:x: e2e tests failed

Closes #385 
Closes #383 