### PR TITLE
e2e-test: stabilize tests

### DIFF
--- a/e2e-test/cypress/integration/documents_spec.js
+++ b/e2e-test/cypress/integration/documents_spec.js
@@ -3,13 +3,15 @@ import "cypress-file-upload";
 let projectId;
 let subprojectId;
 let workflowitemId;
+let baseUrl, apiRoute;
 // Actual file in fixture folder
 const fileName = "documents_test.json";
 
 describe("Attaching a document to a workflowitem.", function() {
   before(() => {
+    baseUrl = Cypress.env("API_BASE_URL") || `${Cypress.config("baseUrl")}/test`;
+    apiRoute = baseUrl.toLowerCase().includes("test") ? "/test/api" : "/api";
     cy.login();
-
     cy.createProject("documents test project", "workflowitem documents test", [])
       .then(({ id }) => {
         projectId = id;
@@ -32,13 +34,19 @@ describe("Attaching a document to a workflowitem.", function() {
 
   const uploadDocument = (fileDisplayName, fileName) => {
     // open edit dialog:
-    cy.get("div[title=Edit] > button").click();
+    cy.get("div[title=Edit] > button")
+      .should("be.visible")
+      .click();
 
     // click "next" button:
-    cy.get("[data-test=next]").click();
+    cy.get("[data-test=next]")
+      .should("be.visible")
+      .click();
 
     // enter the file name:
-    cy.get("#documentnameinput").type(fileDisplayName);
+    cy.get("#documentnameinput")
+      .should("be.visible")
+      .type(fileDisplayName);
 
     // "upload" the file:
     cy.fixture(fileName).then(fileContent => {
@@ -52,15 +60,28 @@ describe("Attaching a document to a workflowitem.", function() {
 
   it("A document can be validated.", function() {
     const fileDisplayName = "Validation_Test";
+    cy.server();
+    cy.route("POST", apiRoute + "/workflowitem.update*").as("update");
+    cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
+    cy.route("POST", apiRoute + "/workflowitem.validate*").as("validate");
+
     uploadDocument(fileDisplayName, fileName);
     // submit and close the dialog:
-    cy.get("[data-test=submit]").click();
+    cy.get("[data-test=submit]")
+      .should("be.visible")
+      .click();
 
     // open the info dialog window:
-    cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
+    cy.wait("@update")
+      .wait("@viewDetails")
+      .get(`[data-test^='workflowitem-info-button-${workflowitemId}']`)
+      .should("be.visible")
+      .click();
 
     // go to the documents tab:
-    cy.get("[data-test=workflowitem-documents-tab]").click();
+    cy.get("[data-test=workflowitem-documents-tab]")
+      .should("be.visible")
+      .click();
 
     // upload the same file, for validation:
     cy.fixture(fileName).then(fileContent => {
@@ -71,23 +92,37 @@ describe("Attaching a document to a workflowitem.", function() {
     });
 
     // make sure the validation was successful:
-    cy.get("[data-test=workflowitem-documents-tab]").click();
-    cy.get(`button[label="Validated!"] > span`).should("contain", "OK");
+    cy.wait("@validate")
+      .get(`button[label="Validated!"] > span`)
+      .should("contain", "OK");
   });
 
   it("Validation of wrong document fails.", function() {
     const fileDisplayName = "Wrong_Document_Test";
+    cy.server();
+    cy.route("POST", apiRoute + "/workflowitem.update*").as("update");
+    cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
+    cy.route("POST", apiRoute + "/workflowitem.validate*").as("validate");
+
     uploadDocument(fileDisplayName, fileName);
     // submit and close the dialog:
-    cy.get("[data-test=submit]").click();
+    cy.get("[data-test=submit]")
+      .should("be.visible")
+      .click();
 
     // open the info dialog window:
-    cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
+    cy.wait("@update")
+      .wait("@viewDetails")
+      .get(`[data-test^='workflowitem-info-button-${workflowitemId}']`)
+      .should("be.visible")
+      .click();
 
     // go to the documents tab:
-    cy.get("[data-test=workflowitem-documents-tab]").click();
+    cy.get("[data-test=workflowitem-documents-tab]")
+      .should("be.visible")
+      .click();
 
-    // make sure the validation fails with the wrong document
+    // upload wrong document
     const wrongFileName = "testdata.json";
     cy.fixture(wrongFileName).then(fileContent => {
       cy.get("#docvalidation").upload(
@@ -97,7 +132,8 @@ describe("Attaching a document to a workflowitem.", function() {
     });
 
     // make sure the validation was not successful:
-    cy.get("[data-test=workflowitem-documents-tab]").click();
-    cy.get(`button[label="Changed!"] > span`).should("contain", "Not OK");
+    cy.wait("@validate")
+      .get(`button[label="Changed!"] > span`)
+      .should("contain", "Not OK");
   });
 });

--- a/e2e-test/cypress/integration/global_permissions_spec.js
+++ b/e2e-test/cypress/integration/global_permissions_spec.js
@@ -1,17 +1,18 @@
 const testUserName = "globalPermissionTestUser";
 const testUserNamePassword = "test1234";
+let baseUrl, apiRoute;
 
 describe("Users/Groups Dashboard", function() {
   before(() => {
+    baseUrl = Cypress.env("API_BASE_URL") || `${Cypress.config("baseUrl")}/test`;
+    apiRoute = baseUrl.toLowerCase().includes("test") ? "/test/api" : "/api";
     cy.login("root", "root-secret");
     cy.getUserList().then(userList => {
       const userIds = userList.map(user => user.id);
       if (!userIds.includes(testUserName)) {
-        cy.addUser(testUserName, testUserName, testUserNamePassword);
+        cy.addUser(testUserName, testUserName, testUserNamePassword, "DevOrga");
       }
     });
-    cy.login(testUserName, testUserNamePassword);
-    cy.visit("/users");
   });
 
   beforeEach(function() {
@@ -20,21 +21,34 @@ describe("Users/Groups Dashboard", function() {
   });
 
   it("Display the global permission dialog correctly", function() {
-    cy.reload();
-    cy.get(`[data-test=edit-user-permissions-${testUserName}]`).click();
+    cy.get(`[data-test=edit-user-permissions-${testUserName}]`)
+      .should("be.visible")
+      .click();
     cy.get("[data-test=global-permissions-dialog]").should("be.visible");
-    cy.get("[data-test=cancel]").click();
   });
 
-  it("Grant and revoke permission to user", function() {
-    cy.get(`[data-test=edit-user-permissions-${testUserName}]`).click();
+  it("Grant and revoke permission to user works", function() {
+    cy.server();
+    cy.route("POST", apiRoute + "/global.grantPermission*").as("grantPermission");
+    cy.route("POST", apiRoute + "/global.revokePermission*").as("revokePermission");
+    cy.route("GET", apiRoute + "/global.listPermissions*").as("listPermissions");
+    cy.route("GET", apiRoute + "/user.list*").as("userlist");
+    cy.visit("/users");
+    cy.wait("@userlist")
+      .get(`[data-test=edit-user-permissions-${testUserName}]`)
+      .should("be.visible")
+      .click();
     cy.get("[data-test=global-permissions-dialog]").should("be.visible");
 
     cy.get("[data-test='permission-global.createUser'] input").should("not.be.checked");
     cy.get("[data-test='permission-global.createUser']").click();
+    cy.get("[data-test='permission-global.createUser'] input").should("be.checked");
     cy.get("[data-test=submit]").click();
 
-    cy.get(`[data-test=edit-user-permissions-${testUserName}]`).click();
+    cy.wait("@grantPermission")
+      .wait("@listPermissions")
+      .get(`[data-test=edit-user-permissions-${testUserName}]`)
+      .click();
     cy.get("[data-test=global-permissions-dialog]").should("be.visible");
     cy.get("[data-test='permission-global.createUser'] input").should("be.checked");
 
@@ -43,27 +57,33 @@ describe("Users/Groups Dashboard", function() {
     cy.get("[data-test=submit]").click();
 
     // Check if permission was removed
-    cy.get(`[data-test=edit-user-permissions-${testUserName}]`).click();
+    cy.wait("@revokePermission")
+      .wait("@listPermissions")
+      .get(`[data-test=edit-user-permissions-${testUserName}]`)
+      .click();
     cy.get("[data-test=global-permissions-dialog]").should("be.visible");
     cy.get("[data-test='permission-global.createUser'] input").should("not.be.checked");
   });
 
   it("After clicking 'cancel', the selection is not adopted", function() {
-    cy.get(`[data-test=user-${testUserName}]`).should("be.visible");
-    cy.get(`[data-test=edit-user-permissions-${testUserName}]`)
+    cy.server();
+    cy.route("GET", apiRoute + "/user.list*").as("userlist");
+    cy.visit("/users");
+    cy.wait("@userlist")
+      .get(`[data-test=edit-user-permissions-${testUserName}]`)
       .should("be.visible")
       .click();
     cy.get("[data-test=global-permissions-dialog]").should("be.visible");
 
     cy.get("[data-test='permission-global.createUser'] input").should("not.be.checked");
     cy.get("[data-test='permission-global.createUser']").click();
+    cy.get("[data-test='permission-global.createUser'] input").should("be.checked");
     cy.get("[data-test=cancel]").click();
 
-    cy.get(`[data-test=edit-user-permissions-${testUserName}]`).click();
+    cy.get(`[data-test=edit-user-permissions-${testUserName}]`)
+      .should("be.visible")
+      .click();
     cy.get("[data-test=global-permissions-dialog]").should("be.visible");
     cy.get("[data-test='permission-global.createUser'] input").should("not.be.checked");
-
-    // Restore state to make the test re-runnable
-    cy.get("[data-test=cancel]").click();
   });
 });

--- a/e2e-test/cypress/integration/global_permissions_spec.js
+++ b/e2e-test/cypress/integration/global_permissions_spec.js
@@ -10,7 +10,7 @@ describe("Users/Groups Dashboard", function() {
     cy.getUserList().then(userList => {
       const userIds = userList.map(user => user.id);
       if (!userIds.includes(testUserName)) {
-        cy.addUser(testUserName, testUserName, testUserNamePassword, "DevOrga");
+        cy.addUser(testUserName, testUserName, testUserNamePassword, "KfW");
       }
     });
   });

--- a/e2e-test/cypress/integration/project_close_spec.js
+++ b/e2e-test/cypress/integration/project_close_spec.js
@@ -1,0 +1,85 @@
+describe("Project Close", function() {
+  let projectId;
+  let subprojectId;
+
+  before(() => {
+    cy.login();
+    cy.createProject("p-close", "project close test").then(({ id }) => {
+      projectId = id;
+    });
+  });
+
+  beforeEach(function() {
+    cy.login();
+    cy.visit("/projects/" + projectId);
+  });
+
+  it("When closing the project, a dialog pops up", function() {
+    cy.get("[data-test=pc-button]").should("be.visible");
+
+    // // Close subproject
+    // cy.get("[data-test=spc-button]").click();
+    // cy.get("[data-test=confirmation-dialog]").should("be.visible");
+    // cy.get("[data-test=confirmation-dialog-confirm]").click();
+    // cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+    // cy.get("[data-test=spc-button]").should("not.be.visible");
+
+    // cy.visit(`/projects/${projectId}`);
+    // cy.get("[data-test=pc-button]").should("be.enabled");
+
+    // Cancel closing the project
+    cy.get("[data-test=pc-button]").click();
+    cy.get("[data-test=confirmation-dialog]").should("be.visible");
+    cy.get("[data-test=confirmation-dialog-cancel]").click();
+    cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+
+    // // Close project
+    // cy.get("[data-test=pc-button]").click();
+    // cy.get("[data-test=confirmation-dialog]").should("be.visible");
+    // cy.get("[data-test=confirmation-dialog-confirm]").click();
+    // cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+    // cy.get("[data-test=pc-button]").should("not.be.visible");
+  });
+
+  it("Closing a project with open subprojects is not possible", function() {
+    cy.createSubproject(projectId, "subproject assign test").then(() => {
+      cy.visit("/projects/" + projectId);
+      cy.get("[data-test=pc-button]").should("be.disabled");
+    });
+  });
+
+  it("Closing a project including closed subprojects is possible", function() {
+    cy.createProject("p-close", "project close test").then(({ id }) => {
+      projectId = id;
+      cy.createSubproject(id, "subproject assign test").then(({ id }) => {
+        subprojectId = id;
+        cy.visit("/projects/" + projectId);
+        cy.get("[data-test=pc-button]").should("be.disabled");
+        cy.visit("/projects/" + projectId + "/" + subprojectId);
+
+        // Close subproject
+        cy.get("[data-test=spc-button]").click();
+        cy.get("[data-test=confirmation-dialog]").should("be.visible");
+        cy.get("[data-test=confirmation-dialog-confirm]").click();
+        cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+        cy.get("[data-test=spc-button]").should("not.be.visible");
+
+        cy.visit(`/projects/${projectId}`);
+        cy.get("[data-test=pc-button]").should("be.enabled");
+
+        // Cancel closing the project
+        cy.get("[data-test=pc-button]").click();
+        cy.get("[data-test=confirmation-dialog]").should("be.visible");
+        cy.get("[data-test=confirmation-dialog-cancel]").click();
+        cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+
+        // Close project
+        cy.get("[data-test=pc-button]").click();
+        cy.get("[data-test=confirmation-dialog]").should("be.visible");
+        cy.get("[data-test=confirmation-dialog-confirm]").click();
+        cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+        cy.get("[data-test=pc-button]").should("not.be.visible");
+      });
+    });
+  });
+});

--- a/e2e-test/cypress/integration/subproject_permissions_spec.js
+++ b/e2e-test/cypress/integration/subproject_permissions_spec.js
@@ -1,60 +1,82 @@
 import _cloneDeep from "lodash/cloneDeep";
 
 const executingUser = { id: "mstein", displayname: "Mauro Stein" };
-const testUser = { id: "thouse", displayname: "Tom House" };
-const testGroupId = "admins";
-const groupToGivePermissions = "reviewers";
+const testUser = { id: "thouse", displayname: "Tom House", password: "test" };
+const testUser2 = { id: "jxavier", displayname: "Jane Xavier", password: "test" };
+const testGroup = { id: "admins", displayname: "Admins" };
 let projectId, subprojectId, permissionsBeforeTesting, baseUrl, apiRoute;
 const subprojectDisplayname = "subproject assign test";
+const rootSecret = "root-secret";
 
 describe("Subproject Permissions", function() {
   before(() => {
     baseUrl = Cypress.env("API_BASE_URL") || `${Cypress.config("baseUrl")}/test`;
     apiRoute = baseUrl.toLowerCase().includes("test") ? "/test/api" : "/api";
-
-    cy.login();
-    cy.createProject("p-subp-assign", "subproject assign test").then(({ id }) => {
-      projectId = id;
-      cy.createSubproject(projectId, subprojectDisplayname).then(({ id }) => {
-        subprojectId = id;
-      });
-    });
   });
 
   beforeEach(function() {
     cy.login();
-    cy.visit(`/projects/${projectId}`);
-    permissionsBeforeTesting = { project: {}, subproject: {} };
-    cy.listProjectPermissions(projectId).then(permissions => {
-      permissionsBeforeTesting.project = permissions;
-    });
-    cy.listSubprojectPermissions(projectId, subprojectId).then(permissions => {
-      permissionsBeforeTesting.subproject = permissions;
-      resetUser(testUser.id, permissions);
+    cy.createProject("p-subp-permissions", "subproject permissions test").then(({ id }) => {
+      projectId = id;
+      cy.createSubproject(projectId, subprojectDisplayname).then(({ id }) => {
+        subprojectId = id;
+        permissionsBeforeTesting = { project: {}, subproject: {} };
+        cy.listProjectPermissions(projectId).then(permissions => {
+          permissionsBeforeTesting.project = permissions;
+        });
+        cy.listSubprojectPermissions(projectId, subprojectId).then(permissions => {
+          permissionsBeforeTesting.subproject = permissions;
+        });
+        cy.visit(`/projects/${projectId}`);
+      });
     });
   });
 
-  function resetUser(userId, permissions) {
-    const intentsToRevoke = Object.keys(permissions).filter(intent => permissions[intent].includes(userId));
-    intentsToRevoke.forEach(intent => cy.revokeProjectPermission(projectId, intent, userId));
+  function alphabeticalSort(a, b) {
+    const stringA = a.toUpperCase();
+    const stringB = b.toUpperCase();
+    if (stringA < stringB) {
+      return -1;
+    }
+    if (stringA > stringB) {
+      return 1;
+    }
+    return 0;
+  }
+
+  function sortPermissionsObject(permissions) {
+    for (const intent in permissions) {
+      if (permissions.hasOwnProperty(intent)) {
+        const identities = permissions[intent];
+        permissions[intent] = identities.sort(alphabeticalSort);
+      }
+    }
+    return permissions;
   }
 
   function assertUnchangedPermissions(permissionsBeforeTesting, projectId, subprojectId) {
+    permissionsBeforeTesting.project = sortPermissionsObject(permissionsBeforeTesting.project);
+    permissionsBeforeTesting.subproject = sortPermissionsObject(permissionsBeforeTesting.subproject);
     cy.listProjectPermissions(projectId).then(permissions => {
-      expect(permissions).to.deep.equal(permissionsBeforeTesting.project);
+      expect(sortPermissionsObject(permissions)).to.deep.equal(permissionsBeforeTesting.project);
     });
     cy.listSubprojectPermissions(projectId, subprojectId).then(permissions => {
-      expect(permissions).to.deep.equal(permissionsBeforeTesting.subproject);
+      expect(sortPermissionsObject(permissions)).to.deep.equal(permissionsBeforeTesting.subproject);
     });
   }
 
-  function addViewPermissions(permissions, identity) {
+  /**
+   * @param {boolean} listPermIncluded    If set to true subproject.intent.listPermissions is also added
+   */
+  function addViewPermissions(permissions, identity, listPermIncluded = true) {
     const permissionsCopy = _cloneDeep(permissions);
     addPermission(permissionsCopy.project, "project.viewSummary", identity);
     addPermission(permissionsCopy.project, "project.viewDetails", identity);
     addPermission(permissionsCopy.subproject, "subproject.viewSummary", identity);
     addPermission(permissionsCopy.subproject, "subproject.viewDetails", identity);
-    addPermission(permissionsCopy.subproject, "subproject.intent.listPermissions", identity);
+    if (listPermIncluded) {
+      addPermission(permissionsCopy.subproject, "subproject.intent.listPermissions", identity);
+    }
     return permissionsCopy;
   }
 
@@ -62,37 +84,12 @@ describe("Subproject Permissions", function() {
     permissions[intent].push(identity);
     return permissions;
   }
-  function removePermission(permissions, intent, identity) {
-    permissions[intent] = permissions[intent].filter(id => {
-      return id !== identity;
-    });
-    return permissions;
-  }
-
-  function changePermissionInGui(intent, identity) {
-    cy.get(`[data-test='permission-select-${intent}']`).click();
-    cy.get("[data-test=permission-list]")
-      .find(`li[value*='${identity}']`)
-      .click()
-      .type("{esc}");
-  }
-
-  function actionTableIncludes(permissionText) {
-    cy.get("[data-test=actions-table-body]")
-      .should("be.visible")
-      .children()
-      .should("have.length", 5)
-      .find("td")
-      .contains(permissionText)
-      .should("have.length", 1);
-  }
-
-  function filterPermissionsById(permissions, id) {
-    return Object.keys(permissions).filter(intent => permissions[intent].includes(id));
-  }
 
   it("Show subproject permissions correctly", function() {
-    cy.get("[data-test=spp-button-0]").click();
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
     cy.get("[data-test=view-list]")
       .should("be.visible")
       .children()
@@ -115,105 +112,172 @@ describe("Subproject Permissions", function() {
   });
 
   it("Canceling the permission dialog doesn't revoke nor grant permissions ", function() {
-    cy.get("[data-test=spp-button-0]").click();
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
     cy.get("[data-test=permission-close]").click();
+    cy.get("[data-test=permission-container]").should("not.be.visible");
     assertUnchangedPermissions(permissionsBeforeTesting, projectId, subprojectId);
   });
 
   it("Submitting the permission dialog without any changes doesn't revoke nor grant permissions and close the dialog", function() {
-    cy.get("[data-test=spp-button-0]").click();
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
+    // Open confirmation
+    cy.get("[data-test=permission-submit]")
+      .should("be.visible")
+      .click();
     cy.get("[data-test=permission-container]").should("not.be.visible");
     assertUnchangedPermissions(permissionsBeforeTesting, projectId, subprojectId);
   });
 
   it("Submitting the permission dialog after adding a user opens a confirmation dialog", function() {
-    cy.get("[data-test=spp-button-0]").click();
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
+    // Open permission search popup
     cy.get("[data-test='permission-select-subproject.intent.grantPermission']").click();
+    // Select and add a User
     cy.get("[data-test='permission-list']")
+      .should("be.visible")
       .find(`li[value*='${testUser.id}']`)
-      .click()
+      .click();
+    // Close permission search popup
+    cy.get("[data-test=permission-search] input")
+      .should("be.visible")
       .type("{esc}");
+    cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
+    // Open confirmation
     cy.get("[data-test=confirmation-dialog-cancel]").should("be.visible");
   });
 
   it("Submitting the permission dialog after removing a user opens a confirmation dialog", function() {
-    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id);
-    cy.get("[data-test=spp-button-0]").click();
-    cy.get("[data-test='permission-select-subproject.viewSummary']").click();
-    cy.get("[data-test='permission-list']")
-      .find(`li[value*='${testUser.id}']`)
-      .click()
-      .type("{esc}");
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    cy.get("[data-test=confirmation-dialog-cancel]").should("be.visible");
-    cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id);
+    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id).then(() => {
+      cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+      cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+        .should("be.visible")
+        .click();
+      // Open permission search popup
+      cy.get("[data-test='permission-select-subproject.viewSummary']").click();
+      // Select and add a User
+      cy.get("[data-test='permission-list']")
+        .should("be.visible")
+        .find(`li[value*='${testUser.id}']`)
+        .click();
+      // Close permission search popup
+      cy.get("[data-test=permission-search] input")
+        .should("be.visible")
+        .type("{esc}");
+      cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+      cy.get("[data-test=permission-submit]").click();
+      // Open confirmation
+      cy.get("[data-test=confirmation-dialog-cancel]").should("be.visible");
+    });
   });
 
   it("Submitting the permission dialog without subproject.intent.grantPermission disables the submit button when adding user", function() {
-    cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser.id);
-
-    cy.get("[data-test=spp-button-0]").click();
-    // Add permission
-    changePermissionInGui("subproject.intent.grantPermission", testUser.id);
-    cy.get("[data-test=permission-submit]").should("be.disabled");
-    // Remove permission
-    changePermissionInGui("subproject.intent.grantPermission", testUser.id);
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    cy.get("[data-test=confirmation-dialog-cancel]").should("not.be.visible");
-
-    // Reset permissions
-    cy.login("root", "root-secret");
-    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser.id);
+    cy.login("root", rootSecret);
+    cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser.id).then(
+      () => {
+        // Mstein login
+        cy.login();
+        cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+        cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+          .should("be.visible")
+          .click();
+        // Open permission search popup
+        cy.get("[data-test='permission-select-subproject.intent.grantPermission']").click();
+        // Select and add a User
+        cy.get("[data-test='permission-list']")
+          .should("be.visible")
+          .find(`li[value*='${testUser.id}']`)
+          .click();
+        // Close permission search popup
+        cy.get("[data-test=permission-search] input")
+          .should("be.visible")
+          .type("{esc}");
+        cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+        cy.get("[data-test=permission-submit]").should("be.disabled");
+      }
+    );
   });
 
   it("Submitting the permission dialog without subproject.intent.revokePermission disables the submit button when removing user", function() {
-    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", testUser.id);
-    cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.revokePermission", executingUser.id);
-
-    cy.get("[data-test=spp-button-0]").click();
-    // Remove permission
-    changePermissionInGui("subproject.intent.grantPermission", testUser.id);
-    cy.get("[data-test=permission-submit]").should("be.disabled");
-    // Add permission
-    changePermissionInGui("subproject.intent.grantPermission", testUser.id);
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    cy.get("[data-test=confirmation-dialog-cancel]").should("not.be.visible");
-
-    // Reset permissions
-    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.revokePermission", executingUser.id);
-    cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", testUser.id);
+    cy.login("root", rootSecret);
+    // Grant test User view-permission
+    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id).then(() => {
+      // Revoke revoke-permission from mstein
+      cy.revokeSubprojectPermission(
+        projectId,
+        subprojectId,
+        "subproject.intent.revokePermission",
+        executingUser.id
+      ).then(() => {
+        // Mstein login
+        cy.login();
+        cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+        cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+          .should("be.visible")
+          .click();
+        // Open permission search popup
+        cy.get("[data-test='permission-select-subproject.viewSummary']").click();
+        // Select and remove a User
+        cy.get("[data-test='permission-list']")
+          .should("be.visible")
+          .find(`li[value*='${testUser.id}']`)
+          .click();
+        // Close permission search popup
+        cy.get("[data-test=permission-search] input")
+          .should("be.visible")
+          .type("{esc}");
+        cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+        cy.get("[data-test=permission-submit]").should("be.disabled");
+      });
+    });
   });
 
   it("User having 'view permissions'- permission only can view but not grant/revoke permissions", function() {
-    cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser.id);
-    cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.revokePermission", executingUser.id);
-
-    cy.get("[data-test=spp-button-0]").click();
-    cy.get(`[data-test='permission-select-subproject.viewDetails']`).click();
-    cy.get("[data-test=read-only-permissions-text]").should("be.visible");
-    cy.get("[data-test=permission-list]")
-      .find(`li[value*='${testUser.id}']`)
-      .find("input")
-      .should("be.disabled");
-
-    cy.login("root", "root-secret");
-    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser.id);
-    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.revokePermission", executingUser.id);
+    cy.login("root", rootSecret);
+    // Grant test User view-permission
+    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id).then(() => {
+      cy.grantProjectPermission(projectId, "project.viewDetails", testUser.id).then(() => {
+        // Test user login
+        cy.login(testUser.id, testUser.password);
+        cy.visit(`/projects/${projectId}`);
+        cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+        cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+          .should("have.css", "opacity", "0")
+          .should("be.disabled");
+      });
+    });
   });
 
-  it("Granting update permissions views 4 additional permissions needed", function() {
-    cy.get("[data-test=spp-button-0]").click();
-    // Add permission
-    changePermissionInGui("subproject.update", testUser.id);
+  it("Granting update permissions views 4 additional view permissions needed", function() {
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
+    // Open permission search popup
+    cy.get("[data-test='permission-select-subproject.update']")
+      .scrollIntoView()
+      .should("be.visible")
+      .click();
+    // Select and add a User
+    cy.get("[data-test='permission-list']")
+      .should("be.visible")
+      .find(`li[value*='${testUser.id}']`)
+      .click();
+    // Close permission search popup
+    cy.get("[data-test=permission-search] input")
+      .should("be.visible")
+      .type("{esc}");
+    cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
+    // Open confirmation
     cy.get("[data-test=actions-table-body]")
       .should("be.visible")
       .children()
@@ -221,266 +285,295 @@ describe("Subproject Permissions", function() {
   });
 
   it("Granting revoke permissions views 5 additional permissions needed including 'view permission'-permissions", function() {
-    cy.get("[data-test=spp-button-0]").click();
-    // Add permission
-    changePermissionInGui("subproject.intent.revokePermission", testUser.id);
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    actionTableIncludes("view permissions");
-  });
-
-  it("Granting view permissions doesn't additionally view the same permission", function() {
-    cy.grantProjectPermission(projectId, "project.viewDetails", testUser.id);
-    cy.grantProjectPermission(projectId, "project.viewSummary", testUser.id);
-
-    cy.get("[data-test=spp-button-0]").click();
-    // Add permission
-    changePermissionInGui("subproject.viewDetails", testUser.id);
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    cy.get("[data-test=actions-table-body]")
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
       .should("be.visible")
-      .children()
-      .should("have.length", 1)
-      .find("td")
-      .contains("view summary")
-      .should("have.length", 1);
-
-    //Reset permissions
-    cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id);
-    cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id);
-  });
-
-  it("Executing additional actions grant permissions correctly", function() {
-    cy.get("[data-test=spp-button-0]").click();
-    // Add permission
-    changePermissionInGui("subproject.intent.revokePermission", testUser.id);
+      .click();
+    // Open permission search popup
+    cy.get("[data-test='permission-select-subproject.intent.revokePermission']").click();
+    // Select and add a User
+    cy.get("[data-test='permission-list']")
+      .should("be.visible")
+      .find(`li[value*='${testUser.id}']`)
+      .click();
+    // Close permission search popup
+    cy.get("[data-test=permission-search] input")
+      .should("be.visible")
+      .type("{esc}");
+    cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+    // Open confirmation
     cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    // listPermissions calls are done
     cy.get("[data-test=actions-table-body]")
       .should("be.visible")
       .children()
       .should("have.length", 5);
-    // Make sure cypress waits for future listPermissions calls
+  });
+
+  it("Granting view permissions doesn't additionally view the same permission", function() {
+    // Grant test User project view-permission
+    cy.grantProjectPermission(projectId, "project.viewSummary", testUser.id).then(() => {
+      cy.grantProjectPermission(projectId, "project.viewDetails", testUser.id).then(() => {
+        // Mstein login
+        cy.login();
+        cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+        cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+          .should("be.visible")
+          .click();
+        // Open permission search popup
+        cy.get("[data-test='permission-select-subproject.viewDetails']").click();
+        // Select and add test user
+        cy.get("[data-test='permission-list']")
+          .should("be.visible")
+          .find(`li[value*='${testUser.id}']`)
+          .click();
+        // Close permission search popup
+        cy.get("[data-test=permission-search] input")
+          .should("be.visible")
+          .type("{esc}");
+        cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+        cy.get("[data-test=permission-submit]").click();
+        // Confirmation opens
+        cy.get("[data-test=actions-table-body]")
+          .should("be.visible")
+          .children()
+          .should("have.length", 1)
+          .find("td")
+          .contains("view summary")
+          .should("have.length", 1);
+      });
+    });
+  });
+
+  it("Executing additional actions grant permissions correctly", function() {
     cy.server();
     cy.route("GET", apiRoute + "/project.intent.listPermissions*").as("listProjectPermissions");
     cy.route("GET", apiRoute + "/subproject.intent.listPermissions*").as("listSubprojectPermissions");
-    cy.get("[data-test=confirmation-dialog-confirm]").click();
-    cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"]);
-    assertUnchangedPermissions(addViewPermissions(permissionsBeforeTesting, testUser.id), projectId, subprojectId);
 
-    // Reset permissions
-    Cypress.Promise.all([
-      cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testUser.id)
-    ]);
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
+    // Open permission search popup
+    cy.wait("@listSubprojectPermissions")
+      .get("[data-test='permission-select-subproject.intent.revokePermission']")
+      .click();
+    // Select and add a User
+    cy.get("[data-test='permission-list']")
+      .should("be.visible")
+      .find(`li[value*='${testUser.id}']`)
+      .click();
+    // Close permission search popup
+    cy.get("[data-test=permission-search] input")
+      .should("be.visible")
+      .type("{esc}");
+    cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+    // Open confirmation
+    cy.get("[data-test=permission-submit]").click();
+    cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"])
+      .get("[data-test=actions-table-body]")
+      .should("be.visible")
+      .children()
+      .should("have.length", 5);
+    cy.get("[data-test=confirmation-dialog-confirm]")
+      .should("be.visible")
+      .click();
+
+    // Check permissions has changed
+    cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"]);
+    // Permissions before testing equal the current permission + viewPermissions
+    assertUnchangedPermissions(addViewPermissions(permissionsBeforeTesting, testUser.id), projectId, subprojectId);
   });
 
-  it("Executing additional actions as normal user extended through group permissions", function() {
+  it("User with grant permission inherited by a group can grant a permission", function() {
+    cy.server();
+    cy.route("GET", apiRoute + "/project.intent.listPermissions*").as("listProjectPermissions");
+    cy.route("GET", apiRoute + "/subproject.intent.listPermissions*").as("listSubprojectPermissions");
     Cypress.Promise.all([
       // grant permissions to testgroup
-      cy.grantProjectPermission(projectId, "project.viewSummary", testGroupId),
-      cy.grantProjectPermission(projectId, "project.viewDetails", testGroupId),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testGroupId),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testGroupId),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", testGroupId)
+      cy.grantProjectPermission(projectId, "project.viewSummary", testGroup.id),
+      cy.grantProjectPermission(projectId, "project.viewDetails", testGroup.id),
+      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testGroup.id),
+      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testGroup.id),
+      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testGroup.id),
+      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", testGroup.id)
     ]).then(() => {
-      // user from testgroup grant other group some permission
-      cy.login("jdoe", "test");
-      cy.get("[data-test=spp-button-0]").click();
-      // Add permission
-      changePermissionInGui("subproject.intent.revokePermission", groupToGivePermissions);
-      cy.get("[data-test=permission-submit]").click();
-      // Confirmation opens
-      // listPermissions calls are done
-      cy.get("[data-test=actions-table-body]")
+      // Modify permissionsBeforeTestingr regarding theprevious api calls
+      permissionsBeforeTesting.project["project.viewSummary"].push(testGroup.id);
+      permissionsBeforeTesting.project["project.viewDetails"].push(testGroup.id);
+      permissionsBeforeTesting.subproject["subproject.viewSummary"].push(testGroup.id);
+      permissionsBeforeTesting.subproject["subproject.viewDetails"].push(testGroup.id);
+      permissionsBeforeTesting.subproject["subproject.intent.listPermissions"].push(testGroup.id);
+      permissionsBeforeTesting.subproject["subproject.intent.grantPermission"].push(testGroup.id);
+      // user from testgroup grant permission to user
+      cy.login(testUser.id, testUser.password);
+      cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+      cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+        .should("be.visible")
+        .click();
+      // Open permission search popup
+      cy.wait("@listSubprojectPermissions")
+        .get("[data-test='permission-select-subproject.intent.grantPermission']")
+        .click();
+      // Select and add a User
+      cy.get("[data-test='permission-list']")
+        .should("be.visible")
+        .find(`li[value*='${testUser2.id}']`)
+        .click();
+      // Close permission search popup
+      cy.get("[data-test=permission-search] input")
+        .should("be.visible")
+        .type("{esc}");
+      cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+      cy.get("[data-test=permission-submit]")
+        .should("be.visible")
+        .click();
+      cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"])
+        .get("[data-test=actions-table-body]")
         .should("be.visible")
         .children()
         .should("have.length", 5);
-      // Make sure cypress waits for future listPermissions calls
-      cy.server();
-      cy.route("GET", apiRoute + "/project.intent.listPermissions*").as("listProjectPermissions");
-      cy.route("GET", apiRoute + "/subproject.intent.listPermissions*").as("listSubprojectPermissions");
+      // Confirm additional actions
       cy.get("[data-test=confirmation-dialog-confirm]").click();
-      cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"]);
 
-      // Reset permissions of testgroup
-      Cypress.Promise.all([
-        cy.login("mstein", "test"),
-        cy.revokeProjectPermission(projectId, "project.viewSummary", testGroupId),
-        cy.revokeProjectPermission(projectId, "project.viewDetails", testGroupId),
-        cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testGroupId),
-        cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testGroupId),
-        cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", testGroupId)
-      ]).then(() => {
-        assertUnchangedPermissions(
-          addViewPermissions(permissionsBeforeTesting, groupToGivePermissions),
-          projectId,
-          subprojectId
-        );
-      });
+      // Check permissions has changed
+      cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"]);
+      // Permissions before testing equal the previous permissions + additional actions
+      cy.login();
+      assertUnchangedPermissions(addViewPermissions(permissionsBeforeTesting, testUser2.id), projectId, subprojectId);
     });
   });
 
-  it("Granting assign/grant/revoke permissions additionally generates an action to grant 'list permissions'-permissions", function() {
-    // Check assign
-    cy.get("[data-test=spp-button-0]").click();
-    changePermissionInGui("subproject.assign", testUser.id);
+  it("Granting grant-permission permission additionally generates an action to grant list-permissions permission", function() {
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
+    // Open permission search popup
+    cy.get("[data-test='permission-select-subproject.intent.grantPermission']").click();
+    // Select and add test user
+    cy.get("[data-test='permission-list']")
+      .should("be.visible")
+      .find(`li[value*='${testUser.id}']`)
+      .click();
+    // Close permission search popup
+    cy.get("[data-test=permission-search] input")
+      .should("be.visible")
+      .type("{esc}");
+    cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     cy.get("[data-test=permission-submit]").click();
     // Confirmation opens
-    actionTableIncludes("view permissions");
-    cy.get("[data-test=confirmation-dialog-cancel]").click();
-    changePermissionInGui("subproject.assign", testUser.id);
-    // Check grant
-    changePermissionInGui("subproject.intent.grantPermission", testUser.id);
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    actionTableIncludes("view permissions");
-    cy.get("[data-test=confirmation-dialog-cancel]").click();
-    changePermissionInGui("subproject.intent.grantPermission", testUser.id);
-    // Check revoke
-    changePermissionInGui("subproject.intent.revokePermission", testUser.id);
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    actionTableIncludes("view permissions");
+    cy.get("[data-test=actions-table-body]")
+      .should("be.visible")
+      .children()
+      .should("have.length", 5)
+      .find("td")
+      .contains("view permissions")
+      .should("have.length", 1);
   });
 
   it("Confirmation of multiple grant permission changes grants permissions correctly", function() {
-    cy.get("[data-test=spp-button-0]").click();
-    // Add permissions
-    changePermissionInGui("subproject.update", testUser.id);
-    changePermissionInGui("subproject.createWorkflowitem", testUser.id);
-    changePermissionInGui("subproject.viewSummary", testUser.id);
-    changePermissionInGui("subproject.viewDetails", testUser.id);
-    changePermissionInGui("subproject.intent.listPermissions", testUser.id);
-    cy.get("[data-test=permission-submit]").click();
-    // Confirmation opens
-    cy.get("[data-test=actions-table-body]").should("be.visible");
     cy.server();
     cy.route("GET", apiRoute + "/project.intent.listPermissions*").as("listProjectPermissions");
-    cy.get("[data-test=confirmation-dialog-confirm]").click();
-    // Additional actions are executed
-    cy.wait("@listProjectPermissions");
     cy.route("GET", apiRoute + "/subproject.intent.listPermissions*").as("listSubprojectPermissions");
-    cy.get("[data-test=confirmation-dialog-confirm]")
-      .should("be.not.disabled")
+    cy.route("GET", apiRoute + "/project.viewDetails*").as("viewDetails");
+    const testIds = [testUser.id, testUser2.id, testGroup.id];
+    // Grant testUser testUser2 and admins write permissions (createWorkflowitem)
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
       .click();
-    // Original actions are executed
-    cy.get("[data-test=permission-submit]").should("not.be.visible");
-    cy.wait("@listSubprojectPermissions");
-    let permissions = addViewPermissions(permissionsBeforeTesting, testUser.id);
-    permissions.subproject["subproject.update"].push(testUser.id);
-    permissions.subproject["subproject.createWorkflowitem"].push(testUser.id);
-    assertUnchangedPermissions(permissions, projectId, subprojectId);
+    // Open permission search popup
+    cy.wait("@listSubprojectPermissions")
+      .get("[data-test='permission-select-subproject.createWorkflowitem']")
+      .should("be.visible")
+      .click();
+    // Select and add all test Identities
+    cy.wrap(testIds).each(id => {
+      cy.get("[data-test='permission-list']")
+        .should("be.visible")
+        .find(`li[value*='${id}']`)
+        .click();
+    });
+    // Close permission search popup
+    cy.get("[data-test=permission-search] input")
+      .should("be.visible")
+      .type("{esc}");
+    cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+    cy.get("[data-test=permission-submit]").click();
+    // Confirmation opens
+    cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"])
+      .get("[data-test=actions-table-body]")
+      .should("be.visible")
+      .children()
+      // 4 permissions per user/group granted
+      .should("have.length", 4 * 3);
+    // Confirm additional actions
+    cy.get("[data-test=confirmation-dialog-confirm]").click();
 
-    // Reset permissions
-    Cypress.Promise.all([
-      cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id),
-      cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.update", testUser.id),
-      cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.createWorkflowitem", testUser.id)
-    ]);
+    // Check permissions has changed
+    cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"])
+      .get("[data-test=confirmation-dialog-confirm]")
+      .click();
+    // Permissions before testing equal the previous permissions + additional actions
+    cy.wrap(testIds)
+      .each(id => {
+        permissionsBeforeTesting.subproject["subproject.createWorkflowitem"].push(id);
+        permissionsBeforeTesting = addViewPermissions(permissionsBeforeTesting, id, false);
+      })
+      .then(() => {
+        // Push identities in specific order so assertion doesn't fail
+        assertUnchangedPermissions(permissionsBeforeTesting, projectId, subprojectId);
+      });
   });
 
   it("Confirmation of multiple revoke permission changes grants permissions correctly", function() {
-    let permissionsCopy;
-    Cypress.Promise.all([
-      cy.grantProjectPermission(projectId, "project.viewSummary", testUser.id),
-      cy.grantProjectPermission(projectId, "project.viewDetails", testUser.id),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testUser.id),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testUser.id),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.update", testUser.id),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.createWorkflowitem", testUser.id)
-    ]).then(() => {
-      cy.listProjectPermissions(projectId).then(permissions => {
-        permissionsBeforeTesting.project = permissions;
-      });
-      cy.listSubprojectPermissions(projectId, subprojectId).then(permissions => {
-        permissionsBeforeTesting.subproject = permissions;
-
-        permissionsCopy = _cloneDeep(permissionsBeforeTesting);
-        cy.get("[data-test=spp-button-0]").click();
-        // Remove permissions
-        changePermissionInGui("subproject.update", testUser.id);
-        changePermissionInGui("subproject.createWorkflowitem", testUser.id);
-        changePermissionInGui("subproject.viewSummary", testUser.id);
-        changePermissionInGui("subproject.viewDetails", testUser.id);
-        changePermissionInGui("subproject.intent.listPermissions", testUser.id);
-        cy.get("[data-test=permission-submit]").click();
-        // Confirmation opens
-        cy.get("[data-test=confirmation-dialog-confirm]").should("be.visible");
-        cy.server();
-        cy.route("GET", apiRoute + "/subproject.intent.listPermissions*").as("listSubprojectPermissions");
-        cy.get("[data-test=confirmation-dialog-confirm]").click();
-        // Original actions are executed
-        cy.get("[data-test=permission-submit]").should("not.be.visible");
-        cy.wait("@listSubprojectPermissions");
-        // Equal permissions
-        permissionsCopy.subproject = removePermission(permissionsCopy.subproject, "subproject.update", testUser.id);
-        permissionsCopy.subproject = removePermission(
-          permissionsCopy.subproject,
-          "subproject.createWorkflowitem",
-          testUser.id
-        );
-        permissionsCopy.subproject = removePermission(
-          permissionsCopy.subproject,
-          "subproject.viewSummary",
-          testUser.id
-        );
-        permissionsCopy.subproject = removePermission(
-          permissionsCopy.subproject,
-          "subproject.viewDetails",
-          testUser.id
-        );
-        permissionsCopy.subproject = removePermission(
-          permissionsCopy.subproject,
-          "subproject.intent.listPermissions",
-          testUser.id
-        );
-
-        assertUnchangedPermissions(permissionsCopy, projectId, subprojectId);
-
-        // Reset permissions
-        cy.revokeProjectPermission(projectId, "project.viewSummary", testUser.id);
-        cy.revokeProjectPermission(projectId, "project.viewDetails", testUser.id);
-      });
+    cy.server();
+    cy.route("GET", apiRoute + "/project.intent.listPermissions*").as("listProjectPermissions");
+    cy.route("GET", apiRoute + "/subproject.intent.listPermissions*").as("listSubprojectPermissions");
+    const testIds = [testUser.id, testUser2.id, testGroup.id];
+    // Revoke testUser testUser2 and admins write permissions (assign)
+    // Modify permissionsBeforeTestingr regarding theprevious api calls
+    cy.wrap(testIds).each(id => {
+      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.assign", id),
+        permissionsBeforeTesting.subproject["subproject.assign"].push(id);
     });
-  });
-
-  it("Grant group Permission and test if their users have them", function() {
-    let filteredSubProjectPermissions, isSubProjectPermissionSet;
-    Cypress.Promise.all([
-      cy.grantProjectPermission(projectId, "project.viewSummary", testGroupId),
-      cy.grantProjectPermission(projectId, "project.viewDetails", testGroupId),
-      cy.grantProjectPermission(projectId, "project.intent.listPermissions", testGroupId),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", testGroupId),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testGroupId),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testGroupId),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.update", testGroupId),
-      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.createWorkflowitem", testGroupId)
-    ]).then(() => {
-      // login as group-user
-      cy.login("jdoe", "test");
-      cy.visit(`/projects`);
-
-      cy.listSubprojectPermissions(projectId, subprojectId).then(permissions => {
-        filteredSubProjectPermissions = filterPermissionsById(permissions, testGroupId);
-        isSubProjectPermissionSet =
-          filteredSubProjectPermissions.includes("subproject.viewSummary") &&
-          filteredSubProjectPermissions.includes("subproject.viewDetails") &&
-          filteredSubProjectPermissions.includes("subproject.intent.listPermissions") &&
-          filteredSubProjectPermissions.includes("subproject.update") &&
-          filteredSubProjectPermissions.includes("subproject.createWorkflowitem");
-        cy.expect(isSubProjectPermissionSet).to.equal(true);
-      });
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
+    // Open permission search popup
+    cy.wait("@listSubprojectPermissions")
+      .get("[data-test='permission-select-subproject.assign']")
+      .click();
+    // Select and add all test Identities
+    cy.wrap(testIds).each(id => {
+      cy.get("[data-test='permission-list']")
+        .should("be.visible")
+        .find(`li[value*='${id}']`)
+        .click();
     });
+    // Close permission search popup
+    cy.get("[data-test=permission-search] input")
+      .should("be.visible")
+      .type("{esc}");
+    cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
+    cy.get("[data-test=permission-submit]").click();
+    // Confirmation opens
+    cy.wait(["@listProjectPermissions", "@listSubprojectPermissions"])
+      .get("[data-test=confirmation-dialog]")
+      .should("be.visible");
+
+    // Confirm revoke permissions
+    cy.get("[data-test=confirmation-dialog-confirm]").click();
+    // Permissions before testing equal the previous permissions without assign permissions for testIds
+    cy.wrap(testIds)
+      .each(testId => {
+        permissionsBeforeTesting.subproject["subproject.assign"] = permissionsBeforeTesting.subproject[
+          "subproject.assign"
+        ].filter(id => id !== testId);
+      })
+      .then(() => {
+        assertUnchangedPermissions(permissionsBeforeTesting, projectId, subprojectId);
+      });
   });
 });

--- a/e2e-test/cypress/integration/subproject_permissions_spec.js
+++ b/e2e-test/cypress/integration/subproject_permissions_spec.js
@@ -91,6 +91,7 @@ describe("Subproject Permissions", function() {
       .should("be.visible")
       .click();
     cy.get("[data-test=view-list]")
+      .scrollIntoView()
       .should("be.visible")
       .children()
       .find("input")
@@ -143,11 +144,14 @@ describe("Subproject Permissions", function() {
     cy.get("[data-test='permission-select-subproject.intent.grantPermission']").click();
     // Select and add a User
     cy.get("[data-test='permission-list']")
+      .scrollIntoView()
       .should("be.visible")
       .find(`li[value*='${testUser.id}']`)
+      .scrollIntoView()
       .click();
     // Close permission search popup
     cy.get("[data-test=permission-search] input")
+      .scrollIntoView()
       .should("be.visible")
       .type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -166,11 +170,13 @@ describe("Subproject Permissions", function() {
       cy.get("[data-test='permission-select-subproject.viewSummary']").click();
       // Select and add a User
       cy.get("[data-test='permission-list']")
+        .scrollIntoView()
         .should("be.visible")
         .find(`li[value*='${testUser.id}']`)
         .click();
       // Close permission search popup
       cy.get("[data-test=permission-search] input")
+        .scrollIntoView()
         .should("be.visible")
         .type("{esc}");
       cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -194,11 +200,13 @@ describe("Subproject Permissions", function() {
         cy.get("[data-test='permission-select-subproject.intent.grantPermission']").click();
         // Select and add a User
         cy.get("[data-test='permission-list']")
+          .scrollIntoView()
           .should("be.visible")
           .find(`li[value*='${testUser.id}']`)
           .click();
         // Close permission search popup
         cy.get("[data-test=permission-search] input")
+          .scrollIntoView()
           .should("be.visible")
           .type("{esc}");
         cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -228,11 +236,13 @@ describe("Subproject Permissions", function() {
         cy.get("[data-test='permission-select-subproject.viewSummary']").click();
         // Select and remove a User
         cy.get("[data-test='permission-list']")
+          .scrollIntoView()
           .should("be.visible")
           .find(`li[value*='${testUser.id}']`)
           .click();
         // Close permission search popup
         cy.get("[data-test=permission-search] input")
+          .scrollIntoView()
           .should("be.visible")
           .type("{esc}");
         cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -268,11 +278,13 @@ describe("Subproject Permissions", function() {
       .click();
     // Select and add a User
     cy.get("[data-test='permission-list']")
+      .scrollIntoView()
       .should("be.visible")
       .find(`li[value*='${testUser.id}']`)
       .click();
     // Close permission search popup
     cy.get("[data-test=permission-search] input")
+      .scrollIntoView()
       .should("be.visible")
       .type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -293,11 +305,13 @@ describe("Subproject Permissions", function() {
     cy.get("[data-test='permission-select-subproject.intent.revokePermission']").click();
     // Select and add a User
     cy.get("[data-test='permission-list']")
+      .scrollIntoView()
       .should("be.visible")
       .find(`li[value*='${testUser.id}']`)
       .click();
     // Close permission search popup
     cy.get("[data-test=permission-search] input")
+      .scrollIntoView()
       .should("be.visible")
       .type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -323,11 +337,13 @@ describe("Subproject Permissions", function() {
         cy.get("[data-test='permission-select-subproject.viewDetails']").click();
         // Select and add test user
         cy.get("[data-test='permission-list']")
+          .scrollIntoView()
           .should("be.visible")
           .find(`li[value*='${testUser.id}']`)
           .click();
         // Close permission search popup
         cy.get("[data-test=permission-search] input")
+          .scrollIntoView()
           .should("be.visible")
           .type("{esc}");
         cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -359,11 +375,13 @@ describe("Subproject Permissions", function() {
       .click();
     // Select and add a User
     cy.get("[data-test='permission-list']")
+      .scrollIntoView()
       .should("be.visible")
       .find(`li[value*='${testUser.id}']`)
       .click();
     // Close permission search popup
     cy.get("[data-test=permission-search] input")
+      .scrollIntoView()
       .should("be.visible")
       .type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -416,11 +434,13 @@ describe("Subproject Permissions", function() {
         .click();
       // Select and add a User
       cy.get("[data-test='permission-list']")
+        .scrollIntoView()
         .should("be.visible")
         .find(`li[value*='${testUser2.id}']`)
         .click();
       // Close permission search popup
       cy.get("[data-test=permission-search] input")
+        .scrollIntoView()
         .should("be.visible")
         .type("{esc}");
       cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -452,11 +472,13 @@ describe("Subproject Permissions", function() {
     cy.get("[data-test='permission-select-subproject.intent.grantPermission']").click();
     // Select and add test user
     cy.get("[data-test='permission-list']")
+      .scrollIntoView()
       .should("be.visible")
       .find(`li[value*='${testUser.id}']`)
       .click();
     // Close permission search popup
     cy.get("[data-test=permission-search] input")
+      .scrollIntoView()
       .should("be.visible")
       .type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -490,12 +512,14 @@ describe("Subproject Permissions", function() {
     // Select and add all test Identities
     cy.wrap(testIds).each(id => {
       cy.get("[data-test='permission-list']")
+        .scrollIntoView()
         .should("be.visible")
         .find(`li[value*='${id}']`)
         .click();
     });
     // Close permission search popup
     cy.get("[data-test=permission-search] input")
+      .scrollIntoView()
       .should("be.visible")
       .type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
@@ -548,12 +572,14 @@ describe("Subproject Permissions", function() {
     // Select and add all test Identities
     cy.wrap(testIds).each(id => {
       cy.get("[data-test='permission-list']")
+        .scrollIntoView()
         .should("be.visible")
         .find(`li[value*='${id}']`)
         .click();
     });
     // Close permission search popup
     cy.get("[data-test=permission-search] input")
+      .scrollIntoView()
       .should("be.visible")
       .type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");

--- a/e2e-test/cypress/integration/subproject_search_spec.js
+++ b/e2e-test/cypress/integration/subproject_search_spec.js
@@ -36,6 +36,7 @@ describe("Subproject Search", function() {
     cy.get("[data-test=subproject-row]").should("be.visible");
     cy.get("[data-test=search-input]")
       .should("be.visible")
+      .click()
       .type("SearchTest");
     cy.get("[data-test=highlighted-displayname]")
       .find("mark")
@@ -52,7 +53,9 @@ describe("Subproject Search", function() {
       .find("[data-test=search-input]")
       .should("be.visible")
       .should("not.be.disabled");
-    cy.get("[data-test=search-input").type(projectWithTag.subprojectTitle);
+    cy.get("[data-test=search-input")
+      .click()
+      .type(projectWithTag.subprojectTitle);
     cy.get("[data-test=highlighted-displayname]").contains(projectWithTag.subprojectTitle);
     //Only one element should should be in the list
     cy.get("[data-test=subproject-title-0]").should("be.visible");
@@ -65,7 +68,9 @@ describe("Subproject Search", function() {
       .find("[data-test=search-bar]")
       .find("[data-test=search-input]")
       .should("be.visible");
-    cy.get("[data-test=search-input]").type("name:" + projectWithTag.subprojectTitle);
+    cy.get("[data-test=search-input]")
+      .click()
+      .type("name:" + projectWithTag.subprojectTitle);
     cy.get("[data-test=highlighted-displayname]").contains(projectWithTag.subprojectTitle);
     //Only one element should should be in the list
     cy.get("[data-test=subproject-title-0]").should("be.visible");
@@ -76,6 +81,7 @@ describe("Subproject Search", function() {
       .find("[data-test=search-input]")
       .should("be.visible");
     cy.get("[data-test=search-input]")
+      .click()
       .type("{selectall}{backspace}")
       .type("status: open");
     cy.get("[data-test=ssp-table]").contains("Open");
@@ -94,6 +100,7 @@ describe("Subproject Search", function() {
     cy.get("[data-test=sub-projects]")
       .find("[data-test=search-bar]")
       .find("[data-test=search-input]")
+      .click()
       .type("SearchTestExample");
     // Go into detail view
     cy.get("[data-test=subproject-view-details-0]").click();
@@ -112,7 +119,9 @@ describe("Subproject Search", function() {
       .find("[data-test=search-input]")
       .should("be.visible");
     // Type into search bar
-    cy.get("[data-test=search-input]").type("SearchTestExample");
+    cy.get("[data-test=search-input]")
+      .click()
+      .type("SearchTestExample");
     // Navigate via Main breadcrumb
     cy.get("[data-test=breadcrumb-Main]").click();
     // Go back to subproject view
@@ -131,7 +140,9 @@ describe("Subproject Search", function() {
       .should("be.visible")
       .should("not.be.disabled");
     // Type into search bar
-    cy.get("[data-test=search-input]").type("SearchTestExample");
+    cy.get("[data-test=search-input]")
+      .click()
+      .type("SearchTestExample");
     // Navigate via Projects breadcrumb
     cy.get("[data-test=breadcrumb-Projects]").click();
     // Go back to subproject view

--- a/e2e-test/cypress/integration/workflowitem_create_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_create_spec.js
@@ -24,10 +24,17 @@ describe("Workflowitem create", function() {
   it("When creating an allocated workflowitem, the currency is equal to the subproject's currency", function() {
     // Open create-dialog of workflow item
     cy.get("[data-test=createWorkflowitem]").click();
-    cy.get("[data-test=nameinput] input").type("Test");
-    cy.get("[data-test=datepicker-due-date]").type("2050-02-02");
+    cy.get("[data-test=creation-dialog]").should("be.visible");
+
+    cy.get("[data-test=nameinput] input")
+      .click()
+      .type("Test");
+    cy.get("[data-test=datepicker-due-date]")
+      .click()
+      .type("2050-02-02");
     cy.get("[data-test=commentinput] textarea")
       .last()
+      .click()
       .type("Test");
     cy.get("[data-test=amount-type-allocated]").click();
     cy.get("[data-test=dropdown-currencies-click]").should("contain", "EUR");
@@ -94,19 +101,28 @@ describe("Workflowitem create", function() {
     cy.get("[data-test=perm-warning-badge-disabled]").should("be.visible");
   });
 
-  it("Check if after selecting another currency, the exchange rate was entered and saved correctly", function() {
-    // The workflow item amount should be displayed in the
-    // subproject's currency
-    cy.get("[data-test=workflowitem-amount]")
-      .first()
-      .should("contain", "€");
-
-    // The information on the workflow item amount
-    // and exchange rate is displayed in a tooltip
-    cy.get("[data-test=amount-explanation]")
-      .first()
-      .should("have.attr", "title")
-      .should("contain", "$");
+  it("Show exchange rate correctly when currency of workflowitem differs from the subproject currency", function() {
+    // Create a workflow item
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem assign test", {
+      amountType: "allocated",
+      amount: "1",
+      currency: "USD",
+      exchangeRate: "1.4"
+    }).then(({ id }) => {
+      let workflowitemId = id;
+      // The workflow item amount should be displayed in the
+      // subproject's currency
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
+      cy.get("[data-test=workflowitem-amount]")
+        .first()
+        .should("contain", "€");
+      // The information on the workflow item amount
+      // and exchange rate is displayed in a tooltip
+      cy.get("[data-test=amount-explanation]")
+        .first()
+        .should("have.attr", "title")
+        .should("contain", "$");
+    });
   });
 
   it("Root can not create a Workflowitem", function() {

--- a/e2e-test/cypress/integration/workflowitem_create_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_create_spec.js
@@ -40,24 +40,36 @@ describe("Workflowitem create", function() {
   it("Check warnings that permissions are not assigned", function() {
     // Create a workflow item
     cy.get("[data-test=createWorkflowitem]").click();
-    cy.get("[data-test=nameinput] input").type("Test");
-    cy.get("[data-test=datepicker-due-date]").type("2050-02-02");
+    cy.get("[data-test=nameinput] input")
+      .should("be.visible")
+      .click()
+      .type("Test");
+    cy.get("[data-test=datepicker-due-date]")
+      .click()
+      .type("2050-02-02");
     cy.get("[data-test=commentinput] textarea")
       .last()
+      .click()
       .type("Test");
     cy.get("[data-test=amount-type-allocated]").click();
 
     // Select a different currency than the subproject currency
     cy.get("[data-test=dropdown-currencies-click]").click();
-    cy.get("[data-value=USD]").click();
+    cy.get("[data-value=USD]")
+      .should("be.visible")
+      .click();
 
     // Enter amount
-    cy.get("[data-test=amountinput] input").type("1234");
+    cy.get("[data-test=amountinput] input")
+      .click()
+      .type("1234");
 
     // The exchange rate field should be enabled because
     // we selected a different currency
     cy.get("[data-test=rateinput] input").should("be.enabled");
-    cy.get("[data-test=rateinput] input").type("1.5");
+    cy.get("[data-test=rateinput] input")
+      .click()
+      .type("1.5");
     cy.get("[data-test=next]").click();
     cy.get("[data-test=submit]").click();
 
@@ -73,14 +85,13 @@ describe("Workflowitem create", function() {
     cy.get("[data-test=workflowitem-table]")
       .find("[data-test=show-workflowitem-permissions]")
       .last()
-      .click({ force: true })
-      .then(() => {
-        cy.get("[data-test=permission-submit]")
-          .click()
-          .then(() => {
-            cy.get("[data-test=perm-warning-badge-disabled]").should("be.visible");
-          });
-      });
+      .click({ force: true });
+    cy.get("[data-test=permission-container]")
+      .should("be.visible")
+      .get("[data-test=permission-submit]")
+      .click();
+
+    cy.get("[data-test=perm-warning-badge-disabled]").should("be.visible");
   });
 
   it("Check if after selecting another currency, the exchange rate was entered and saved correctly", function() {
@@ -115,6 +126,7 @@ describe("Workflowitem create", function() {
       dueDate: "2050-03-03"
     }).then(({ id }) => {
       let workflowitemId = id;
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
       cy.get("[data-test=due-date]").should("be.visible");
       // No orange alertborder
@@ -122,13 +134,14 @@ describe("Workflowitem create", function() {
     });
   });
 
-  it("If the due-date is set and  exceeded, it should be displayed in workflowitem details with alert-border", function() {
+  it("If the due-date is set and exceeded, it should be displayed in workflowitem details with alert-border", function() {
     // Create a workflow item
     cy.createWorkflowitem(projectId, subprojectId, "workflowitem assign test", {
       amountType: "N/A",
       dueDate: "2000-03-03"
     }).then(({ id }) => {
       let workflowitemId = id;
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
       cy.get("[data-test=due-date]").should("be.visible");
       // With orange alert-border
@@ -143,6 +156,7 @@ describe("Workflowitem create", function() {
       dueDate: ""
     }).then(({ id }) => {
       let workflowitemId = id;
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
       cy.get("[data-test=due-date]").should("not.be.visible");
     });
@@ -152,6 +166,7 @@ describe("Workflowitem create", function() {
     // Create a workflow item
     cy.createWorkflowitem(projectId, subprojectId, "workflowitem assign test").then(({ id }) => {
       let workflowitemId = id;
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
       cy.get("[data-test=due-date]").should("not.be.visible");
     });
@@ -165,6 +180,7 @@ describe("Workflowitem create", function() {
     }).then(({ id }) => {
       let workflowitemId = id;
       // Check if info icon badge is displayed
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get(`[data-test^='info-warning-badge-enabled-${workflowitemId}']`).should("be.visible");
     });
   });
@@ -177,6 +193,7 @@ describe("Workflowitem create", function() {
     }).then(({ id }) => {
       let workflowitemId = id;
       // Check if info icon badge is displayed
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get(`[data-test^='info-warning-badge-enabled-${workflowitemId}']`).should("be.visible");
     });
   });
@@ -189,6 +206,7 @@ describe("Workflowitem create", function() {
     }).then(({ id }) => {
       let workflowitemId = id;
       // Check if info icon badge is NOT displayed
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get(`[data-test^='info-warning-badge-enabled-${workflowitemId}']`).should("not.be.visible");
     });
   });
@@ -200,6 +218,7 @@ describe("Workflowitem create", function() {
     }).then(({ id }) => {
       let workflowitemId = id;
       // Check if info icon badge is NOT displayed
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get(`[data-test^='info-warning-badge-enabled-${workflowitemId}']`).should("not.be.visible");
     });
   });

--- a/e2e-test/cypress/integration/workflowitem_edit_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_edit_spec.js
@@ -1,23 +1,20 @@
 describe("Workflowitem edit", function() {
   let projectId;
   let subprojectId;
+  let workflowitemId;
   let baseUrl, apiRoute;
-
-  const dueDateExceeded = "2000-01-01";
 
   before(() => {
     baseUrl = Cypress.env("API_BASE_URL") || `${Cypress.config("baseUrl")}/test`;
     apiRoute = baseUrl.toLowerCase().includes("test") ? "/test/api" : "/api";
     cy.login();
 
-    cy.createProject("workflowitem edit test project", "workflowitem edit test", [])
-      .then(({ id }) => {
-        projectId = id;
-        return cy.createSubproject(projectId, "workflowitem edit test", "EUR");
-      })
-      .then(({ id }) => {
+    cy.createProject("workflowitem edit test project", "workflowitem edit test").then(({ id }) => {
+      projectId = id;
+      cy.createSubproject(projectId, "workflowitem edit test", "EUR").then(({ id }) => {
         subprojectId = id;
       });
+    });
   });
 
   beforeEach(function() {
@@ -29,10 +26,13 @@ describe("Workflowitem edit", function() {
     "When editing a workflow item with a different currency than the subproject currency, " +
       "the selected currency is displayed",
     function() {
+      cy.server();
+      cy.route("POST", apiRoute + "/subproject.createWorkflowitem*").as("create");
+      cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
+
       // Create a workflow item and select a different currency
       cy.get("[data-test=createWorkflowitem]").click();
       cy.get("[data-test=nameinput] input").type("Test");
-      cy.get("[data-test=datepicker-due-date]").type(dueDateExceeded);
       cy.get("[data-test=commentinput] textarea")
         .last()
         .type("Test");
@@ -43,9 +43,6 @@ describe("Workflowitem edit", function() {
       cy.get("[data-test=rateinput] input").should("be.enabled");
       cy.get("[data-test=rateinput] input").type("1.5");
       cy.get("[data-test=next]").click();
-      cy.server();
-      cy.route("POST", apiRoute + "/subproject.createWorkflowitem*").as("create");
-      cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
       cy.get("[data-test=submit]").click();
 
       // Verify the selected values
@@ -59,142 +56,135 @@ describe("Workflowitem edit", function() {
         .should("have.attr", "title")
         .should("contain", "$");
 
-      // Edit the workflow item and verify that the
-      // pre-selected currency is the one we selected
-      // when the workflow item was created
+      // Open edit workflow item dialog
       cy.get("[data-test=edit-workflowitem]")
         .last()
         .click({ force: true });
+      // Verify the pre-selected currency is the one selected before
       cy.get("[data-test=dropdown-currencies-click]").should("contain", "USD");
-
-      // Close the dialog
-      cy.get("[data-test=cancel]").click();
     }
   );
   it("When the due-date is not exceeded, the info icon badge is not displayed ", function() {
-    // Edit a workflow item
-    cy.get("[data-test=edit-workflowitem]").click();
-    cy.get("[data-test=nameinput] input")
-      .clear()
-      .type("Test_changed");
-    cy.get("[data-test=datepicker-due-date]").type("2050-01-01");
-    cy.get("[data-test=commentinput] textarea")
-      .last()
-      .clear()
-      .type("Test_changed");
-    cy.get("[data-test=next]").click();
-    cy.server();
-    cy.route("POST", apiRoute + "/subproject.createWorkflowitem*").as("create");
-    cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
-    cy.get("[data-test=submit]").click();
-    // Check if info icon badge is not displayed
-    cy.get(`[data-test^='info-warning-badge-disabled-']`).should("be.visible");
-    cy.get(`[data-test^='info-warning-badge-enabled-']`).should("not.be.visible");
+    // Create a workflowitem
+    const tomorrow = getTomorrowsIsoDate();
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem edit test", {
+      dueDate: tomorrow
+    }).then(({ id }) => {
+      workflowitemId = id;
+      cy.visit(`/projects/${projectId}/${subprojectId}`);
+
+      // Check if info icon badge is displayed
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test^='info-warning-badge-disabled-']").should(
+        "be.visible"
+      );
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test^='info-warning-badge-enabled-']").should(
+        "not.be.visible"
+      );
+    });
   });
 
   it("When the due-date is exceeded, the info icon badge is displayed ", function() {
-    // Edit a workflow item
-    cy.get("[data-test=edit-workflowitem]").click();
-    cy.get("[data-test=nameinput] input")
-      .clear()
-      .type("Test_changed");
-    cy.get("[data-test=datepicker-due-date]").type(dueDateExceeded);
-    cy.get("[data-test=commentinput] textarea")
-      .last()
-      .clear()
-      .type("Test_changed");
-    cy.get("[data-test=next]").click();
-    cy.server();
-    cy.route("POST", apiRoute + "/subproject.createWorkflowitem*").as("create");
-    cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
-    cy.get("[data-test=submit]").click();
-    // Check if info icon badge is displayed
-    cy.get(`[data-test^='info-warning-badge-enabled-']`).should("be.visible");
-    cy.get(`[data-test^='info-warning-badge-disabled-']`).should("not.be.visible");
+    // Create a workflowitem
+    const yesterday = getYesterdaysIsoDate();
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem edit test", {
+      dueDate: yesterday
+    }).then(({ id }) => {
+      workflowitemId = id;
+      cy.visit(`/projects/${projectId}/${subprojectId}`);
+
+      // Check if info icon badge is displayed
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test^='info-warning-badge-disabled-']").should(
+        "not.be.visible"
+      );
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test^='info-warning-badge-enabled-']").should(
+        "be.visible"
+      );
+    });
   });
 
   it("When the due-date is set, the due-date field is pre-filled", function() {
-    // Edit last workflow item
-    cy.get("[data-test=edit-workflowitem]")
-      .last()
-      .click();
-    // Check if date is set by default
-    cy.get("[data-test=datepicker-due-date] input")
-      .invoke("val")
-      .then(date => {
-        expect(dueDateExceeded).to.equal(date);
-      });
+    // Create a workflowitem
+    const dueDate = new Date().toISOString();
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem edit test", {
+      dueDate: dueDate
+    }).then(({ id }) => {
+      workflowitemId = id;
+      cy.visit(`/projects/${projectId}/${subprojectId}`);
+      // Open edit workflow item dialog
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test=edit-workflowitem]").click();
+      // Check if date is set by default
+      cy.get("[data-test=datepicker-due-date] input")
+        .invoke("val")
+        .then(date => {
+          expect(dueDate.slice(0, 10)).to.equal(date);
+        });
+    });
   });
 
   it("When the due-date is set, the due-date can be deleted by pressing the clear-button", function() {
-    // Edit last workflow item
-    cy.get("[data-test=edit-workflowitem]")
-      .last()
-      .click();
-    // Check if date is set by default
-    cy.get("[data-test=datepicker-due-date] input")
-      .invoke("val")
-      .then(date => {
-        expect(dueDateExceeded).to.equal(date);
-      });
-    // Clear the date-picker
-    cy.get("[data-test=clear-datepicker-due-date]").click();
-    // Check if date-picker is cleared
-    cy.get("[data-test=datepicker-due-date] input")
-      .invoke("val")
-      .then(date => {
-        expect("").to.equal(date);
-      });
-    // Send to API to remove the due-date
-    cy.get("[data-test=next]").click();
-    cy.get("[data-test=submit]").click();
-    cy.server();
-    cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
-    cy.wait("@viewDetails")
-      .get("[data-test=edit-workflowitem]")
-      .last()
-      .click();
-    // Check if due-date is removed successfully
-    cy.get("[data-test=datepicker-due-date] input")
-      .invoke("val")
-      .then(date => {
-        expect("").to.equal(date);
-      });
+    // Create a workflowitem
+    const dueDate = new Date().toISOString();
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem edit test", {
+      dueDate: dueDate
+    }).then(({ id }) => {
+      workflowitemId = id;
+      cy.visit(`/projects/${projectId}/${subprojectId}`);
+      // Edit workflow item
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test=edit-workflowitem]").click();
+      // Clear the date-picker
+      cy.get("[data-test=clear-datepicker-due-date]")
+        .should("be.visible")
+        .click();
+      // Check if date-picker is cleared
+      cy.get("[data-test=datepicker-due-date] input")
+        .invoke("val")
+        .then(date => {
+          expect("").to.equal(date);
+        });
+    });
   });
 
-  // it("When closing a workflow item, a dialog pops up", function() {
-  //   // Cancel closing the workflow item
-  //   cy.get("[data-test=close-workflowitem]")
-  //     .first()
-  //     .click();
-  //   cy.get("[data-test=confirmation-dialog]").should("be.visible");
-  //   cy.get("[data-test=confirmation-dialog-cancel]").click();
-  //   cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
-
-  //   // Close the workflow item
-  //   cy.get("[data-test=close-workflowitem]")
-  //     .first()
-  //     .click();
-  //   cy.get("[data-test=confirmation-dialog]").should("be.visible");
-  //   cy.get("[data-test=confirmation-dialog-confirm]").click();
-  //   cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
-  //   cy.get("[data-test=close-workflowitem]")
-  //     .first()
-  //     .should("be.disabled");
-  // });
-
-  // it("When closing the subproject, a dialog pops up", function() {
-  //   // Cancel closing the subproject
-  //   cy.get("[data-test=spc-button]").click();
-  //   cy.get("[data-test=confirmation-dialog]").should("be.visible");
-  //   cy.get("[data-test=confirmation-dialog-cancel]").click();
-  //   cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
-
-  //   // Close the subproject
-  //   cy.get("[data-test=spc-button]").click();
-  //   cy.get("[data-test=confirmation-dialog]").should("be.visible");
-  //   cy.get("[data-test=confirmation-dialog-confirm]").click();
-  //   cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
-  //   cy.get("[data-test=spc-button]").should("not.be.visible");
-  // });
+  it("The due-date can be removed from a workflowitem", function() {
+    cy.server();
+    cy.route("POST", apiRoute + "/workflowitem.update*").as("update");
+    cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
+    // Create a workflowitem
+    const dueDate = new Date().toISOString();
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem edit test", {
+      dueDate: dueDate
+    }).then(({ id }) => {
+      workflowitemId = id;
+      cy.visit(`/projects/${projectId}/${subprojectId}`);
+      // Edit workflow item
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test=edit-workflowitem]").click();
+      // Remove the due date
+      cy.get("[data-test=clear-datepicker-due-date]")
+        .should("be.visible")
+        .click();
+      cy.get("[data-test=next]").click();
+      cy.get("[data-test=submit]")
+        .should("be.visible")
+        .click();
+      // Check if due-date is removed successfully
+      cy.wait("@update")
+        .wait("@viewDetails")
+        .get("[data-test=workflowitem-" + workflowitemId + "] [data-test*=workflowitem-info-button]")
+        .click();
+      cy.get("[data-test=due-date]").should("not.be.visible");
+    });
+  });
 });
+
+function getTomorrowsIsoDate() {
+  const today = new Date();
+  const tomorrow = new Date();
+  tomorrow.setDate(today.getDate() + 1);
+  return tomorrow.toISOString();
+}
+
+function getYesterdaysIsoDate() {
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  return yesterday.toISOString();
+}

--- a/e2e-test/cypress/integration/workflowitem_edit_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_edit_spec.js
@@ -74,6 +74,7 @@ describe("Workflowitem edit", function() {
       cy.visit(`/projects/${projectId}/${subprojectId}`);
 
       // Check if info icon badge is displayed
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test^='info-warning-badge-disabled-']").should(
         "be.visible"
       );
@@ -93,6 +94,7 @@ describe("Workflowitem edit", function() {
       cy.visit(`/projects/${projectId}/${subprojectId}`);
 
       // Check if info icon badge is displayed
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test^='info-warning-badge-disabled-']").should(
         "not.be.visible"
       );
@@ -111,6 +113,7 @@ describe("Workflowitem edit", function() {
       workflowitemId = id;
       cy.visit(`/projects/${projectId}/${subprojectId}`);
       // Open edit workflow item dialog
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test=edit-workflowitem]").click();
       // Check if date is set by default
       cy.get("[data-test=datepicker-due-date] input")
@@ -130,6 +133,7 @@ describe("Workflowitem edit", function() {
       workflowitemId = id;
       cy.visit(`/projects/${projectId}/${subprojectId}`);
       // Edit workflow item
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test=edit-workflowitem]").click();
       // Clear the date-picker
       cy.get("[data-test=clear-datepicker-due-date]")
@@ -156,6 +160,7 @@ describe("Workflowitem edit", function() {
       workflowitemId = id;
       cy.visit(`/projects/${projectId}/${subprojectId}`);
       // Edit workflow item
+      cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test=edit-workflowitem]").click();
       // Remove the due date
       cy.get("[data-test=clear-datepicker-due-date]")
@@ -168,8 +173,9 @@ describe("Workflowitem edit", function() {
       // Check if due-date is removed successfully
       cy.wait("@update")
         .wait("@viewDetails")
-        .get("[data-test=workflowitem-" + workflowitemId + "] [data-test*=workflowitem-info-button]")
-        .click();
+        .get("[data-test=workflowitem-" + workflowitemId + "]")
+        .should("be.visible");
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test*=workflowitem-info-button]").click();
       cy.get("[data-test=due-date]").should("not.be.visible");
     });
   });

--- a/e2e-test/cypress/integration/workflowitem_history_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_history_spec.js
@@ -2,6 +2,7 @@ describe("Workflowitem's history", function() {
   let projectId;
   let subprojectId;
   let workflowitemId;
+  let baseUrl, apiRoute;
 
   const yesterday = Cypress.moment()
     .add(-1, "days")
@@ -14,6 +15,8 @@ describe("Workflowitem's history", function() {
     .format("YYYY-MM-DD");
 
   before(() => {
+    baseUrl = Cypress.env("API_BASE_URL") || `${Cypress.config("baseUrl")}/test`;
+    apiRoute = baseUrl.toLowerCase().includes("test") ? "/test/api" : "/api";
     cy.login();
     cy.createProject("p-subp-assign", "workflowitem assign test").then(({ id }) => {
       projectId = id;
@@ -31,13 +34,20 @@ describe("Workflowitem's history", function() {
     cy.visit(`/projects/${projectId}/${subprojectId}`);
   });
 
-  it("The history contains only the workflowitem creation event.", function() {
+  it("The history contains only the creation event after creation.", function() {
+    cy.server();
+    cy.route("GET", apiRoute + "/workflowitem.viewHistory*").as("viewHistory");
+
+    cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
     cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
     // opens info dialog window..
-    cy.get("[data-test=workflowitem-history-tab]").click();
+    cy.get("[data-test=workflowitem-history-tab]")
+      .should("be.visible")
+      .click();
 
     // Count history items => should be one
-    cy.get("[data-test=history-list] li.history-item")
+    cy.wait("@viewHistory")
+      .get("[data-test=history-list] li.history-item")
       .first()
       .should("be.visible");
     cy.get("[data-test=history-list]")
@@ -52,28 +62,30 @@ describe("Workflowitem's history", function() {
   });
 
   it("The history is sorted from new to old", function() {
+    cy.server();
+    cy.route("GET", apiRoute + "/workflowitem.viewHistory*").as("viewHistory");
+
     // Update workflowitem to create new history event
-    cy.get(`[data-test=workflowitem-table]`)
-      .find("[data-test=edit-workflowitem]")
-      .last()
-      .click();
+    cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
+    cy.get(`[data-test=workflowitem-${workflowitemId}] [data-test=edit-workflowitem]`).click();
+    cy.get(`[data-test=creation-dialog]`).should("be.visible");
     cy.get("[data-test=nameinput] input").type("-changed");
     cy.get("[data-test=next]").click();
-    cy.get("[data-test=submit]").click();
-
-    cy.get("[data-test=workflowitem-table]")
-      .find("button[data-test^='workflowitem-info-button-']")
+    cy.get("[data-test=submit]")
+      .should("be.visible")
       .click();
-    // opens info dialog window..
+    // Open info dialog
+    cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
+    cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
     cy.get("[data-test=workflowitem-history-tab]").click();
-
     // The oldest entry is the create event
-    cy.get("[data-test=history-list]")
+    cy.wait("@viewHistory")
+      .get("[data-test=history-list]")
+      .should("be.visible")
       .find("li.history-item")
       .should("have.length", 2)
       .last()
       .should("contain", "created workflowitem");
-
     // The newest entry is the update event
     cy.get("[data-test=history-list]")
       .find("li.history-item")
@@ -82,134 +94,218 @@ describe("Workflowitem's history", function() {
   });
 
   it("When changing the tab, the history is fetched correctly", function() {
+    cy.server();
+    cy.route("GET", apiRoute + "/workflowitem.viewHistory*").as("viewHistory");
+
+    // Open info dialog
+    cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
     cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
-
-    // opens info dialog window..
-
     cy.get("[data-test=workflowitem-history-tab]").click();
 
     // Count history items => should be one
-    cy.get("[data-test=history-list] li.history-item")
+    cy.wait("@viewHistory")
+      .get("[data-test=history-list] li.history-item")
       .first()
       .should("be.visible");
 
     cy.get("[data-test=workflowitem-documents-tab]").click();
     cy.get("[data-test=workflowitem-history-tab]").click();
 
-    // Items should be visible and user should not be logged out
-    cy.get("[data-test=history-list] li.history-item")
+    // Items should be visible
+    cy.wait("@viewHistory")
+      .get("[data-test=history-list] li.history-item")
       .first()
       .should("be.visible");
   });
 
-  it("Check if history exists", function() {
-    cy.get(`[data-test=workflowitem-info-button-${workflowitemId}]`).click();
-    cy.get("[data-test=workflowitem-history-tab]").click();
-    cy.get("[data-test=search-history]").click();
-    // The oldest entry is the create event
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 2)
-      .last()
-      .should("contain", "created workflowitem");
-    // The newest entry is the update event
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .first()
-      .should("contain", "changed workflowitem");
+  it("All different types of history events are shown", function() {
+    cy.server();
+    cy.route("GET", apiRoute + "/workflowitem.viewHistory*").as("viewHistory");
+
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem assign test").then(({ id }) => {
+      workflowitemId = id;
+      // Create 5 additional history events
+      cy.updateWorkflowitem(projectId, subprojectId, workflowitemId, { displayName: "updated Name" });
+      cy.assignWorkflowitem(projectId, subprojectId, workflowitemId, "jxavier");
+      cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.view", "jxavier");
+      cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.view", "jxavier");
+      // List all workflowitems to get all wfitem-ids
+      cy.listWorkflowitems(projectId, subprojectId).then(({ workflowitems }) => {
+        const ordering = workflowitems.reduce((workflowitemIds, workflowitem) => {
+          if (workflowitem.data.id !== workflowitemId) {
+            workflowitemIds.push(workflowitem.data.id);
+          }
+          return workflowitemIds;
+        }, []);
+        // Move the current workflowitem to the first position so the item can be closed
+        ordering.unshift(workflowitemId);
+        cy.reorderWorkflowitems(projectId, subprojectId, ordering);
+        cy.closeWorkflowitem(projectId, subprojectId, workflowitemId);
+        cy.visit(`/projects/${projectId}/${subprojectId}`);
+
+        cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
+        cy.get(`[data-test=workflowitem-info-button-${workflowitemId}]`).click();
+        cy.get("[data-test=workflowitem-history-tab]")
+          .should("be.visible")
+          .click();
+        cy.wait("@viewHistory")
+          .get("[data-test=search-history]")
+          .should("be.visible")
+          .click();
+        // All additional history events should be shown
+        cy.get("[data-test=history-list] li.history-item").should("have.length", 6);
+      });
+    });
   });
 
-  it("Fetch history with different filters", function() {
-    cy.get(`[data-test=workflowitem-info-button-${workflowitemId}]`).click();
-    cy.get("[data-test=workflowitem-history-tab]").click();
-    cy.get("[data-test=search-history]").click();
-    // Filter by timeframe that does include both history items
-    cy.get("[data-test=datepicker-filter-startat]").type(yesterday);
-    cy.get("[data-test=datepicker-filter-endat]").type(tomorrow);
-    cy.get("[data-test=search]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 2);
-    cy.get("[data-test=reset]").click();
-    // Filter by timeframe that does not include both history items
-    cy.get("[data-test=datepicker-filter-startat]").type(tomorrow);
-    cy.get("[data-test=datepicker-filter-endat]").type(afterTomorrow);
-    cy.get("[data-test=search]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 0);
-    cy.get("[data-test=reset]").click();
-    // Filter by event type
-    cy.get("[data-test=dropdown-filter-eventtype-click]").click();
-    cy.get("[data-value=workflowitem_created]").click();
-    cy.get("[data-test=search]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 1);
-    cy.get("[data-test=reset]").click();
-    cy.get("[data-test=dropdown-filter-eventtype-click]").click();
-    cy.get("[data-value=workflowitem_closed]").click();
-    cy.get("[data-test=search]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 0);
-    cy.get("[data-test=reset]").click();
-    // Filter by publisher (user id)
-    cy.get("[data-test=dropdown-filter-publisher-click]").click();
-    cy.get("[data-value=mstein]").click();
-    cy.get("[data-test=search]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 2);
-    cy.get("[data-test=dropdown-filter-publisher-click]").click();
-    cy.get("[data-value=jdoe]").click();
-    cy.get("[data-test=search]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 0);
-    cy.get("[data-test=reset]").click();
+  it("All history search filter are working correctly", function() {
+    cy.server();
+    cy.route("GET", apiRoute + "/workflowitem.viewHistory*").as("viewHistory");
+
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem assign test").then(({ id }) => {
+      workflowitemId = id;
+      // Create 5 additional history events
+      cy.updateWorkflowitem(projectId, subprojectId, workflowitemId, { displayName: "updated Name" });
+      cy.assignWorkflowitem(projectId, subprojectId, workflowitemId, "jxavier");
+      cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.view", "jxavier");
+      cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.view", "jxavier");
+      // List all workflowitems to get all wfitem-ids
+      cy.listWorkflowitems(projectId, subprojectId).then(({ workflowitems }) => {
+        const ordering = workflowitems.reduce((workflowitemIds, workflowitem) => {
+          if (workflowitem.data.id !== workflowitemId) {
+            workflowitemIds.push(workflowitem.data.id);
+          }
+          return workflowitemIds;
+        }, []);
+        // Move the current workflowitem to the first position so the item can be closed
+        ordering.unshift(workflowitemId);
+        cy.reorderWorkflowitems(projectId, subprojectId, ordering);
+        cy.closeWorkflowitem(projectId, subprojectId, workflowitemId);
+        cy.visit(`/projects/${projectId}/${subprojectId}`);
+
+        cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
+        cy.get(`[data-test=workflowitem-info-button-${workflowitemId}]`).click();
+        cy.get("[data-test=workflowitem-history-tab]")
+          .should("be.visible")
+          .click();
+        // wait for the 1st viewHistory call so cypress can increment the viewHistory calls correctly
+        cy.wait("@viewHistory")
+          .get("[data-test=search-history]")
+          .should("be.visible")
+          .click();
+        // Filter by timeframe that does include all history items
+        cy.get("[data-test=datepicker-filter-startat]").type(yesterday);
+        cy.get("[data-test=datepicker-filter-endat]").type(tomorrow);
+        cy.get("[data-test=search]").click();
+        cy.wait("@viewHistory")
+          .get("[data-test=history-list] li.history-item")
+          .should("have.length", 6);
+        cy.get("[data-test=reset]").click();
+        // Filter by timeframe that does not include any history items
+        cy.get("[data-test=datepicker-filter-startat]").type(tomorrow);
+        cy.get("[data-test=datepicker-filter-endat]").type(afterTomorrow);
+        cy.get("[data-test=search]").click();
+        cy.wait("@viewHistory")
+          .get("[data-test=history-list] li.history-item")
+          .should("have.length", 0);
+        cy.get("[data-test=reset]").click();
+        // Filter by event type workflowitem_created
+        cy.get("[data-test=dropdown-filter-eventtype-click]").click();
+        cy.get("[data-value=workflowitem_created]")
+          .should("be.visible")
+          .click();
+        cy.get("[data-test=search]").click();
+        cy.wait("@viewHistory")
+          .get("[data-test=history-list] li.history-item")
+          .should("have.length", 1);
+        // Filter by event type workflowitem_closed
+        cy.get("[data-test=reset]").click();
+        cy.get("[data-test=dropdown-filter-eventtype-click]").click();
+        cy.get("[data-value=workflowitem_closed]")
+          .should("be.visible")
+          .click();
+        cy.wait("@viewHistory")
+          .get("[data-test=search]")
+          .click();
+        cy.get("[data-test=history-list] li.history-item").should("have.length", 1);
+        cy.get("[data-test=reset]").click();
+        // Filter by publisher mstein
+        cy.get("[data-test=dropdown-filter-publisher-click]").click();
+        cy.get("[data-value=mstein]")
+          .should("be.visible")
+          .click();
+        cy.get("[data-test=search]").click();
+        cy.wait("@viewHistory")
+          .get("[data-test=history-list] li.history-item")
+          .should("have.length", 6);
+        // Filter by publisher jdoe
+        cy.get("[data-test=dropdown-filter-publisher-click]").click();
+        cy.get("[data-value=jdoe]")
+          .should("be.visible")
+          .click();
+        cy.get("[data-test=search]").click();
+        cy.wait("@viewHistory")
+          .get("[data-test=history-list] li.history-item")
+          .should("have.length", 0);
+        cy.get("[data-test=reset]").click();
+      });
+    });
   });
 
   it("Search with multiple values and reset search panel after closing history panel", function() {
-    cy.get(`[data-test=workflowitem-info-button-${workflowitemId}]`).click();
-    cy.get("[data-test=workflowitem-history-tab]").click();
-    cy.get("[data-test=search-history]").click();
-    // Search panel is collapsed and search values are reseted after closing it
-    cy.get("[data-test=dropdown-filter-publisher-click]").click();
-    cy.get("[data-value=mstein]").click();
-    cy.get("[data-test=dropdown-filter-eventtype-click]").click();
-    cy.get("[data-value=workflowitem_closed]").click();
-    cy.get("[data-test=search]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 0);
-    cy.get("[data-test=workflowdetails-close]").click();
-    cy.get(`[data-test^=workflowitem-info-button-${workflowitemId}]`).click();
-    cy.get("[data-test=workflowitem-history-tab]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 2);
-  });
+    cy.server();
+    cy.route("GET", apiRoute + "/workflowitem.viewHistory*").as("viewHistory");
 
-  it("Search with multiple values and reset search panel after clicking reset", function() {
-    cy.get(`[data-test=workflowitem-info-button-${workflowitemId}]`).click();
-    cy.get("[data-test=workflowitem-history-tab]").click();
-    cy.get("[data-test=search-history]").click();
-    cy.get("[data-test=dropdown-filter-publisher-click]").click();
-    cy.get("[data-value=mstein]").click();
-    cy.get("[data-test=dropdown-filter-eventtype-click]").click();
-    cy.get("[data-value=workflowitem_closed]").click();
-    cy.get("[data-test=search]").click();
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 0);
-    cy.get("[data-test=reset]").click();
-    // value in dropdown should not exist
-    cy.get("[data-test=dropdown-filter-publisher-click]")
-      .find("input")
-      .should("not.have.attr", "data-value");
-    cy.get("[data-test=history-list]")
-      .find("li.history-item")
-      .should("have.length", 2);
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem assign test").then(({ id }) => {
+      workflowitemId = id;
+      // Create 5 additional history events
+      cy.updateWorkflowitem(projectId, subprojectId, workflowitemId, { displayName: "updated Name" });
+      cy.assignWorkflowitem(projectId, subprojectId, workflowitemId, "jxavier");
+      cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.view", "jxavier");
+      cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.view", "jxavier");
+      // List all workflowitems to get all wfitem-ids
+      cy.listWorkflowitems(projectId, subprojectId).then(({ workflowitems }) => {
+        const ordering = workflowitems.reduce((workflowitemIds, workflowitem) => {
+          if (workflowitem.data.id !== workflowitemId) {
+            workflowitemIds.push(workflowitem.data.id);
+          }
+          return workflowitemIds;
+        }, []);
+        // Move the current workflowitem to the first position so the item can be closed
+        ordering.unshift(workflowitemId);
+        cy.reorderWorkflowitems(projectId, subprojectId, ordering);
+        cy.closeWorkflowitem(projectId, subprojectId, workflowitemId);
+        cy.visit(`/projects/${projectId}/${subprojectId}`);
+
+        cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
+        cy.get(`[data-test=workflowitem-info-button-${workflowitemId}]`).click();
+        cy.get("[data-test=workflowitem-history-tab]")
+          .should("be.visible")
+          .click();
+        // wait for the 1st viewHistory call so cypress can increment the viewHistory calls correctly
+        cy.wait("@viewHistory")
+          .get("[data-test=search-history]")
+          .should("be.visible")
+          .click();
+        // Set publisher mstein
+        cy.get("[data-test=dropdown-filter-publisher-click]").click();
+        cy.get("[data-value=mstein]")
+          .should("be.visible")
+          .click();
+        // Set event type workflowitem_closed
+        cy.get("[data-test=dropdown-filter-eventtype-click]").click();
+        cy.get("[data-value=workflowitem_closed]")
+          .should("be.visible")
+          .click();
+        // Set timeframe yesterday until tomorrow
+        cy.get("[data-test=datepicker-filter-startat]").type(yesterday);
+        cy.get("[data-test=datepicker-filter-endat]").type(tomorrow);
+        cy.get("[data-test=search]").click();
+        cy.wait("@viewHistory")
+          .get("[data-test=history-list]")
+          .find("li.history-item")
+          .should("have.length", 1);
+      });
+    });
   });
 });

--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -425,6 +425,7 @@ Cypress.Commands.add("closeProject", projectId => {
     .its("body")
     .then(body => Cypress.Promise.resolve(body.data));
 });
+
 Cypress.Commands.add("closeWorkflowitem", (projectId, subprojectId, workflowitemId) => {
   cy.request({
     url: `${baseUrl}/api/workflowitem.close`,
@@ -438,6 +439,68 @@ Cypress.Commands.add("closeWorkflowitem", (projectId, subprojectId, workflowitem
         projectId,
         subprojectId,
         workflowitemId
+      }
+    }
+  })
+    .its("body")
+    .then(body => Cypress.Promise.resolve(body.data));
+});
+
+Cypress.Commands.add("updateWorkflowitem", (projectId, subprojectId, workflowitemId, opts = {}) => {
+  cy.request({
+    url: `${baseUrl}/api/workflowitem.update`,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: {
+      apiVersion: "1.0",
+      data: {
+        projectId,
+        subprojectId,
+        workflowitemId,
+        ...opts
+      }
+    }
+  })
+    .its("body")
+    .then(body => Cypress.Promise.resolve(body.data));
+});
+
+Cypress.Commands.add("reorderWorkflowitems", (projectId, subprojectId, ordering) => {
+  cy.request({
+    url: `${baseUrl}/api/subproject.reorderWorkflowitems`,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: {
+      apiVersion: "1.0",
+      data: {
+        projectId,
+        subprojectId,
+        ordering
+      }
+    }
+  })
+    .its("body")
+    .then(body => Cypress.Promise.resolve(body.data));
+});
+
+Cypress.Commands.add("assignWorkflowitem", (projectId, subprojectId, workflowitemId, identity) => {
+  cy.request({
+    url: `${baseUrl}/api/workflowitem.assign`,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: {
+      apiVersion: "1.0",
+      data: {
+        projectId,
+        subprojectId,
+        workflowitemId,
+        identity
       }
     }
   })
@@ -482,6 +545,18 @@ Cypress.Commands.add("listSubprojectPermissions", (projectId, subprojectId) => {
 Cypress.Commands.add("listWorkflowitemPermissions", (projectId, subprojectId, workflowitemId) => {
   cy.request({
     url: `${baseUrl}/api/workflowitem.intent.listPermissions?projectId=${projectId}&subprojectId=${subprojectId}&workflowitemId=${workflowitemId}`,
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
+    .its("body")
+    .then(body => Cypress.Promise.resolve(body.data));
+});
+
+Cypress.Commands.add("listWorkflowitems", (projectId, subprojectId, workflowitemId) => {
+  cy.request({
+    url: `${baseUrl}/api/workflowitem.list?projectId=${projectId}&subprojectId=${subprojectId}&workflowitemId=${workflowitemId}`,
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`

--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -99,7 +99,7 @@ Cypress.Commands.add("fetchSubprojects", projectId => {
     .then(body => Cypress.Promise.resolve(body.data.subprojects));
 });
 
-Cypress.Commands.add("createWorkflowitem", (projectId, subprojectId, displayName, opts = { amountType: "N/A" }) => {
+Cypress.Commands.add("createWorkflowitem", (projectId, subprojectId, displayName, opts = {}) => {
   cy.request({
     url: `${baseUrl}/api/subproject.createWorkflowitem`,
     method: "POST",
@@ -112,6 +112,7 @@ Cypress.Commands.add("createWorkflowitem", (projectId, subprojectId, displayName
         projectId: projectId,
         subprojectId: subprojectId,
         displayName: displayName,
+        amountType: "N/A",
         ...opts
       }
     }

--- a/frontend/src/pages/Common/Permissions/PermissionSelection.js
+++ b/frontend/src/pages/Common/Permissions/PermissionSelection.js
@@ -105,6 +105,7 @@ class PermissionSelection extends Component {
           autoWidth
           value={selections}
           renderValue={s => s.join(", ")}
+          MenuProps={{ "data-test": "permission-selection-popup" }}
         >
           {this.props.disabled ? (
             <ListSubheader

--- a/frontend/src/pages/Common/Permissions/PermissionsTable.js
+++ b/frontend/src/pages/Common/Permissions/PermissionsTable.js
@@ -45,7 +45,11 @@ const PermissionTable = ({
     <div>
       {intentOrder.map(section => {
         return (
-          <Card key={section.name + "section"} style={{ marginTop: "12px", marginBottom: "12px" }}>
+          <Card
+            key={section.name + "section"}
+            style={{ marginTop: "12px", marginBottom: "12px" }}
+            data-test="permission-table"
+          >
             <CardHeader subheader={strings.permissions[section.name]} />
             <CardContent>
               <List data-test={`${section.name}-list`}>

--- a/frontend/src/pages/SubProjects/SubProjectContainer.js
+++ b/frontend/src/pages/SubProjects/SubProjectContainer.js
@@ -48,8 +48,8 @@ class SubProjectContainer extends Component {
 
   componentDidMount() {
     this.props.setSelectedView(this.projectId, "project");
-    this.props.fetchAllProjectDetails(this.projectId, true);
     this.props.fetchUser();
+    this.props.fetchAllProjectDetails(this.projectId, true);
     this.setState({ isDataFetched: true });
 
     // Get Searchword from URL if available

--- a/frontend/src/pages/SubProjects/SubProjectTable.js
+++ b/frontend/src/pages/SubProjects/SubProjectTable.js
@@ -137,7 +137,7 @@ const getTableEntries = ({
     if (!redacted && visibleSubproject) {
       const amountString = displaySubprojectBudget(projectedBudgets);
       return (
-        <TableRow key={index}>
+        <TableRow key={index} data-test={`subproject-${id}`}>
           <TableCell className={classes.displayName} data-test={`subproject-title-${index}`}>
             <Highlight
               data-test="highlighted-displayname"

--- a/frontend/src/pages/Workflows/WorkflowContainer.js
+++ b/frontend/src/pages/Workflows/WorkflowContainer.js
@@ -57,8 +57,8 @@ class WorkflowContainer extends Component {
 
   componentDidMount() {
     this.props.setSelectedView(this.subprojectId, "subProject");
-    this.props.fetchAllSubprojectDetails(this.projectId, this.subprojectId, true);
     this.props.fetchUser();
+    this.props.fetchAllSubprojectDetails(this.projectId, this.subprojectId, true);
     this.setState({ isDataFetched: true });
   }
 

--- a/frontend/src/pages/Workflows/WorkflowItem.js
+++ b/frontend/src/pages/Workflows/WorkflowItem.js
@@ -484,7 +484,7 @@ export const WorkflowItem = withTheme()(
               className={`${getCardClass(classes, workflowSortEnabled, status)} ${classes.card}`}
               style={getCardStyle(classes, workflowSortEnabled, status)}
             >
-              <div className={classes.workflowContent}>
+              <div className={classes.workflowContent} data-test={`workflowitem-${id}`}>
                 <div className={classes.infoCell}>{infoButton}</div>
                 <div className={`${classes.text} ${classes.workflowCell}`} style={itemStyle}>
                   <Typography variant="body2" className={classes.typographs}>


### PR DESCRIPTION
**Checklist:**
- Every test shall be independent and can be run by its own (cypress.only())
- If api calls are made in the background cypress has to wait for that route before expecting an element

**Critical test files**:
- `workflowitem_history_spec.js`
- `workflowitem_edit_spec.js`
- `subproject_edit_spec.js`
   - Subproject Edit When closing the project, a dialog pops up
- `subproject_permissions_spec.js`
    - Subproject Permissions Submitting the permission dialog without any changes doesn't revoke nor grant permissions and close the dialog
- `global_permissions_spec.js`
- `documents.spec`
   - Attaching a document to a workflowitem. A document can be validated.

TODO:

- [x]  `workflowitem_history_spec.js`
- [x] `workflowitem_edit_spec.js`
- [x] `workflowitem_create_spec.js`
- [x] `subproject_edit_spec.js`
- [x] `subproject_search_spec.js`
- [x] `subproject_permissions_spec.js`
- [x] `global_permissions_spec.js`
- [x] `documents.spec`

Closes #501