### PR TITLE
API/UI: Prevent revoke permission of last user of a wItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-Fixed a bug where it was impossible to edit an email address of a user [#510](https://github.com/openkfw/TruBudget/issues/510)
-The excel sheet is now exported including the fields `dueDate` and `workflowitemType` [#511](https://github.com/openkfw/TruBudget/issues/511)
-Fixed a bug where all displayed versions disappeared after switching page [#512](https://github.com/openkfw/TruBudget/issues/512)
+- Fixed a bug where it was impossible to edit an email address of a user [#510](https://github.com/openkfw/TruBudget/issues/510)
+- The excel sheet is now exported including the fields `dueDate` and `workflowitemType` [#511](https://github.com/openkfw/TruBudget/issues/511)
+- Fixed a bug where all displayed versions disappeared after switching page [#512](https://github.com/openkfw/TruBudget/issues/512)
+- Prevent a user from revoking a permission from him-/herself at workflowitem level [#514](https://github.com/openkfw/TruBudget/issues/514)
 
 <!-- ### Changed -->
 

--- a/api/src/http_errors.ts
+++ b/api/src/http_errors.ts
@@ -1,5 +1,4 @@
 import { VError } from "verror";
-
 import logger from "./lib/logger";
 
 interface ErrorBody {
@@ -43,8 +42,14 @@ function handleError(error: Error): { code: number; message: string } {
     case "NotAuthorized":
       return { code: 403, message: error.message };
 
-    case "PreconditionError":
+    case "NotFound":
+      return { code: 404, message: error.message };
+
+    case "AlreadyExists":
       return { code: 409, message: error.message };
+
+    case "PreconditionError":
+      return { code: 412, message: error.message };
 
     default:
       return { code: 500, message: error.message };

--- a/api/src/service/domain/errors/already_exists.ts
+++ b/api/src/service/domain/errors/already_exists.ts
@@ -1,0 +1,21 @@
+import { Ctx } from "../../../lib/ctx";
+import { BusinessEvent } from "../business_event";
+
+/**
+ * @param {string} id           Identity which already exists.
+ */
+export class AlreadyExists extends Error {
+  constructor(
+    private readonly ctx: Ctx,
+    private readonly businessEvent: BusinessEvent,
+    id: string,
+  ) {
+    super(`Intent ${businessEvent.type} failed. ${id} already exists.`);
+
+    this.name = "AlreadyExists";
+    // Maintains proper stack trace for where our error was thrown (only available on V8):
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AlreadyExists);
+    }
+  }
+}

--- a/api/src/service/domain/errors/not_found.ts
+++ b/api/src/service/domain/errors/not_found.ts
@@ -14,6 +14,7 @@ export class NotFound extends Error {
     private readonly entityId: string,
   ) {
     super(`Not found: ${entityType} ${entityId}`);
+    this.name = "NotFound";
 
     // Maintains proper stack trace for where our error was thrown (only available on V8):
     if (Error.captureStackTrace) {

--- a/api/src/service/domain/errors/precondition_error.ts
+++ b/api/src/service/domain/errors/precondition_error.ts
@@ -10,6 +10,7 @@ export class PreconditionError extends Error {
     // TODO this shouldn't be failed to apply event but failed to execute intent
     super(`Failed to apply ${businessEvent.type}, a precondition is not fulfilled: ${message}`);
 
+    this.name = "PreconditionError";
     // Maintains proper stack trace for where our error was thrown (only available on V8):
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, PreconditionError);

--- a/api/src/service/domain/organization/user_create.spec.ts
+++ b/api/src/service/domain/organization/user_create.spec.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
-
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
+import { AlreadyExists } from "../errors/already_exists";
 import { NotAuthorized } from "../errors/not_authorized";
 import { PreconditionError } from "../errors/precondition_error";
 import { ServiceUser } from "./service_user";
@@ -34,11 +34,11 @@ const dummyKeyPair = {
 
 const baseRepository = {
   getGlobalPermissions: () => Promise.resolve(noPermissions),
-  userExists: userId => Promise.resolve(false),
-  organizationExists: organization => Promise.resolve(true),
+  userExists: (userId) => Promise.resolve(false),
+  organizationExists: (organization) => Promise.resolve(true),
   createKeyPair: () => Promise.resolve(dummyKeyPair),
-  hash: plaintext => Promise.resolve("dummyHash"),
-  encrypt: plaintext => Promise.resolve("dummyEncrypted"),
+  hash: (plaintext) => Promise.resolve("dummyHash"),
+  encrypt: (plaintext) => Promise.resolve("dummyEncrypted"),
 };
 
 describe("Create a new user: authorization", () => {
@@ -63,16 +63,16 @@ describe("Create a new user: conditions", () => {
   it("User that already exists cannot be created", async () => {
     const result = await createUser(ctx, root, requestData, {
       ...baseRepository,
-      userExists: userId => Promise.resolve(true),
+      userExists: (userId) => Promise.resolve(true),
     });
     assert.isTrue(Result.isErr(result));
-    assert.instanceOf(result, PreconditionError);
+    assert.instanceOf(result, AlreadyExists);
   });
 
   it("User without an existing organization cannot be created", async () => {
     const result = await createUser(ctx, root, requestData, {
       ...baseRepository,
-      organizationExists: organization => Promise.resolve(false),
+      organizationExists: (organization) => Promise.resolve(false),
     });
     assert.isTrue(Result.isErr(result));
     assert.instanceOf(result, PreconditionError);

--- a/api/src/service/domain/workflow/global_permission_grant.ts
+++ b/api/src/service/domain/workflow/global_permission_grant.ts
@@ -2,15 +2,13 @@ import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
-import { InvalidCommand } from "../errors/invalid_command";
 import { NotAuthorized } from "../errors/not_authorized";
 import { PreconditionError } from "../errors/precondition_error";
 import { Identity } from "../organization/identity";
 import { ServiceUser } from "../organization/service_user";
 import * as UserRecord from "../organization/user_record";
-import * as GlobalPermissionGranted from "./global_permission_granted";
 import * as GlobalPermissions from "./global_permissions";
-import { sourceProjects } from "./project_eventsourcing";
+import * as GlobalPermissionGranted from "./global_permission_granted";
 
 interface Repository {
   getGlobalPermissions(): Promise<GlobalPermissions.GlobalPermissions>;

--- a/api/src/service/domain/workflow/project_create.ts
+++ b/api/src/service/domain/workflow/project_create.ts
@@ -6,6 +6,7 @@ import * as Result from "../../../result";
 import { randomString } from "../../hash";
 import * as AdditionalData from "../additional_data";
 import { BusinessEvent } from "../business_event";
+import { AlreadyExists } from "../errors/already_exists";
 import { InvalidCommand } from "../errors/invalid_command";
 import { NotAuthorized } from "../errors/not_authorized";
 import { PreconditionError } from "../errors/precondition_error";
@@ -13,8 +14,8 @@ import { ServiceUser } from "../organization/service_user";
 import { Permissions } from "../permissions";
 import * as GlobalPermissions from "./global_permissions";
 import * as Project from "./project";
-import * as ProjectCreated from "./project_created";
 import { ProjectedBudget, projectedBudgetListSchema } from "./projected_budget";
+import * as ProjectCreated from "./project_created";
 
 /**
  * Initial data for the new project as given in the request.
@@ -82,9 +83,7 @@ export async function createProject(
   const badEntry = findDuplicateBudgetEntry(createEvent.project.projectedBudgets);
   if (badEntry !== undefined) {
     const error = new Error(
-      `more than one projected budget for organization ${badEntry.organization} and currency ${
-        badEntry.currencyCode
-      }`,
+      `more than one projected budget for organization ${badEntry.organization} and currency ${badEntry.currencyCode}`,
     );
     return { newEvents: [], errors: [new InvalidCommand(ctx, createEvent, [error])] };
   }
@@ -92,7 +91,7 @@ export async function createProject(
   if (await repository.projectExists(createEvent.project.id)) {
     return {
       newEvents: [],
-      errors: [new PreconditionError(ctx, createEvent, "project already exists")],
+      errors: [new AlreadyExists(ctx, createEvent, createEvent.project.id)],
     };
   }
 

--- a/api/src/service/domain/workflow/project_permission_revoke.spec.ts
+++ b/api/src/service/domain/workflow/project_permission_revoke.spec.ts
@@ -1,0 +1,109 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { PreconditionError } from "../errors/precondition_error";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import * as Project from "./project";
+import * as ProjectPermissionRevoke from "./project_permission_revoke";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const executingUser: ServiceUser = { id: "mstein", groups: [] };
+const testUser: ServiceUser = { id: "testUser", groups: [] };
+
+const permissions: Permissions = {
+  "project.viewSummary": ["testUser"],
+  "project.viewDetails": ["testUser"],
+  "project.intent.grantPermission": ["testUser"],
+  "project.intent.revokePermission": ["mstein"],
+};
+
+const testProject: Project.Project = {
+  id: "testProject",
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: "unitTestName",
+  description: "",
+  projectedBudgets: [],
+  permissions,
+  log: [],
+  additionalData: {},
+  tags: [],
+};
+
+describe("revoke project permissions", () => {
+  it("With the 'project.intent.revokePermission' permission, the user can revoke project permissions", async () => {
+    const revokeResult = await ProjectPermissionRevoke.revokeProjectPermission(
+      ctx,
+      executingUser,
+      testProject.id,
+      testUser.id,
+      "project.viewDetails",
+      {
+        getProject: async () => testProject,
+      },
+    );
+
+    if (Result.isErr(revokeResult)) {
+      throw revokeResult;
+    }
+    assert.lengthOf(revokeResult.newEvents, 1);
+    const revokeEvent = revokeResult.newEvents[0];
+    const expectedEvent: BusinessEvent = {
+      type: "project_permission_revoked",
+      source: ctx.source,
+      publisher: executingUser.id,
+      time: revokeEvent.time,
+      projectId: testProject.id,
+      permission: "project.viewDetails",
+      revokee: testUser.id,
+    };
+    assert.deepEqual(expectedEvent, revokeEvent);
+  });
+
+  it("Without the 'project.intent.revokePermission' permission, the user cannot revoke project permissions", async () => {
+    const projectWithoutPermission: Project.Project = {
+      id: "testProject",
+      createdAt: new Date().toISOString(),
+      status: "open",
+      displayName: "unitTestName",
+      description: "",
+      projectedBudgets: [],
+      permissions: { "project.intent.revokePermission": [] },
+      log: [],
+      additionalData: {},
+      tags: [],
+    };
+    const revokeResult = await ProjectPermissionRevoke.revokeProjectPermission(
+      ctx,
+      executingUser,
+      testProject.id,
+      testUser.id,
+      "project.viewDetails",
+      {
+        getProject: async () => projectWithoutPermission,
+      },
+    );
+
+    assert.isTrue(Result.isErr(revokeResult));
+    assert.instanceOf(revokeResult, NotAuthorized);
+  });
+
+  it("Revoking grantPermission permission of last user is not allowed and leads to a precondition error.", async () => {
+    const revokeResult = await ProjectPermissionRevoke.revokeProjectPermission(
+      ctx,
+      executingUser,
+      testProject.id,
+      testUser.id,
+      "project.intent.grantPermission",
+      {
+        getProject: async () => testProject,
+      },
+    );
+
+    assert.isTrue(Result.isErr(revokeResult));
+    assert.instanceOf(revokeResult, PreconditionError);
+  });
+});

--- a/api/src/service/domain/workflow/project_permission_revoke.ts
+++ b/api/src/service/domain/workflow/project_permission_revoke.ts
@@ -7,6 +7,7 @@ import { BusinessEvent } from "../business_event";
 import { InvalidCommand } from "../errors/invalid_command";
 import { NotAuthorized } from "../errors/not_authorized";
 import { NotFound } from "../errors/not_found";
+import { PreconditionError } from "../errors/precondition_error";
 import { Identity } from "../organization/identity";
 import { ServiceUser } from "../organization/service_user";
 import * as Project from "./project";
@@ -52,6 +53,20 @@ export async function revokeProjectPermission(
   const updatedProject = ProjectEventSourcing.newProjectFromEvent(ctx, project, permissionRevoked);
   if (Result.isErr(updatedProject)) {
     return new InvalidCommand(ctx, permissionRevoked, [updatedProject]);
+  }
+
+  // Prevent revoking grant permission of last user
+  const intents: Intent[] = ["project.intent.grantPermission"];
+  if (
+    intents.includes(intent) &&
+    project.permissions[`${intent}`] !== undefined &&
+    project.permissions[`${intent}`].length === 1
+  ) {
+    return new PreconditionError(
+      ctx,
+      permissionRevoked,
+      `Revoking ${intent} of last user is not allowed.`,
+    );
   }
 
   // Only emit the event if it causes any changes to the permissions:

--- a/api/src/service/domain/workflow/subproject_create.ts
+++ b/api/src/service/domain/workflow/subproject_create.ts
@@ -6,6 +6,7 @@ import * as Result from "../../../result";
 import { randomString } from "../../hash";
 import * as AdditionalData from "../additional_data";
 import { BusinessEvent } from "../business_event";
+import { AlreadyExists } from "../errors/already_exists";
 import { InvalidCommand } from "../errors/invalid_command";
 import { NotAuthorized } from "../errors/not_authorized";
 import { NotFound } from "../errors/not_found";
@@ -18,7 +19,6 @@ import * as Project from "./project";
 import { ProjectedBudget, projectedBudgetListSchema } from "./projected_budget";
 import * as Subproject from "./subproject";
 import * as SubprojectCreated from "./subproject_created";
-import { sourceSubprojects } from "./subproject_eventsourcing";
 
 export interface RequestData {
   projectId: Project.Id;
@@ -88,7 +88,7 @@ export async function createSubproject(
   if (
     await repository.subprojectExists(subprojectCreated.projectId, subprojectCreated.subproject.id)
   ) {
-    return new PreconditionError(ctx, subprojectCreated, "subproject already exists");
+    return new AlreadyExists(ctx, subprojectCreated, subprojectCreated.subproject.id);
   }
 
   const projectPermissionsResult = await repository.projectPermissions(projectId);

--- a/api/src/service/domain/workflow/subproject_permission_revoke.spec.ts
+++ b/api/src/service/domain/workflow/subproject_permission_revoke.spec.ts
@@ -1,0 +1,117 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { PreconditionError } from "../errors/precondition_error";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import * as Subproject from "./subproject";
+import * as SubprojectPermissionRevoke from "./subproject_permission_revoke";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const executingUser: ServiceUser = { id: "mstein", groups: [] };
+const testUser: ServiceUser = { id: "testUser", groups: [] };
+
+const permissions: Permissions = {
+  "subproject.viewSummary": ["testUser"],
+  "subproject.viewDetails": ["testUser"],
+  "subproject.intent.grantPermission": ["testUser"],
+  "subproject.intent.revokePermission": ["mstein"],
+};
+
+const testsubproject: Subproject.Subproject = {
+  id: "testsubproject",
+  projectId: "testProject",
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: "unitTestName",
+  description: "",
+  currency: "EUR",
+  workflowitemOrdering: [],
+  projectedBudgets: [],
+  permissions,
+  log: [],
+  additionalData: {},
+};
+
+describe("revoke subproject permissions", () => {
+  it("With the 'subproject.intent.revokePermission' permission, the user can revoke subproject permissions", async () => {
+    const revokeResult = await SubprojectPermissionRevoke.revokeSubprojectPermission(
+      ctx,
+      executingUser,
+      testsubproject.projectId,
+      testsubproject.id,
+      testUser.id,
+      "subproject.viewDetails",
+      {
+        getSubproject: async () => testsubproject,
+      },
+    );
+
+    if (Result.isErr(revokeResult)) {
+      throw revokeResult;
+    }
+    assert.lengthOf(revokeResult.newEvents, 1);
+    const revokeEvent = revokeResult.newEvents[0];
+    const expectedEvent: BusinessEvent = {
+      type: "subproject_permission_revoked",
+      source: ctx.source,
+      publisher: executingUser.id,
+      time: revokeEvent.time,
+      projectId: testsubproject.projectId,
+      subprojectId: testsubproject.id,
+      permission: "subproject.viewDetails",
+      revokee: testUser.id,
+    };
+    assert.deepEqual(expectedEvent, revokeEvent);
+  });
+
+  it("Without the 'subproject.intent.revokePermission' permission, the user cannot revoke subproject permissions", async () => {
+    const subprojectWithoutPermission: Subproject.Subproject = {
+      id: "testsubproject",
+      projectId: "testProject",
+      createdAt: new Date().toISOString(),
+      status: "open",
+      displayName: "unitTestName",
+      description: "",
+      currency: "EUR",
+      workflowitemOrdering: [],
+      projectedBudgets: [],
+      permissions: { "subproject.intent.revokePermission": [] },
+      log: [],
+      additionalData: {},
+    };
+    const revokeResult = await SubprojectPermissionRevoke.revokeSubprojectPermission(
+      ctx,
+      executingUser,
+      testsubproject.projectId,
+      testsubproject.id,
+      testUser.id,
+      "subproject.viewDetails",
+      {
+        getSubproject: async () => subprojectWithoutPermission,
+      },
+    );
+
+    assert.isTrue(Result.isErr(revokeResult));
+    assert.instanceOf(revokeResult, NotAuthorized);
+  });
+
+  it("Revoking grantPermission permission of last user is not allowed and leads to a precondition error.", async () => {
+    const revokeResult = await SubprojectPermissionRevoke.revokeSubprojectPermission(
+      ctx,
+      executingUser,
+      testsubproject.projectId,
+      testsubproject.id,
+      testUser.id,
+      "subproject.intent.grantPermission",
+      {
+        getSubproject: async () => testsubproject,
+      },
+    );
+
+    assert.isTrue(Result.isErr(revokeResult));
+    assert.instanceOf(revokeResult, PreconditionError);
+  });
+});

--- a/api/src/service/domain/workflow/workflowitem_permission_revoke.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_revoke.spec.ts
@@ -1,0 +1,122 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { PreconditionError } from "../errors/precondition_error";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import * as Workflowitem from "./workflowitem";
+import * as WorkflowitemPermissionRevoke from "./workflowitem_permission_revoke";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const executingUser: ServiceUser = { id: "mstein", groups: [] };
+const testUser: ServiceUser = { id: "testUser", groups: [] };
+const projectId = "testProject";
+
+const permissions: Permissions = {
+  "workflowitem.view": ["testUser"],
+  "workflowitem.assign": ["testUser"],
+  "workflowitem.intent.grantPermission": ["testUser"],
+  "workflowitem.intent.revokePermission": ["mstein"],
+};
+
+const testworkflowitem: Workflowitem.Workflowitem = {
+  isRedacted: false,
+  id: "testworkflowitem",
+  subprojectId: "testSubproject",
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: "unitTestName",
+  description: "",
+  amountType: "N/A",
+  documents: [],
+  permissions,
+  log: [],
+  additionalData: {},
+};
+
+describe("revoke workflowitem permissions", () => {
+  it("With the 'workflowitem.intent.revokePermission' permission, the user can revoke workflowitem permissions", async () => {
+    const revokeResult = await WorkflowitemPermissionRevoke.revokeWorkflowitemPermission(
+      ctx,
+      executingUser,
+      projectId,
+      testworkflowitem.subprojectId,
+      testworkflowitem.id,
+      testUser.id,
+      "workflowitem.assign",
+      {
+        getWorkflowitem: async () => testworkflowitem,
+      },
+    );
+
+    if (Result.isErr(revokeResult)) {
+      throw revokeResult;
+    }
+    assert.lengthOf(revokeResult.newEvents, 1);
+    const revokeEvent = revokeResult.newEvents[0];
+    const expectedEvent: BusinessEvent = {
+      type: "workflowitem_permission_revoked",
+      source: ctx.source,
+      publisher: executingUser.id,
+      time: revokeEvent.time,
+      projectId: projectId,
+      subprojectId: testworkflowitem.subprojectId,
+      workflowitemId: testworkflowitem.id,
+      permission: "workflowitem.assign",
+      revokee: testUser.id,
+    };
+    assert.deepEqual(expectedEvent, revokeEvent);
+  });
+
+  it("Without the 'workflowitem.intent.revokePermission' permission, the user cannot revoke workflowitem permissions", async () => {
+    const workflowitemWithoutPermission: Workflowitem.Workflowitem = {
+      isRedacted: false,
+      id: "testworkflowitem",
+      subprojectId: "testsubProject",
+      createdAt: new Date().toISOString(),
+      status: "open",
+      displayName: "unitTestName",
+      amountType: "N/A",
+      description: "",
+      documents: [],
+      permissions: { "workflowitem.intent.revokePermission": [] },
+      log: [],
+      additionalData: {},
+    };
+    const revokeResult = await WorkflowitemPermissionRevoke.revokeWorkflowitemPermission(
+      ctx,
+      executingUser,
+      projectId,
+      testworkflowitem.subprojectId,
+      testworkflowitem.id,
+      testUser.id,
+      "workflowitem.view",
+      {
+        getWorkflowitem: async () => workflowitemWithoutPermission,
+      },
+    );
+
+    assert.isTrue(Result.isErr(revokeResult));
+    assert.instanceOf(revokeResult, NotAuthorized);
+  });
+
+  it("Revoking grantPermission permission of last user is not allowed and leads to a precondition error.", async () => {
+    const revokeResult = await WorkflowitemPermissionRevoke.revokeWorkflowitemPermission(
+      ctx,
+      executingUser,
+      projectId,
+      testworkflowitem.subprojectId,
+      testworkflowitem.id,
+      testUser.id,
+      "workflowitem.intent.grantPermission",
+      {
+        getWorkflowitem: async () => testworkflowitem,
+      },
+    );
+
+    assert.isTrue(Result.isErr(revokeResult));
+    assert.instanceOf(revokeResult, PreconditionError);
+  });
+});

--- a/api/src/service/domain/workflow/workflowitem_permission_revoke.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_revoke.ts
@@ -7,6 +7,7 @@ import { BusinessEvent } from "../business_event";
 import { InvalidCommand } from "../errors/invalid_command";
 import { NotAuthorized } from "../errors/not_authorized";
 import { NotFound } from "../errors/not_found";
+import { PreconditionError } from "../errors/precondition_error";
 import { Identity } from "../organization/identity";
 import { ServiceUser } from "../organization/service_user";
 import * as Project from "./project";
@@ -71,6 +72,20 @@ export async function revokeWorkflowitemPermission(
   );
   if (Result.isErr(updatedWorkflowitem)) {
     return new InvalidCommand(ctx, permissionRevoked, [updatedWorkflowitem]);
+  }
+
+  // Prevent revoking grant permission of last user
+  const intents: Intent[] = ["workflowitem.intent.grantPermission"];
+  if (
+    intents.includes(intent) &&
+    workflowitem.permissions[`${intent}`] !== undefined &&
+    workflowitem.permissions[`${intent}`].length === 1
+  ) {
+    return new PreconditionError(
+      ctx,
+      permissionRevoked,
+      `Revoking ${intent} of last user is not allowed.`,
+    );
   }
 
   // Only emit the event if it causes any changes to the permissions:

--- a/api/src/service/user_create.ts
+++ b/api/src/service/user_create.ts
@@ -24,12 +24,12 @@ export async function createUser(
 ): Promise<AuthToken.AuthToken> {
   const result = await UserCreate.createUser(ctx, serviceUser, requestData, {
     getGlobalPermissions: async () => getGlobalPermissions(conn, ctx, serviceUser),
-    userExists: async userId => userExists(conn, ctx, serviceUser, userId),
-    organizationExists: async organization =>
+    userExists: async (userId) => userExists(conn, ctx, serviceUser, userId),
+    organizationExists: async (organization) =>
       organizationExists(conn.multichainClient, organization),
     createKeyPair: async () => createkeypairs(conn.multichainClient),
-    hash: async plaintext => hashPassword(plaintext),
-    encrypt: async plaintext => encrypt(organizationSecret, plaintext),
+    hash: async (plaintext) => hashPassword(plaintext),
+    encrypt: async (plaintext) => encrypt(organizationSecret, plaintext),
   });
   if (Result.isErr(result)) return Promise.reject(result);
   if (!result.length) {
@@ -47,11 +47,11 @@ export async function createUser(
     throw new Error(`Expected new events to yield exactly one user, got: ${JSON.stringify(users)}`);
   }
   const token = await AuthToken.fromUserRecord(users[0], {
-    getGroupsForUser: async userId => {
+    getGroupsForUser: async (userId) => {
       const groups = await GroupQuery.getGroupsForUser(conn, ctx, serviceUser, userId);
-      return groups.map(group => group.id);
+      return groups.map((group) => group.id);
     },
-    getOrganizationAddress: async organization => {
+    getOrganizationAddress: async (organization) => {
       const address = await getOrganizationAddress(conn.multichainClient, organization);
       if (address === undefined) {
         throw new Error(`Could not find address for organization "${organization}"`);

--- a/e2e-test/cypress/integration/project_assignee_spec.js
+++ b/e2e-test/cypress/integration/project_assignee_spec.js
@@ -1,5 +1,6 @@
 describe("Project Assignee", function() {
   const executingUser = "mstein";
+  const testUser = "jdoe";
   let projectId;
   let permissionsBeforeTesting;
 
@@ -122,6 +123,8 @@ describe("Project Assignee", function() {
     assertViewPermissions(permissionsBeforeTesting, projectId, false);
   });
   it("Assigning without project permission to grant view permissions is not possible", function() {
+    // Grant project.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantProjectPermission(projectId, "project.intent.grantPermission", testUser);
     cy.revokeProjectPermission(projectId, "project.intent.grantPermission", executingUser);
     // Open dialog
     cy.get("@firstUncheckedRadioButton").then(firstUncheckedRadioButton => {

--- a/e2e-test/cypress/integration/project_permissions_spec.js
+++ b/e2e-test/cypress/integration/project_permissions_spec.js
@@ -2,6 +2,7 @@ import _cloneDeep from "lodash/cloneDeep";
 
 const executingUser = { id: "mstein", displayname: "Mauro Stein" };
 const testUser = { id: "thouse", displayname: "Tom House" };
+const testUser2 = { id: "jdoe", displayname: "John Doe" };
 let projectId, permissionsBeforeTesting, baseUrl, apiRoute;
 const groupToGivePermissions = "reviewers";
 const testGroupId = "admins";
@@ -200,7 +201,19 @@ describe("Project Permissions", function() {
     cy.get("[data-test=confirmation-dialog-cancel]").should("be.visible");
   });
 
+  it("Revoke a permission from myself is not allowed", function() {
+    cy.get(`[data-test=project-card-${projectId}]`)
+      .find("button[data-test^='pp-button']")
+      .click();
+    cy.get("[data-test='permission-select-project.viewSummary']").click();
+    cy.get("[data-test='permission-list']")
+      .find(`li[value*='${executingUser.id}'] input`)
+      .should("be.disabled");
+  });
+
   it("Submitting the permission dialog without project.intent.grantPermission disables the submit button when adding user", function() {
+    // Grant project.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantProjectPermission(projectId, "project.intent.grantPermission", testUser2.id);
     cy.revokeProjectPermission(projectId, "project.intent.grantPermission", executingUser.id);
 
     cy.get(`[data-test=project-card-${projectId}]`)
@@ -241,6 +254,8 @@ describe("Project Permissions", function() {
   });
 
   it("User having 'view permissions'- permission only can view but not grant/revoke permissions", function() {
+    // Grant project.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantProjectPermission(projectId, "project.intent.grantPermission", testUser2.id);
     cy.revokeProjectPermission(projectId, "project.intent.grantPermission", executingUser.id);
     cy.revokeProjectPermission(projectId, "project.intent.revokePermission", executingUser.id);
 

--- a/e2e-test/cypress/integration/subproject_assignee_spec.js
+++ b/e2e-test/cypress/integration/subproject_assignee_spec.js
@@ -1,5 +1,6 @@
 describe("Subproject Assignee", function() {
   const executingUser = "mstein";
+  const testUser = "jdoe";
   let projectId;
   let subprojectId;
   let permissionsBeforeTesting;
@@ -152,6 +153,8 @@ describe("Subproject Assignee", function() {
     assertViewPermissions(permissionsBeforeTesting, projectId, subprojectId, false);
   });
   it("Assigning without project permission to grant view permissions is not possible", function() {
+    // Grant project.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantProjectPermission(projectId, "project.intent.grantPermission", testUser);
     cy.revokeProjectPermission(projectId, "project.intent.grantPermission", executingUser);
     // Open dialog
     cy.get("@firstUncheckedRadioButton").then(firstUncheckedRadioButton => {
@@ -172,6 +175,8 @@ describe("Subproject Assignee", function() {
     cy.grantProjectPermission(projectId, "project.intent.grantPermission", executingUser);
   });
   it("Assigning without subproject permission to grant view permissions is not possible", function() {
+    // Grant subproject.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", testUser);
     cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser);
 
     // Open dialog
@@ -193,6 +198,9 @@ describe("Subproject Assignee", function() {
     cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser);
   });
   it("Assigning without project nor subproject permission to grant view permissions is not possible", function() {
+    // Grant project/subproject.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantProjectPermission(projectId, "project.intent.grantPermission", testUser);
+    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", testUser);
     cy.revokeProjectPermission(projectId, "project.intent.grantPermission", executingUser);
     cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser);
 

--- a/e2e-test/cypress/integration/subproject_permissions_spec.js
+++ b/e2e-test/cypress/integration/subproject_permissions_spec.js
@@ -150,10 +150,7 @@ describe("Subproject Permissions", function() {
       .scrollIntoView()
       .click();
     // Close permission search popup
-    cy.get("[data-test=permission-search] input")
-      .scrollIntoView()
-      .should("be.visible")
-      .type("{esc}");
+    cy.get("[data-test=permission-search] input").type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     cy.get("[data-test=permission-submit]").click();
     // Open confirmation
@@ -175,10 +172,7 @@ describe("Subproject Permissions", function() {
         .find(`li[value*='${testUser.id}']`)
         .click();
       // Close permission search popup
-      cy.get("[data-test=permission-search] input")
-        .scrollIntoView()
-        .should("be.visible")
-        .type("{esc}");
+      cy.get("[data-test=permission-search] input").type("{esc}");
       cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
       cy.get("[data-test=permission-submit]").click();
       // Open confirmation
@@ -186,8 +180,25 @@ describe("Subproject Permissions", function() {
     });
   });
 
+  it("Revoke a permission from myself is not allowed", function() {
+    cy.get("[data-test=subproject-" + subprojectId + "]").should("be.visible");
+    cy.get("[data-test=subproject-" + subprojectId + "] [data-test*=spp-button]")
+      .should("be.visible")
+      .click();
+    // Open permission search popup
+    cy.get("[data-test='permission-select-subproject.viewSummary']").click();
+    // Select and add a User
+    cy.get("[data-test='permission-list']")
+      .scrollIntoView()
+      .should("be.visible")
+      .find(`li[value*='${executingUser.id}'] input`)
+      .should("be.disabled");
+  });
+
   it("Submitting the permission dialog without subproject.intent.grantPermission disables the submit button when adding user", function() {
     cy.login("root", rootSecret);
+    // Grant subproject.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", testUser2.id);
     cy.revokeSubprojectPermission(projectId, subprojectId, "subproject.intent.grantPermission", executingUser.id).then(
       () => {
         // Mstein login
@@ -205,10 +216,7 @@ describe("Subproject Permissions", function() {
           .find(`li[value*='${testUser.id}']`)
           .click();
         // Close permission search popup
-        cy.get("[data-test=permission-search] input")
-          .scrollIntoView()
-          .should("be.visible")
-          .type("{esc}");
+        cy.get("[data-test=permission-search] input").type("{esc}");
         cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
         cy.get("[data-test=permission-submit]").should("be.disabled");
       }
@@ -241,10 +249,7 @@ describe("Subproject Permissions", function() {
           .find(`li[value*='${testUser.id}']`)
           .click();
         // Close permission search popup
-        cy.get("[data-test=permission-search] input")
-          .scrollIntoView()
-          .should("be.visible")
-          .type("{esc}");
+        cy.get("[data-test=permission-search] input").type("{esc}");
         cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
         cy.get("[data-test=permission-submit]").should("be.disabled");
       });
@@ -282,11 +287,8 @@ describe("Subproject Permissions", function() {
       .should("be.visible")
       .find(`li[value*='${testUser.id}']`)
       .click();
-    // Close permission search popup
-    cy.get("[data-test=permission-search] input")
-      .scrollIntoView()
-      .should("be.visible")
-      .type("{esc}");
+    // Close permission popup
+    cy.get("[data-test=permission-search] input").type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     cy.get("[data-test=permission-submit]").click();
     // Open confirmation
@@ -310,10 +312,7 @@ describe("Subproject Permissions", function() {
       .find(`li[value*='${testUser.id}']`)
       .click();
     // Close permission search popup
-    cy.get("[data-test=permission-search] input")
-      .scrollIntoView()
-      .should("be.visible")
-      .type("{esc}");
+    cy.get("[data-test=permission-search] input").type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     // Open confirmation
     cy.get("[data-test=permission-submit]").click();
@@ -342,10 +341,7 @@ describe("Subproject Permissions", function() {
           .find(`li[value*='${testUser.id}']`)
           .click();
         // Close permission search popup
-        cy.get("[data-test=permission-search] input")
-          .scrollIntoView()
-          .should("be.visible")
-          .type("{esc}");
+        cy.get("[data-test=permission-search] input").type("{esc}");
         cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
         cy.get("[data-test=permission-submit]").click();
         // Confirmation opens
@@ -380,10 +376,7 @@ describe("Subproject Permissions", function() {
       .find(`li[value*='${testUser.id}']`)
       .click();
     // Close permission search popup
-    cy.get("[data-test=permission-search] input")
-      .scrollIntoView()
-      .should("be.visible")
-      .type("{esc}");
+    cy.get("[data-test=permission-search] input").type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     // Open confirmation
     cy.get("[data-test=permission-submit]").click();
@@ -439,10 +432,7 @@ describe("Subproject Permissions", function() {
         .find(`li[value*='${testUser2.id}']`)
         .click();
       // Close permission search popup
-      cy.get("[data-test=permission-search] input")
-        .scrollIntoView()
-        .should("be.visible")
-        .type("{esc}");
+      cy.get("[data-test=permission-search] input").type("{esc}");
       cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
       cy.get("[data-test=permission-submit]")
         .should("be.visible")
@@ -477,10 +467,7 @@ describe("Subproject Permissions", function() {
       .find(`li[value*='${testUser.id}']`)
       .click();
     // Close permission search popup
-    cy.get("[data-test=permission-search] input")
-      .scrollIntoView()
-      .should("be.visible")
-      .type("{esc}");
+    cy.get("[data-test=permission-search] input").type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     cy.get("[data-test=permission-submit]").click();
     // Confirmation opens
@@ -518,10 +505,7 @@ describe("Subproject Permissions", function() {
         .click();
     });
     // Close permission search popup
-    cy.get("[data-test=permission-search] input")
-      .scrollIntoView()
-      .should("be.visible")
-      .type("{esc}");
+    cy.get("[data-test=permission-search] input").type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     cy.get("[data-test=permission-submit]").click();
     // Confirmation opens
@@ -578,10 +562,7 @@ describe("Subproject Permissions", function() {
         .click();
     });
     // Close permission search popup
-    cy.get("[data-test=permission-search] input")
-      .scrollIntoView()
-      .should("be.visible")
-      .type("{esc}");
+    cy.get("[data-test=permission-search] input").type("{esc}");
     cy.get("[data-test=permission-selection-popup]").should("not.be.visible");
     cy.get("[data-test=permission-submit]").click();
     // Confirmation opens

--- a/e2e-test/cypress/integration/workflowitem_history_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_history_spec.js
@@ -64,6 +64,7 @@ describe("Workflowitem's history", function() {
   it("The history is sorted from new to old", function() {
     cy.server();
     cy.route("GET", apiRoute + "/workflowitem.viewHistory*").as("viewHistory");
+    cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
 
     // Update workflowitem to create new history event
     cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
@@ -76,7 +77,9 @@ describe("Workflowitem's history", function() {
       .click();
     // Open info dialog
     cy.get(`[data-test=workflowitem-${workflowitemId}]`).should("be.visible");
-    cy.get(`[data-test^='workflowitem-info-button-${workflowitemId}']`).click();
+    cy.wait("@viewDetails")
+      .get(`[data-test*='workflowitem-info-button-${workflowitemId}']`)
+      .click();
     cy.get("[data-test=workflowitem-history-tab]").click();
     // The oldest entry is the create event
     cy.wait("@viewHistory")

--- a/e2e-test/cypress/integration/workflowitem_permissions_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_permissions_spec.js
@@ -2,6 +2,7 @@ import _cloneDeep from "lodash/cloneDeep";
 
 const executingUser = { id: "mstein", displayname: "Mauro Stein" };
 const testUser = { id: "thouse", displayname: "Tom House" };
+const testUser2 = { id: "jdoe", displayname: "John Doe" };
 const testGroupId = "admins";
 const groupToGivePermissions = "reviewers";
 let projectId, subprojectId, workflowitemId, permissionsBeforeTesting, baseUrl, apiRoute;
@@ -169,8 +170,20 @@ describe("Workflowitem Permissions", function() {
     cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.view", testUser.id);
   });
 
+  it("Revoke a permission from myself is not allowed", function() {
+    cy.get("[data-test=show-workflowitem-permissions]")
+      .first()
+      .click();
+    cy.get("[data-test='permission-select-workflowitem.intent.grantPermission']").click();
+    cy.get("[data-test='permission-list']")
+      .find(`li[value*='${executingUser.id}'] input`)
+      .should("be.disabled");
+  });
+
   it("Submitting the permission dialog without workflowitem.intent.grantPermission disables the submit button when adding user", function() {
     const intent = "workflowitem.intent.grantPermission";
+    // Grant workflowitem.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, intent, testUser2.id);
     cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, intent, testUser.id);
     cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, intent, executingUser.id);
 
@@ -220,6 +233,8 @@ describe("Workflowitem Permissions", function() {
     const grantIntent = "workflowitem.intent.grantPermission";
     const revokeIntent = "workflowitem.intent.revokePermission";
 
+    // Grant workflowitem.intent.grantPermission to other user first because it's not allowed to revoke the last user
+    cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, grantIntent, testUser2.id);
     cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, grantIntent, executingUser.id);
     cy.revokeWorkflowitemPermission(projectId, subprojectId, workflowitemId, revokeIntent, executingUser.id);
 

--- a/frontend/src/pages/Common/Permissions/PermissionSelection.js
+++ b/frontend/src/pages/Common/Permissions/PermissionSelection.js
@@ -14,7 +14,7 @@ import React, { Component } from "react";
 
 import strings from "../../../localizeStrings";
 
-const renderSelection = (user, permissionedUser, permissionName, grant, revoke, myself, disabled) =>
+const renderSelection = (user, permissionedUser, intent, grant, revoke, myself, disabled) =>
   user.map(u => {
     const checked = permissionedUser.indexOf(u.id) > -1;
     return (
@@ -22,7 +22,7 @@ const renderSelection = (user, permissionedUser, permissionName, grant, revoke, 
         disabled={(u.id === myself && checked) || disabled}
         key={u.id + "selection"}
         value={u.id}
-        onClick={checked ? () => revoke(permissionName, u.id) : () => grant(permissionName, u.id)}
+        onClick={checked ? () => revoke(intent, u.id) : () => grant(intent, u.id)}
       >
         <Checkbox checked={checked} disabled={(u.id === myself && checked) || disabled} />
         <ListItemText primary={u.displayName} />

--- a/frontend/src/pages/Loading/actions.js
+++ b/frontend/src/pages/Loading/actions.js
@@ -1,23 +1,18 @@
 export const FETCH_USER = "FETCH_USER";
-export const SHOW_LOADING_INDICATOR = 'SHOW_LOADING_INDICATOR';
-export const HIDE_LOADING_INDICATOR = 'HIDE_LOADING_INDICATOR';
-export const CANCEL_DEBOUNCE = 'CANCEL_DEBOUNCE';
+export const SHOW_LOADING_INDICATOR = "SHOW_LOADING_INDICATOR";
+export const HIDE_LOADING_INDICATOR = "HIDE_LOADING_INDICATOR";
+export const CANCEL_DEBOUNCE = "CANCEL_DEBOUNCE";
 
 export function fetchUserWithToken(showLoading = false) {
   return {
     type: FETCH_USER,
     showLoading
-  }
+  };
 }
 export function showLoadingIndicator() {
   return {
-    type: SHOW_LOADING_INDICATOR,
-    meta: {
-      debounce: {
-        time: 300
-      }
-    }
-  }
+    type: SHOW_LOADING_INDICATOR
+  };
 }
 
 export function cancelDebounce() {
@@ -29,11 +24,11 @@ export function cancelDebounce() {
         key: SHOW_LOADING_INDICATOR
       }
     }
-  }
+  };
 }
 
 export function hideLoadingIndicator() {
   return {
-    type: HIDE_LOADING_INDICATOR,
-  }
+    type: HIDE_LOADING_INDICATOR
+  };
 }

--- a/frontend/src/pages/Workflows/WorkflowBatchEditContainer.js
+++ b/frontend/src/pages/Workflows/WorkflowBatchEditContainer.js
@@ -40,7 +40,8 @@ const mapStateToProps = state => {
     submittedWorkflowItems: state.getIn(["workflow", "submittedWorkflowItems"]),
     failedWorkflowItem: state.getIn(["workflow", "failedWorkflowItem"]),
     submitDone: state.getIn(["workflow", "submitDone"]),
-    submitInProgress: state.getIn(["workflow", "submitInProgress"])
+    submitInProgress: state.getIn(["workflow", "submitInProgress"]),
+    myself: state.getIn(["login", "id"])
   };
 };
 

--- a/frontend/src/pages/Workflows/WorkflowContainer.js
+++ b/frontend/src/pages/Workflows/WorkflowContainer.js
@@ -59,7 +59,6 @@ class WorkflowContainer extends Component {
     this.props.setSelectedView(this.subprojectId, "subProject");
     this.props.fetchUser();
     this.props.fetchAllSubprojectDetails(this.projectId, this.subprojectId, true);
-    this.setState({ isDataFetched: true });
   }
 
   componentWillUnmount() {
@@ -95,33 +94,29 @@ class WorkflowContainer extends Component {
       <div>
         {!this.props.workflowSortEnabled ? this.addLiveUpdates() : null}
         <div style={globalStyles.innerContainer}>
-          {!this.state.isDataFetched ? (
-            <div />
-          ) : (
-            <div>
-              <SubProjectDetails
-                {...this.props}
-                projectId={this.projectId}
-                subprojectId={this.subprojectId}
-                canViewPermissions={canViewPermissions}
-                canAssignSubproject={canAssignSubproject}
-                closeSubproject={this.closeSubproject}
-                canCloseSubproject={canCloseSubproject}
-                isDataLoading={this.props.isDataLoading}
-              />
+          <div>
+            <SubProjectDetails
+              {...this.props}
+              projectId={this.projectId}
+              subprojectId={this.subprojectId}
+              canViewPermissions={canViewPermissions}
+              canAssignSubproject={canAssignSubproject}
+              closeSubproject={this.closeSubproject}
+              canCloseSubproject={canCloseSubproject}
+              isDataLoading={this.props.isDataLoading}
+            />
 
-              {this.props.permissionDialogShown ? (
-                <WorkflowItemPermissionsContainer projectId={this.projectId} subProjectId={this.subprojectId} />
-              ) : null}
-              <Workflow
-                {...this.props}
-                projectId={this.projectId}
-                subProjectId={this.subprojectId}
-                closeWorkflowItem={this.closeWorkflowItem}
-                isDataLoading={this.props.isDataLoading}
-              />
-            </div>
-          )}
+            {this.props.permissionDialogShown ? (
+              <WorkflowItemPermissionsContainer projectId={this.projectId} subProjectId={this.subprojectId} />
+            ) : null}
+            <Workflow
+              {...this.props}
+              projectId={this.projectId}
+              subProjectId={this.subprojectId}
+              closeWorkflowItem={this.closeWorkflowItem}
+              isDataLoading={this.props.isDataLoading}
+            />
+          </div>
           <WorkflowDialogContainer location={this.props.location} />
           <AdditionalInfo
             resources={this.props.workflowItems}

--- a/frontend/src/pages/Workflows/WorkflowEditDrawer.js
+++ b/frontend/src/pages/Workflows/WorkflowEditDrawer.js
@@ -55,7 +55,8 @@ const WorkflowEditDrawer = props => {
     tempDrawerAssignee,
     tempDrawerPermissions,
     storeAssignee,
-    projectId
+    projectId,
+    myself
   } = props;
   const permissions = _isEmpty(tempDrawerPermissions) ? getDefaultPermissions() : tempDrawerPermissions;
 
@@ -122,6 +123,7 @@ const WorkflowEditDrawer = props => {
           addTemporaryPermission={grantPermission}
           removeTemporaryPermission={revokePermission}
           temporaryPermissions={permissions}
+          myself={myself}
         />
       </div>
     </Drawer>

--- a/frontend/src/pages/Workflows/WorkflowItemPermissionsContainer.js
+++ b/frontend/src/pages/Workflows/WorkflowItemPermissionsContainer.js
@@ -125,7 +125,8 @@ const mapStateToProps = state => {
     workflowItems: state.getIn(["workflow", "workflowItems"]),
     permissionDialogShown: state.getIn(["workflow", "showWorkflowPermissions"]),
     userList: state.getIn(["login", "user"]),
-    isConfirmationDialogOpen: state.getIn(["confirmation", "open"])
+    isConfirmationDialogOpen: state.getIn(["confirmation", "open"]),
+    myself: state.getIn(["login", "id"])
   };
 };
 

--- a/frontend/src/sagas.js
+++ b/frontend/src/sagas.js
@@ -596,7 +596,7 @@ export function* validateDocumentSaga({ base64String, hash }) {
       type: VALIDATE_DOCUMENT_SUCCESS,
       isIdentical: data.isIdentical
     });
-  }, true);
+  }, false);
 }
 
 export function* setEnvironmentSaga(action) {

--- a/provisioning/src/api.js
+++ b/provisioning/src/api.js
@@ -5,8 +5,8 @@ const authenticate = async (axios, userId, password) => {
     axios.post("/user.authenticate", {
       user: {
         id: userId,
-        password
-      }
+        password,
+      },
     })
   );
   const body = response.data;
@@ -15,22 +15,22 @@ const authenticate = async (axios, userId, password) => {
 };
 
 const createUser = async (axios, user, organization) => {
-  await withRetry(() =>
-    axios.post("/global.createUser", {
+  await withRetry(() => {
+    return axios.post("/global.createUser", {
       user: {
         ...user,
-        organization
-      }
-    })
-  );
+        organization,
+      },
+    });
+  });
 };
 
 const createGroup = async (axios, group) => {
   await withRetry(() =>
     axios.post("/global.createGroup", {
       group: {
-        ...group
-      }
+        ...group,
+      },
     })
   );
 };
@@ -39,7 +39,7 @@ const addUserToGroup = async (axios, groupId, userId) => {
   await withRetry(() =>
     axios.post("/group.addUser", {
       groupId,
-      userId
+      userId,
     })
   );
 };
@@ -48,7 +48,7 @@ const removeUserFromGroup = async (axios, groupId, userId) => {
   await withRetry(() =>
     axios.post("/group.removeUser", {
       groupId,
-      userId
+      userId,
     })
   );
 };
@@ -57,7 +57,7 @@ const grantGlobalPermissionToUser = async (axios, intent, userId) => {
   return await withRetry(() =>
     axios.post("/global.grantPermission", {
       intent,
-      identity: userId
+      identity: userId,
     })
   );
 };
@@ -65,14 +65,14 @@ const grantGlobalPermissionToUser = async (axios, intent, userId) => {
 const grantAllPermissionsToUser = async (axios, userId) => {
   return await withRetry(() =>
     axios.post("/global.grantAllPermissions", {
-      identity: userId
+      identity: userId,
     })
   );
 };
 
 const createProject = async (axios, projectTemplate) => {
   const args = {
-    ...projectTemplate
+    ...projectTemplate,
   };
   delete args.permissions;
   delete args.subprojects;
@@ -80,8 +80,8 @@ const createProject = async (axios, projectTemplate) => {
     axios.post("/global.createProject", {
       project: {
         ...args,
-        status: "open" // otherwise we won't be able to add subprojects
-      }
+        status: "open", // otherwise we won't be able to add subprojects
+      },
     })
   );
 };
@@ -89,14 +89,14 @@ const createProject = async (axios, projectTemplate) => {
 const closeProject = async (axios, project) => {
   await withRetry(() =>
     axios.post("/project.close", {
-      projectId: project.data.id
+      projectId: project.data.id,
     })
   );
 };
 
 const createSubproject = async (axios, project, subprojectTemplate) => {
   const args = {
-    ...subprojectTemplate
+    ...subprojectTemplate,
   };
   delete args.permissions;
   delete args.workflows;
@@ -106,8 +106,8 @@ const createSubproject = async (axios, project, subprojectTemplate) => {
       subproject: {
         ...args,
         description: "FAILED UPDATE?",
-        status: "open" // otherwise we won't be able to add workflowitems
-      }
+        status: "open", // otherwise we won't be able to add workflowitems
+      },
     })
   );
 };
@@ -116,7 +116,7 @@ const updateProject = async (axios, projectId, description) => {
   await withRetry(() =>
     axios.post("/project.update", {
       projectId: projectId,
-      description: description || ""
+      description: description || "",
     })
   );
 };
@@ -131,7 +131,7 @@ const updateSubproject = async (
     axios.post("/subproject.update", {
       projectId: projectId,
       subprojectId: subprojectId,
-      description: description || ""
+      description: description || "",
     })
   );
 };
@@ -139,7 +139,7 @@ const closeSubproject = async (axios, projectId, subprojectId) => {
   await withRetry(() =>
     axios.post("/subproject.close", {
       projectId: projectId,
-      subprojectId: subprojectId
+      subprojectId: subprojectId,
     })
   );
 };
@@ -160,7 +160,7 @@ const updateWorkflowitem = async (
       projectId: projectId,
       subprojectId: subprojectId,
       workflowitemId: workflowitemId,
-      description: description || ""
+      description: description || "",
     })
   );
 };
@@ -174,7 +174,7 @@ const closeWorkflowitem = async (
     axios.post("/workflowitem.close", {
       projectId: projectId,
       subprojectId: subprojectId,
-      workflowitemId: workflowitemId
+      workflowitemId: workflowitemId,
     })
   );
 };
@@ -183,11 +183,11 @@ const findProject = async (axios, projectTemplate) => {
   return await withRetry(() =>
     axios
       .get("/project.list")
-      .then(res => res.data.data.items)
-      .then(projects =>
-        projects.find(p => p.data.displayName === projectTemplate.displayName)
+      .then((res) => res.data.data.items)
+      .then((projects) =>
+        projects.find((p) => p.data.displayName === projectTemplate.displayName)
       )
-      .catch(err => {
+      .catch((err) => {
         console.error(err);
         process.exit(1);
       })
@@ -198,10 +198,10 @@ const findSubproject = async (axios, project, subprojectTemplate) => {
   return await withRetry(() =>
     axios
       .get(`/subproject.list?projectId=${project.data.id}`)
-      .then(res => res.data.data.items)
-      .then(subprojects =>
+      .then((res) => res.data.data.items)
+      .then((subprojects) =>
         subprojects.find(
-          x => x.data.displayName === subprojectTemplate.displayName
+          (x) => x.data.displayName === subprojectTemplate.displayName
         )
       )
   );
@@ -216,14 +216,12 @@ const findWorkflowitem = async (
   return await withRetry(() =>
     axios
       .get(
-        `/workflowitem.list?projectId=${project.data.id}&subprojectId=${
-          subproject.data.id
-        }`
+        `/workflowitem.list?projectId=${project.data.id}&subprojectId=${subproject.data.id}`
       )
-      .then(res => res.data.data.workflowitems)
-      .then(items =>
+      .then((res) => res.data.data.workflowitems)
+      .then((items) =>
         items.find(
-          item => item.data.displayName === workflowitemTemplate.displayName
+          (item) => item.data.displayName === workflowitemTemplate.displayName
         )
       )
   );
@@ -244,18 +242,18 @@ const grantPermissions = async (
     body = {
       projectId,
       subprojectId,
-      workflowitemId
+      workflowitemId,
     };
   } else if (subprojectId !== undefined) {
     url = "/subproject.intent.grantPermission";
     body = {
       projectId,
-      subprojectId
+      subprojectId,
     };
   } else if (projectId !== undefined) {
     url = "/project.intent.grantPermission";
     body = {
-      projectId
+      projectId,
     };
   } else {
     throw Error("not even projectId is given..");
@@ -268,7 +266,7 @@ const grantPermissions = async (
         axios.post(url, {
           ...body,
           intent,
-          identity: userId
+          identity: userId,
         })
       );
     }
@@ -280,11 +278,11 @@ const revokeProjectPermission = async (axios, projectId, userId, intent) => {
     axios.post("/project.intent.revokePermission", {
       projectId: projectId,
       identity: userId,
-      intent: intent
+      intent: intent,
     })
   );
 };
-const queryApiDoc = async axios => {
+const queryApiDoc = async (axios) => {
   return await withRetry(() => axios.get("/documentation"));
 };
 
@@ -310,5 +308,5 @@ module.exports = {
   findWorkflowitem,
   grantPermissions,
   revokeProjectPermission,
-  queryApiDoc
+  queryApiDoc,
 };


### PR DESCRIPTION
1. Revoking the permission of the last user on workflowitem level should be prevented for certain permissions, so that it is not possible to "kill" the workflowitem and make it unusable.

1. The provisioning api response logs only contain the error code without a meaningful error message.
This PR also improves the provisioning logs and adapt following error codes on api side:
        - AlreadyExists Error (409)
        - PreconditionError (412)

Closes #514 
Closes #518 