### PR TITLE
ui: Fix typo in language selection

### DIFF
--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -479,7 +479,7 @@ const en = {
     french: "French",
     german: "German",
     portuguese: "Portuguese",
-    georgian: "Gerogian"
+    georgian: "Georgian"
   }
 };
 


### PR DESCRIPTION
Fix a typo in the language selection, where "Georgian" is written as
"Gerogian".

Closes #432 