### PR TITLE
UI: Currencies and number format depends on language now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # Changelog
 
-## [Unreleased]
+### Unreleased
 
 <!-- ### Added -->
 
@@ -17,7 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- UI: Remember language after logout [#420](https://github.com/openkfw/TruBudget/issues/420)
+
+### Changed
+
+- UI: Format currencies and numbers according to the selected language or locale [#135](https://github.com/openkfw/TruBudget/issues/135)
 
 <!-- ### Security -->
 

--- a/e2e-test/cypress/integration/currencies_spec.js
+++ b/e2e-test/cypress/integration/currencies_spec.js
@@ -1,9 +1,6 @@
-const currencies = {
-  EUR: { symbol: "€", format: "%v %s" },
-  USD: { symbol: "$", format: "%s %v" },
-  BRL: { symbol: "R$", format: "%s %v" },
-  XOF: { symbol: "CFA", format: "%s %v" }
-};
+import { languages } from "../support/helper";
+import { currencies } from "../support/helper";
+import { toAmountString } from "../support/helper";
 
 const currenciesArray = Object.keys(currencies);
 const standardBudget = [
@@ -14,7 +11,7 @@ const standardBudget = [
   }
 ];
 
-describe("Overview Page", function() {
+describe("Describe Currencies", function() {
   beforeEach(function() {
     cy.login();
     cy.visit(`/projects`);
@@ -55,14 +52,25 @@ describe("Overview Page", function() {
   });
 
   it("Sets the currency of a new project to EUR and checks if the Euro sign is displayed", function() {
-    cy.createProject("Test", "Test", standardBudget);
-
-    //Fetch projects to get newest one
-    cy.reload();
-
     cy.get("[data-test*=project-card]")
       .last()
       .find("[data-test=project-budget]")
       .should("contain", currencies.EUR.symbol);
+  });
+
+  it("Checking format for Value and currency Symbol of all languages", function() {
+    cy.visit(`/`);
+    languages.forEach(languageElement => {
+      cy.login("mstein", "test", { language: languageElement });
+      cy.visit(`/projects`);
+
+      //get last Project (standardBudget)
+      cy.get("[data-test*=project-card]")
+        .last()
+        .find("[data-test=project-budget]")
+        .get("span")
+        .should("be.visible")
+        .should("contain", toAmountString(standardBudget.currencyCode, standardBudget.value, languageElement));
+    });
   });
 });

--- a/e2e-test/cypress/integration/language_spec.js
+++ b/e2e-test/cypress/integration/language_spec.js
@@ -1,0 +1,32 @@
+import { languages } from "../support/helper";
+
+describe("Language", function() {
+  beforeEach(function() {
+    cy.visit(`/`);
+  });
+
+  it(`Check if language is still selected after logout`, function() {
+    languages.forEach(languageElement => {
+      cy.login("mstein", "test", { language: languageElement });
+      cy.visit(`/projects`);
+      cy.get("[data-test=navbar-logout-button]")
+        .should("be.visible")
+        .click();
+
+      // Check if last selected language is now preselected
+      cy.get("[data-test=loginpage]").should("be.visible");
+      cy.get("[data-test=dropdown-language_selection]").should("be.visible");
+      cy.get("[data-test=dropdown-language_selection]")
+        .click()
+        .focused()
+        .click();
+      cy.get("[data-test=dropdown_selectList]").should("be.visible");
+      // Old language should have been preselected already ([tabindex=0] means preselected)
+      cy.get("[data-test=dropdown_selectList]")
+        .find("[tabindex*=0]")
+        .first()
+        .invoke("attr", "data-value")
+        .should("eq", languageElement);
+    });
+  });
+});

--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -24,7 +24,7 @@ const baseUrl = Cypress.env("API_BASE_URL") || "/test";
 
 let token = undefined;
 
-Cypress.Commands.add("login", (username = "mstein", password = "test") => {
+Cypress.Commands.add("login", (username = "mstein", password = "test", opts = { language: "en-gb" }) => {
   cy.request({
     url: `${baseUrl}/api/user.authenticate`, // assuming you've exposed a seeds route
     method: "POST",
@@ -40,11 +40,11 @@ Cypress.Commands.add("login", (username = "mstein", password = "test") => {
           jwt: body.data.user.token,
           environment: "Test",
           productionActive: false,
-          language: "en-gb",
           id: body.data.user.id,
           displayName: body.data.user.displayName,
           organization: body.data.user.organization,
-          allowedIntents: body.data.user.allowedIntents
+          allowedIntents: body.data.user.allowedIntents,
+          ...opts
         }
       };
       localStorage.setItem("state", JSON.stringify(state));

--- a/e2e-test/cypress/support/helper.js
+++ b/e2e-test/cypress/support/helper.js
@@ -1,33 +1,37 @@
+import accounting from "accounting";
 import _isString from "lodash/isString";
 
-import accounting from "accounting";
-
-const numberFormat = {
-  decimal: ".",
-  thousand: ",",
-  precision: 2
+export const currencies = {
+  EUR: { symbol: "€" },
+  USD: { symbol: "$" },
+  BRL: { symbol: "R$" },
+  XOF: { symbol: "CFA" },
+  DKK: { symbol: "kr." }
 };
 
-const currencies = {
-  EUR: { symbol: "€", format: "%v %s" },
-  USD: { symbol: "$", format: "%s %v" },
-  BRL: { symbol: "R$", format: "%s %v" },
-  XOF: { symbol: "CFA", format: "%s %v" },
-  DKK: { symbol: "kr.", format: "%v %s" }
+export const languages = ["en-gb", "fr", "pt", "de"];
+
+const getFormat = (currency, language) => {
+  switch (language) {
+    case "en-gb":
+      return { format: "%s %v", ...currencies[currency], decimal: ".", thousand: ",", precision: 2 };
+    case "fr":
+    case "pt":
+    case "de":
+      return { format: "%v %s", ...currencies[currency], decimal: ".", thousand: ",", precision: 2 };
+    default:
+      return { format: "%s %v", ...currencies[currency], decimal: ".", thousand: ",", precision: 2 };
+  }
 };
 
-const getCurrencyFormat = currency => ({
-  ...numberFormat,
-  ...currencies[currency]
-});
-
-export function toAmountString(amount, currency) {
+export function toAmountString(amount, currency, language = "en") {
   if (_isString(amount) && amount.trim().length <= 0) {
     return "";
   }
+  const format = getFormat(currency, language);
   if (!currency) {
-    return accounting.formatNumber(amount, numberFormat.precision, numberFormat.thousand, numberFormat.decimal);
+    return accounting.formatNumber(amount, format);
+  } else {
+    return accounting.formatMoney(amount, format);
   }
-
-  return accounting.formatMoney(amount, getCurrencyFormat(currency));
 }

--- a/frontend/src/currency.js
+++ b/frontend/src/currency.js
@@ -1,12 +1,15 @@
 // These are the currencies that are available in the frontend
 // If there is a new currency added, please make sure to also add it to the list of currencies in the end-to-end test
 // See ../e2e-test/currencies_spec.js
+
+import strings from "./localizeStrings.js";
+
 const currencies = {
-  EUR: { symbol: "€", format: "%v %s" },
-  USD: { symbol: "$", format: "%s %v" },
-  BRL: { symbol: "R$", format: "%s %v" },
-  XOF: { symbol: "CFA", format: "%s %v" },
-  DKK: { symbol: "kr.", format: "%v %s" }
+  EUR: { symbol: "€", format: strings.format.numberFormat },
+  USD: { symbol: "$", format: strings.format.numberFormat },
+  BRL: { symbol: "R$", format: strings.format.numberFormat },
+  XOF: { symbol: "CFA", format: strings.format.numberFormat },
+  DKK: { symbol: "kr.", format: strings.format.numberFormat }
 };
 
 export default currencies;

--- a/frontend/src/helper.js
+++ b/frontend/src/helper.js
@@ -9,15 +9,8 @@ import _isEqual from "lodash/isEqual";
 import _isString from "lodash/isString";
 import _isUndefined from "lodash/isUndefined";
 import React from "react";
-
 import currencies from "./currency";
 import strings from "./localizeStrings";
-
-const numberFormat = {
-  decimal: ".",
-  thousand: ",",
-  precision: 2
-};
 
 export const toJS = WrappedComponent => wrappedComponentProps => {
   const KEY = 0;
@@ -34,8 +27,9 @@ export const toJS = WrappedComponent => wrappedComponentProps => {
 };
 
 const getCurrencyFormat = currency => ({
-  ...numberFormat,
-  ...currencies[currency]
+  ...strings.format.numberFormat,
+  ...currencies[currency],
+  format: strings.format.currencyPositon
 });
 
 export const compareObjects = (items, itemToAdd) => {
@@ -80,7 +74,12 @@ export const toAmountString = (amount, currency) => {
     return "";
   }
   if (!currency) {
-    return accounting.formatNumber(amount, numberFormat.precision, numberFormat.thousand, numberFormat.decimal);
+    return accounting.formatNumber(
+      amount,
+      strings.format.numberFormat.precision,
+      strings.format.numberFormat.thousand,
+      strings.format.numberFormat.decimal
+    );
   }
 
   return accounting.formatMoney(amount, getCurrencyFormat(currency));

--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -1,4 +1,12 @@
 const en = {
+  format: {
+    currencyPositon: "%s %v",
+    numberFormat: {
+      decimal: ".",
+      thousand: ",",
+      precision: 2
+    }
+  },
   common: {
     action: "Action",
     actions: "Actions",

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -1,4 +1,12 @@
 const fr = {
+  format: {
+    currencyPositon: "%v %s",
+    numberFormat: {
+      decimal: ",",
+      thousand: ".",
+      precision: 2
+    }
+  },
   common: {
     action: "Action",
     actions: "Actions",

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -1,4 +1,12 @@
 const de = {
+  format: {
+    currencyPositon: "%v %s",
+    numberFormat: {
+      decimal: ",",
+      thousand: ".",
+      precision: 2
+    }
+  },
   common: {
     action: "German: Action",
     actions: "Actions",

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -1,4 +1,12 @@
 const pt = {
+  format: {
+    currencyPositon: "%v %s",
+    numberFormat: {
+      decimal: ",",
+      thousand: ".",
+      precision: 2
+    }
+  },
   common: {
     action: "Ação",
     actions: "Ações",

--- a/frontend/src/pages/Common/NewDropdown.js
+++ b/frontend/src/pages/Common/NewDropdown.js
@@ -30,6 +30,11 @@ class Dropdown extends React.Component {
               name: id,
               id
             }}
+            MenuProps={{
+              MenuListProps: {
+                "data-test": "dropdown_selectList"
+              }
+            }}
             SelectDisplayProps={{ "data-test": `dropdown-${id}-click`, "data-disabled": disabled }}
           >
             {children}

--- a/frontend/src/pages/Login/reducer.js
+++ b/frontend/src/pages/Login/reducer.js
@@ -114,7 +114,7 @@ export default function loginReducer(state = defaultState, action) {
       return newState;
     case ADMIN_LOGOUT_SUCCESS:
     case LOGOUT_SUCCESS:
-      return defaultState;
+      return defaultState.set("language", state.get("language"));
     default:
       return state;
   }

--- a/frontend/src/reducers.js
+++ b/frontend/src/reducers.js
@@ -1,6 +1,6 @@
 /**
  * Combine all reducers in this file and export the combined reducers.
- * If we were to do this in store.js, reducers wouldn't be hot reloadable.
+ * If we were doing this in store.js, reducers wouldn't be hot reloadable.
  */
 
 import { connectRouter, LOCATION_CHANGE } from "connected-react-router";


### PR DESCRIPTION
Description
Currencies and values should be formatted according to selected language The format includes the position of currency-symbol (before or after value) and the point/comma for thousands/decimal. #135

Furthermore, the set language should be preselected after logging out. #420 

Solution
Added formatting in each language js file:
```
en: 
decimal: ".", thousand: ","
symbol left, value right (eg: € 1,000.00)

de, fr, pt: 
decimal: ",", thousand: "."
symbol right, value left (eg: 1.000,00 €)
```
In action "LOGOUT" the current language is set to the next state 

