### PR TITLE
Add missing workflowitem columns to exported excel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ stages:
   before_script:
     - cd $PROJECT_NAME
   script:
-    - npm audit --audit-level=high
+    - npm audit --audit-level=high > /dev/null 2>&1
 
 .node-unit-test: &node-unit-test
   stage: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+Fixed a bug where it was impossible to edit an email address of a user [#510](https://github.com/openkfw/TruBudget/issues/510)
+The excel sheet is now exported including the fields `dueDate` and `workflowitemType` [#511](https://github.com/openkfw/TruBudget/issues/511)
+Fixed a bug where all displayed versions disappeared after switching page [#512](https://github.com/openkfw/TruBudget/issues/512)
 
 <!-- ### Changed -->
 

--- a/e2e-test/cypress/integration/version_spec.js
+++ b/e2e-test/cypress/integration/version_spec.js
@@ -1,4 +1,6 @@
 describe("Component Versions", function() {
+  let projectId;
+
   beforeEach(() => {
     cy.login();
   });
@@ -10,9 +12,9 @@ describe("Component Versions", function() {
       .click();
     cy.get("[data-test=frontendVersion]")
       .should("be.visible")
-      .should(($elem) => {
+      .should($elem => {
         const text = $elem.text();
-        expect(text.trim()).to.match(/[a-z]*\:\s[0-9]+\.[0-9]+\.[0-9]+/);
+        expect(text.trim()).to.match(/[a-z]*:\s[0-9]+\.[0-9]+\.[0-9]+/);
       });
   });
 
@@ -23,9 +25,9 @@ describe("Component Versions", function() {
       .click();
     cy.get("[data-test=apiVersion]")
       .should("be.visible")
-      .should(($elem) => {
+      .should($elem => {
         const text = $elem.text();
-        expect(text.trim()).to.match(/[a-z]*\:\s[0-9]+\.[0-9]+\.[0-9]+/);
+        expect(text.trim()).to.match(/[a-z]*:\s[0-9]+\.[0-9]+\.[0-9]+/);
       });
   });
 
@@ -36,9 +38,9 @@ describe("Component Versions", function() {
       .click();
     cy.get("[data-test=blockchainVersion]")
       .should("be.visible")
-      .should(($elem) => {
+      .should($elem => {
         const text = $elem.text();
-        expect(text.trim()).to.match(/[a-z]*\:\s[0-9]+\.[0-9]+\.[0-9]+/);
+        expect(text.trim()).to.match(/[a-z]*:\s[0-9]+\.[0-9]+\.[0-9]+/);
       });
   });
 
@@ -49,9 +51,43 @@ describe("Component Versions", function() {
       .click();
     cy.get("[data-test=multichainVersion]")
       .should("be.visible")
-      .should(($elem) => {
+      .should($elem => {
         const text = $elem.text();
-        expect(text.trim()).to.match(/[a-z]*\:\s[0-9]+\.[0-9]+.*/);
+        expect(text.trim()).to.match(/[a-z]*:\s[0-9]+\.[0-9]+.*/);
       });
+  });
+
+  it("Shows versions after location change", function() {
+    cy.createProject("p-version", "project for version test").then(({ id }) => {
+      projectId = id;
+      cy.visit(`/projects`);
+      // Check service version
+      cy.get("[data-test=openSideNavbar]")
+        .should("be.visible")
+        .click();
+      cy.get("[data-test=multichainVersion]")
+        .should("be.visible")
+        .should($elem => {
+          const text = $elem.text();
+          expect(text.trim()).to.match(/[a-z]*:\s[0-9]+\.[0-9]+.*/);
+        });
+      // Click outside the sidenavbar to close it
+      cy.get("[data-test=sidenav-drawer-backdrop]").click();
+      cy.get("[data-test=side-navigation]").should("not.be.visible");
+      // Open project
+      cy.get(`[data-test=project-card-${projectId}]`).within(() => {
+        cy.get(`[data-test*=project-view-button]`).click();
+      });
+      // Verify the service versions are still displayed
+      cy.get("[data-test=openSideNavbar]")
+        .should("be.visible")
+        .click();
+      cy.get("[data-test=multichainVersion]")
+        .should("be.visible")
+        .should($elem => {
+          const text = $elem.text();
+          expect(text.trim()).to.match(/[a-z]*:\s[0-9]+\.[0-9]+.*/);
+        });
+    });
   });
 });

--- a/email-notification/package-lock.json
+++ b/email-notification/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "email-notification",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/email-notification/src/db.ts
+++ b/email-notification/src/db.ts
@@ -42,11 +42,8 @@ class DbConnector {
     const client = await this.getDb();
     const tablesToCheck: string[] = [config.userTable];
     const tablePromises: Promise<string[]> = Promise.all(
-      tablesToCheck.map(table => {
-        const query: knex.QueryBuilder<any, any> = client
-          .select()
-          .from(table)
-          .whereRaw("1=0");
+      tablesToCheck.map((table) => {
+        const query: knex.QueryBuilder<any, any> = client.select().from(table).whereRaw("1=0");
         return this.executeQuery(query, `The table ${table} does not exist.`);
       }),
     );
@@ -57,11 +54,8 @@ class DbConnector {
     try {
       const client = await this.getDb();
       if (!(await client.schema.hasTable(config.userTable))) {
-        await client.schema.createTable(config.userTable, table => {
-          table
-            .string(this.idTableName)
-            .notNullable()
-            .unique();
+        await client.schema.createTable(config.userTable, (table) => {
+          table.string(this.idTableName).notNullable().unique();
           table.string(this.emailAddressTableName).notNullable();
         });
         logger.info(`Table '${config.userTable}' created.`);
@@ -79,10 +73,11 @@ class DbConnector {
   public updateUser = async (id: string, emailAddress: string): Promise<void> => {
     const client = await this.getDb();
     try {
-      await client(config.userTable).update({
-        [`${this.idTableName}`]: id,
-        [`${this.emailAddressTableName}`]: emailAddress,
-      });
+      await client(config.userTable)
+        .update({
+          [`${this.emailAddressTableName}`]: emailAddress,
+        })
+        .where({ [`${this.idTableName}`]: id });
       logger.info(`Update User '${id}' with email address '${emailAddress}'`);
     } catch (error) {
       throw error;
@@ -146,11 +141,8 @@ class DbConnector {
   };
 
   private createTable = async (): Promise<void> => {
-    await this.pool.schema.createTable(config.userTable, table => {
-      table
-        .string(this.idTableName)
-        .notNullable()
-        .unique();
+    await this.pool.schema.createTable(config.userTable, (table) => {
+      table.string(this.idTableName).notNullable().unique();
       table.string(this.emailAddressTableName).notNullable();
     });
     logger.info(`Table '${config.userTable}' created.`);

--- a/excel-export/src/api.ts
+++ b/excel-export/src/api.ts
@@ -19,7 +19,7 @@ export interface Project {
       organization: string;
       value: string;
       currencyCode: string;
-    }
+    },
   ];
 }
 
@@ -43,7 +43,7 @@ export interface Subproject {
       organization: string;
       value: string;
       currencyCode: string;
-    }
+    },
   ];
   additionData: any;
 }
@@ -63,14 +63,16 @@ export interface Workflowitem {
   displayName: string;
   description: string;
   assignee: string;
+  workflowitemType?: string;
   billingDate?: string;
   exchangeRate?: string;
+  dueDate?: string;
   amount?: string;
   documents: [
     {
       id: string;
       hash: string;
-    }
+    },
   ];
 }
 
@@ -91,7 +93,7 @@ export async function getProjects(
     `${base}/project.list`,
     getAuthHeader(token),
   );
-  const projectList: Project[] = response.data.data.items.map(i => i.data);
+  const projectList: Project[] = response.data.data.items.map((i) => i.data);
   return projectList;
 }
 
@@ -105,7 +107,7 @@ export async function getSubprojects(
     `${base}/subproject.list?projectId=${projectId}`,
     getAuthHeader(token),
   );
-  const subprojectList: Subproject[] = response.data.data.items.map(i => i.data);
+  const subprojectList: Subproject[] = response.data.data.items.map((i) => i.data);
   return subprojectList;
 }
 
@@ -120,6 +122,6 @@ export async function getWorkflowitems(
     `${base}/workflowitem.list?projectId=${projectId}&subprojectId=${subprojectId}`,
     getAuthHeader(token),
   );
-  const workflowitemList: Workflowitem[] = response.data.data.workflowitems.map(i => i.data);
+  const workflowitemList: Workflowitem[] = response.data.data.workflowitems.map((i) => i.data);
   return workflowitemList;
 }

--- a/excel-export/src/excel.ts
+++ b/excel-export/src/excel.ts
@@ -72,11 +72,13 @@ export async function writeXLSX(
       { header: "Subproject Currency", key: "parentSubprojectCurrency", width: smallWidth },
       { header: "Workflowitem ID", key: "id", width: mediumWidth },
       { header: "Workflowitem Name", key: "displayName", width: mediumWidth },
+      { header: "Workflowitem Type", key: "workflowitemType", width: smallWidth },
       { header: "Created", key: "creationUnixTs", width: mediumWidth },
       { header: "Status", key: "status", width: smallWidth },
       { header: "Description", key: "description", width: mediumWidth },
       { header: "Assignee", key: "assignee", width: smallWidth },
       { header: "Billing Date", key: "billingDate", width: mediumWidth },
+      { header: "Due Date", key: "dueDate", width: mediumWidth },
       { header: "Amount Type", key: "amountType", width: smallWidth },
       { header: "Amount", key: "amount", width: smallWidth },
       { header: "Currency", key: "currency", width: smallWidth },
@@ -122,7 +124,7 @@ export async function writeXLSX(
         })
         .commit();
 
-      project.projectedBudgets.map(projectedBudget => {
+      project.projectedBudgets.map((projectedBudget) => {
         projectProjectedBudgetsSheet
           .addRow({
             ...projectedBudget,
@@ -144,7 +146,7 @@ export async function writeXLSX(
           })
           .commit();
 
-        subproject.projectedBudgets.map(async projectedBudget => {
+        subproject.projectedBudgets.map(async (projectedBudget) => {
           subprojectProjectedBudgetsSheet
             .addRow({
               ...projectedBudget,
@@ -180,7 +182,7 @@ export async function writeXLSX(
               creationUnixTs: new Date(parseInt(workflowitem.creationUnixTs) * 1000).toISOString(),
             })
             .commit();
-          workflowitem.documents.map(doc => {
+          workflowitem.documents.map((doc) => {
             documentSheet
               .addRow({
                 projectId: project.id,

--- a/frontend/src/pages/Common/Password.js
+++ b/frontend/src/pages/Common/Password.js
@@ -1,7 +1,8 @@
 import TextField from "@material-ui/core/TextField";
+import Tooltip from "@material-ui/core/Tooltip";
 import PasswordIcon from "@material-ui/icons/Lock";
 import React from "react";
-import Tooltip from "@material-ui/core/Tooltip";
+import strings from "../../localizeStrings";
 
 const styles = {
   container: {
@@ -43,7 +44,7 @@ const Password = ({
         <TextField
           data-test={props["data-test"] || "password-textfield"}
           style={{ width: "50%" }}
-          label={label}
+          label={label || strings.common.password}
           value={password}
           margin="normal"
           error={failed}

--- a/frontend/src/pages/Common/Username.js
+++ b/frontend/src/pages/Common/Username.js
@@ -5,11 +5,11 @@ import UsernameIcon from "@material-ui/icons/Person";
 import strings from "../../localizeStrings";
 import TextInputWithIcon from "./TextInputWithIcon";
 
-const Username = ({ username, storeUsername, failed, id, failedText, ...props }) => {
+const Username = ({ username, storeUsername, failed, id, failedText, label, ...props }) => {
   return (
     <TextInputWithIcon
       style={{ width: "50%" }}
-      label={strings.common.username}
+      label={label || strings.common.username}
       value={username}
       margin="normal"
       error={failed}

--- a/frontend/src/pages/Navbar/SideNav.js
+++ b/frontend/src/pages/Navbar/SideNav.js
@@ -10,7 +10,12 @@ const SideNav = props => {
   const { showSidebar, toggleSidebar, allowedIntents, ...rest } = props;
   const nodeDashboardEnabled = canViewNodesDashboard(allowedIntents);
   return (
-    <Drawer anchor="left" open={showSidebar} onClose={toggleSidebar}>
+    <Drawer
+      ModalProps={{ BackdropProps: { "data-test": "sidenav-drawer-backdrop" } }}
+      anchor="left"
+      open={showSidebar}
+      onClose={toggleSidebar}
+    >
       <SideNavCard nodeDashboardEnabled={nodeDashboardEnabled} {...rest} />
       <UserProfileContainer />
     </Drawer>

--- a/frontend/src/pages/Navbar/reducer.js
+++ b/frontend/src/pages/Navbar/reducer.js
@@ -49,10 +49,16 @@ export default function navbarReducer(state = defaultState, action) {
     case FETCH_STREAM_NAMES_SUCCESS:
       return state.set("streamNames", fromJS(action.streamNames));
     case SET_SELECTED_VIEW:
-      return defaultState.merge({
+      return state.merge({
         selectedId: action.id,
         selectedSection: action.section,
-        isRoot: state.get("isRoot")
+        showSidebar: false,
+        searchTerm: defaultState.get("searchTerm"),
+        searchBarDisplayed: defaultState.get("searchBarDisplayed"),
+        userProfileOpen: defaultState.get("userProfileOpen"),
+        userProfileEdit: defaultState.get("userProfileEdit"),
+        tempEmailAddress: defaultState.get("tempEmailAddress"),
+        isEmailAddressInputValid: defaultState.get("isEmailAddressInputValid")
       });
     case FETCH_ALL_PROJECT_DETAILS_SUCCESS:
       return state.set("currentProject", action.project.data.displayName);


### PR DESCRIPTION
### Description
In this PR following tasks shall be completed:

- Due to the combination of a log limit of 4MB and a tons of npm audit output the travis audit job would fail. Disabling the npm audit log solves this issue for now.
- Add `workflowitemTypes` and `dueDate` to exported excel sheet #511 
- Add label to password field of user-creation-dialog
- Fix Update statement of email-service. #510 
- Fix display of service versions after location change #512 
- Add danger warning if excel-export project is not adapted after changing a resource (project/subproject/workflowitem) in the api

Last task should prevent a developer to forget adding a new property to the execl-export project.

Closes #510 
Closes #511
Closes #512 