### PR TITLE
Create unit tests for all domain layer functions

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "start": "node dist/",
     "build": "rimraf dist && tsc",
-    "dev": "rimraf dist && tsc --watch && nodemon dist",
+    "dev": "rimraf dist && tsc --watch & nodemon dist",
     "test": "nyc mocha --require ts-node/register \"src/**/*.spec.ts\"",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "generate-report": "nyc report --reporter=html",

--- a/api/src/service/domain/organization/group_create.spec.ts
+++ b/api/src/service/domain/organization/group_create.spec.ts
@@ -1,0 +1,70 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { AlreadyExists } from "../errors/already_exists";
+import { NotAuthorized } from "../errors/not_authorized";
+import * as GlobalPermissions from "../workflow/global_permissions";
+import { createGroup, RequestData } from "./group_create";
+import { ServiceUser } from "./service_user";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const groupId = "group-id";
+const dummy = "dummy";
+
+const noPermissions = {
+  permissions: {},
+  log: [],
+};
+const grantPermissions: GlobalPermissions.GlobalPermissions = {
+  permissions: { "global.createGroup": ["alice"] },
+  log: [],
+};
+
+const requestData: RequestData = {
+  id: groupId,
+  displayName: dummy,
+  description: dummy,
+  members: [alice.id, bob.id],
+};
+
+const baseRepository = {
+  getGlobalPermissions: () => Promise.resolve(noPermissions),
+  groupExists: () => Promise.resolve(false),
+
+};
+
+describe("Create a new group: authorization", () => {
+  it("Without the global.createGroup permission, a user cannot create a new group", async () => {
+    const result = await createGroup(ctx, alice, requestData, baseRepository);
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("With the global.createGroup permission, a user can create a new group", async () => {
+    const result = await createGroup(ctx, alice, requestData,
+      {
+        ...baseRepository,
+        getGlobalPermissions: () => Promise.resolve(grantPermissions),
+      });
+    assert.isTrue(Result.isOk(result));
+  });
+
+  it("The root user can always create a new user", async () => {
+    const result = await createGroup(ctx, root, requestData, baseRepository);
+    assert.isTrue(Result.isOk(result));
+  });
+});
+
+describe("Create a new group: conditions", () => {
+  it("Group that already exists cannot be created", async () => {
+    const result = await createGroup(ctx, root, requestData, {
+      ...baseRepository,
+      groupExists: groupId => Promise.resolve(true),
+    });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, AlreadyExists);
+  });
+});

--- a/api/src/service/domain/organization/group_member_add.spec.ts
+++ b/api/src/service/domain/organization/group_member_add.spec.ts
@@ -3,6 +3,7 @@ import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
 import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
 import { addMember } from "./group_member_add";
 import { ServiceUser } from "./service_user";
 
@@ -37,14 +38,14 @@ const baseRepository = {
     getGroupEvents: async () => Promise.resolve(dummyEvent),
 };
 
-describe("Add new memeber to group: authorization", () => {
-  it("Without the group.addUser permission, a user cannot add a new memeber to a group", async () => {
+describe("Add new member to group: authorization", () => {
+  it("Without the group.addUser permission, a user cannot add a new member to a group", async () => {
     const result = await addMember(ctx, alice, groupId, bob.id, baseRepository);
     assert.isTrue(Result.isErr(result));
     assert.instanceOf(result, NotAuthorized);
   });
 
-  it("With the group.addUser permission, a user can add a new memeber to a group", async () => {
+  it("With the group.addUser permission, a user can add a new member to a group", async () => {
     const result = await addMember(ctx, alice, groupId, bob.id,
       {
       ...baseRepository,
@@ -56,5 +57,16 @@ describe("Add new memeber to group: authorization", () => {
   it("The root user can always add members to a group", async () => {
     const result = await addMember(ctx, root, groupId, bob.id, baseRepository);
     assert.isTrue(Result.isOk(result));
+  });
+});
+describe("Add new member to group: preconditions", () => {
+  it("Adding a new member to a group fails if the group cannot be found", async () => {
+    const result = await addMember(ctx, alice, groupId, bob.id,
+      {
+      ...baseRepository,
+      getGroupEvents: async () => Promise.resolve([]),
+        });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
   });
 });

--- a/api/src/service/domain/organization/group_member_add.spec.ts
+++ b/api/src/service/domain/organization/group_member_add.spec.ts
@@ -1,0 +1,60 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { addMember } from "./group_member_add";
+import { ServiceUser } from "./service_user";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const groupId = "group-id";
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [groupId] };
+const bob: ServiceUser = { id: "bob", groups: [] };
+const groupWithoutPermissions = {
+  id: "group-id",
+  displayName: "dummy",
+  description: "dummy",
+  members: [alice.id],
+  permissions: {},
+  additionalData: {},
+};
+const dummyEvent: BusinessEvent[] = [
+{
+  type: "group_created",
+  source: ctx.source,
+  publisher: alice.id,
+  group: groupWithoutPermissions,
+  time: new Date().toISOString(),
+}];
+const dummyEventWithPermissions = [{
+  ...dummyEvent[0],
+  group: {...groupWithoutPermissions,
+    permissions: {"group.addUser": ["alice"]}},
+  }];
+
+const baseRepository = {
+    getGroupEvents: async () => Promise.resolve(dummyEvent),
+};
+
+describe("Add new memeber to group: authorization", () => {
+  it("Without the group.addUser permission, a user cannot add a new memeber to a group", async () => {
+    const result = await addMember(ctx, alice, groupId, bob.id, baseRepository);
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("With the group.addUser permission, a user can add a new memeber to a group", async () => {
+    const result = await addMember(ctx, alice, groupId, bob.id,
+      {
+      ...baseRepository,
+      getGroupEvents: async () => Promise.resolve(dummyEventWithPermissions),
+        });
+    assert.isTrue(Result.isOk(result));
+  });
+
+  it("The root user can always add members to a group", async () => {
+    const result = await addMember(ctx, root, groupId, bob.id, baseRepository);
+    assert.isTrue(Result.isOk(result));
+  });
+});

--- a/api/src/service/domain/organization/group_member_remove.spec.ts
+++ b/api/src/service/domain/organization/group_member_remove.spec.ts
@@ -3,6 +3,7 @@ import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
 import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
 import { removeMember } from "./group_member_remove";
 import { ServiceUser } from "./service_user";
 
@@ -12,13 +13,13 @@ const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_b
 const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
 const groupId = "group-id";
 const groupWithoutPermissions = {
-    id: "group-id",
-    displayName: "dummy",
-    description: "dummy",
-    members: [alice.id],
-    permissions: {},
-    additionalData: {},
-  };
+  id: "group-id",
+  displayName: "dummy",
+  description: "dummy",
+  members: [alice.id],
+  permissions: {},
+  additionalData: {},
+};
 const dummyEvent: BusinessEvent[] = [
   {
     type: "group_created",
@@ -26,33 +27,45 @@ const dummyEvent: BusinessEvent[] = [
     publisher: alice.id,
     group: groupWithoutPermissions,
     time: new Date().toISOString(),
-  }];
-const dummyEventWithPermissions = [{
+  },
+];
+const dummyEventWithPermissions = [
+  {
     ...dummyEvent[0],
-    group: {...groupWithoutPermissions,
-      permissions: {"group.removeUser": ["alice"]}},
-    }];
+    group: { ...groupWithoutPermissions, permissions: { "group.removeUser": ["alice"] } },
+  },
+];
 const baseRepository = {
-    getGroupEvents: async () => Promise.resolve(dummyEvent),
+  getGroupEvents: async () => Promise.resolve(dummyEvent),
 };
 
-describe("Remove memeber from group: authorization", () => {
-  it("Without the group.removeUser permission, a user cannot remove a memeber from a group", async () => {
+describe("Remove member from group: authorization", () => {
+  it("Without the group.removeUser permission, a user cannot remove a member from a group", async () => {
     const result = await removeMember(ctx, alice, groupId, bob.id, baseRepository);
     assert.isTrue(Result.isErr(result));
     assert.instanceOf(result, NotAuthorized);
   });
-  it("With the group.removeUser permission, a user can remove a memeber from a group", async () => {
-    const result = await removeMember(ctx, alice, groupId, bob.id,
-      {
+  it("With the group.removeUser permission, a user can remove a member from a group", async () => {
+    const result = await removeMember(ctx, alice, groupId, bob.id, {
       ...baseRepository,
       getGroupEvents: async () => Promise.resolve(dummyEventWithPermissions),
-        });
+    });
     assert.isTrue(Result.isOk(result));
   });
 
   it("The root user can always remove members from a group", async () => {
     const result = await removeMember(ctx, root, groupId, bob.id, baseRepository);
     assert.isTrue(Result.isOk(result));
+  });
+});
+
+describe("Remove member from group: preconditions", () => {
+  it("Removing a member from a group fails if the group cannot be found", async () => {
+    const result = await removeMember(ctx, alice, groupId, bob.id, {
+      ...baseRepository,
+      getGroupEvents: async () => Promise.resolve([]),
+    });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
   });
 });

--- a/api/src/service/domain/organization/group_member_remove.spec.ts
+++ b/api/src/service/domain/organization/group_member_remove.spec.ts
@@ -1,0 +1,58 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { removeMember } from "./group_member_remove";
+import { ServiceUser } from "./service_user";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const groupId = "group-id";
+const groupWithoutPermissions = {
+    id: "group-id",
+    displayName: "dummy",
+    description: "dummy",
+    members: [alice.id],
+    permissions: {},
+    additionalData: {},
+  };
+const dummyEvent: BusinessEvent[] = [
+  {
+    type: "group_created",
+    source: ctx.source,
+    publisher: alice.id,
+    group: groupWithoutPermissions,
+    time: new Date().toISOString(),
+  }];
+const dummyEventWithPermissions = [{
+    ...dummyEvent[0],
+    group: {...groupWithoutPermissions,
+      permissions: {"group.removeUser": ["alice"]}},
+    }];
+const baseRepository = {
+    getGroupEvents: async () => Promise.resolve(dummyEvent),
+};
+
+describe("Remove memeber from group: authorization", () => {
+  it("Without the group.removeUser permission, a user cannot remove a memeber from a group", async () => {
+    const result = await removeMember(ctx, alice, groupId, bob.id, baseRepository);
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+  it("With the group.removeUser permission, a user can remove a memeber from a group", async () => {
+    const result = await removeMember(ctx, alice, groupId, bob.id,
+      {
+      ...baseRepository,
+      getGroupEvents: async () => Promise.resolve(dummyEventWithPermissions),
+        });
+    assert.isTrue(Result.isOk(result));
+  });
+
+  it("The root user can always remove members from a group", async () => {
+    const result = await removeMember(ctx, root, groupId, bob.id, baseRepository);
+    assert.isTrue(Result.isOk(result));
+  });
+});

--- a/api/src/service/domain/workflow/project_get.spec.ts
+++ b/api/src/service/domain/workflow/project_get.spec.ts
@@ -1,0 +1,72 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Project } from "./project";
+import { getProject } from "./project_get";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const projectId = "dummy-project";
+const projectName = "dummy-Name";
+
+const permissions = {
+    "project.viewSummary": ["alice"],
+    "project.viewDetails": ["alice"],
+  };
+
+const baseProject: Project = {
+    id: projectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: projectName,
+    description: projectName,
+    assignee: alice.id,
+    projectedBudgets: [],
+    permissions,
+    log: [],
+    tags: [],
+    additionalData: {},
+  };
+
+const baseRepository = {
+    getProject: async () => baseProject,
+    getUsersForIdentity: async (identity: string) => {
+    if (identity === "alice") return ["alice"];
+    if (identity === "root") return ["root"];
+    throw Error(`unexpected identity: ${identity}`);
+  },
+};
+
+describe("get project: authorization", () => {
+  it("Without the required permissions, a user cannot get a project.", async () => {
+    const notPermittedProject = {
+        ...baseProject,
+        permissions: {},
+      };
+    const result = await getProject(ctx, alice, projectId,
+        {
+        ...baseRepository,
+        getProject: async () => notPermittedProject,
+    });
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("With the required permissions, a user can get a project.", async () => {
+    const result = await getProject(ctx, alice, projectId, baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(Result.unwrap(result).id, projectId);
+  });
+
+  it("The root user doesn't need permission to get a project.", async () => {
+    const result = await getProject(ctx, root, projectId, baseRepository);
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(Result.unwrap(result).id, projectId);
+  });
+});

--- a/api/src/service/domain/workflow/project_history_get.spec.ts
+++ b/api/src/service/domain/workflow/project_history_get.spec.ts
@@ -1,0 +1,68 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Project } from "./project";
+import { Filter, getHistory } from "./project_history_get";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const projectId = "dummy-project";
+const projectName = "dummy-Name";
+
+const filter: Filter = {
+    publisher: alice.id,
+    startAt: new Date().toISOString(),
+    endAt: new Date().toISOString(),
+    eventType: "project_created",
+};
+
+const permissions = {
+    "project.viewDetails": ["alice"],
+  };
+
+const baseProject: Project = {
+    id: projectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: projectName,
+    description: projectName,
+    assignee: alice.id,
+    projectedBudgets: [],
+    permissions,
+    log: [],
+    tags: [],
+    additionalData: {},
+  };
+
+const baseRepository = {
+    getProject: async () => baseProject,
+};
+
+describe("get project history: authorization", () => {
+  it("Without the required permissions, a user cannot get a project's history.", async () => {
+    const notPermittedProject = {
+        ...baseProject,
+        permissions: {},
+      };
+    const result = await getHistory(ctx, alice, projectId, filter,
+        {
+        ...baseRepository,
+        getProject: async () => notPermittedProject,
+    });
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("With the required permissions, a user can get a project's history.", async () => {
+    const result = await getHistory(ctx, alice, projectId, filter, baseRepository);
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("The root user doesn't need permission to get a project's history.", async () => {
+    const result = await getHistory(ctx, alice, projectId, filter, baseRepository);
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});

--- a/api/src/service/domain/workflow/project_list.spec.ts
+++ b/api/src/service/domain/workflow/project_list.spec.ts
@@ -13,27 +13,30 @@ const projectId = "dummy-project";
 const projectName = "dummy-Name";
 
 const permissions = {
-    "project.viewSummary": ["alice"],
-    "project.viewDetails": ["alice"],
-  };
+  "project.viewSummary": ["alice"],
+  "project.viewDetails": ["alice"],
+};
 
 const baseProject: Project = {
-    id: projectId,
-    createdAt: new Date().toISOString(),
-    status: "open",
-    displayName: projectName,
-    description: projectName,
-    assignee: alice.id,
-    projectedBudgets: [],
-    permissions,
-    log: [],
-    tags: [],
-    additionalData: {},
-  };
-
+  id: projectId,
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: projectName,
+  description: projectName,
+  assignee: alice.id,
+  projectedBudgets: [],
+  permissions,
+  log: [],
+  tags: [],
+  additionalData: {},
+};
+const notPermittedProject: Project = {
+  ...baseProject,
+  permissions: {},
+};
 const baseRepository = {
-    getAllProjects: async () => [baseProject],
-    getUsersForIdentity: async (identity: string) => {
+  getAllProjects: async () => [baseProject],
+  getUsersForIdentity: async (identity: string) => {
     if (identity === "alice") return ["alice"];
     if (identity === "root") return ["root"];
     throw Error(`unexpected identity: ${identity}`);
@@ -42,27 +45,28 @@ const baseRepository = {
 
 describe("list projects: authorization", () => {
   it("Without the required permissions, a user cannot list all projects.", async () => {
-    const notPermittedProject = {
-        ...baseProject,
-        permissions: {},
-      };
-    const result = await getAllVisible(ctx, alice,
-        {
-        ...baseRepository,
-        getAllProjects: async () => [notPermittedProject],
+    const result = await getAllVisible(ctx, alice, {
+      ...baseRepository,
+      getAllProjects: async () => [notPermittedProject],
     });
 
     // No errors, but no projects visible:
     assert.isTrue(Result.isOk(result), (result as Error).message);
     assert.isEmpty(result);
-
   });
   it("With the required permissions, a user can list all projects.", async () => {
     const result = await getAllVisible(ctx, alice, baseRepository);
 
     assert.isTrue(Result.isOk(result), (result as Error).message);
     assert.equal(result[0].id, projectId);
-
+  });
+  it("A user can only list the projects they have permission to view.", async () => {
+    const result = await getAllVisible(ctx, alice, {
+      ...baseRepository,
+      getAllProjects: async () => [baseProject, notPermittedProject],
+    });
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(Result.unwrap(result).length, 1);
   });
 
   it("The root user doesn't need permission to list all projects.", async () => {

--- a/api/src/service/domain/workflow/project_list.spec.ts
+++ b/api/src/service/domain/workflow/project_list.spec.ts
@@ -1,0 +1,75 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { ServiceUser } from "../organization/service_user";
+import { Project } from "./project";
+import { getAllVisible } from "./project_list";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const projectId = "dummy-project";
+const projectName = "dummy-Name";
+
+const permissions = {
+    "project.viewSummary": ["alice"],
+    "project.viewDetails": ["alice"],
+  };
+
+const baseProject: Project = {
+    id: projectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: projectName,
+    description: projectName,
+    assignee: alice.id,
+    projectedBudgets: [],
+    permissions,
+    log: [],
+    tags: [],
+    additionalData: {},
+  };
+
+const baseRepository = {
+    getAllProjects: async () => [baseProject],
+    getUsersForIdentity: async (identity: string) => {
+    if (identity === "alice") return ["alice"];
+    if (identity === "root") return ["root"];
+    throw Error(`unexpected identity: ${identity}`);
+  },
+};
+
+describe("list projects: authorization", () => {
+  it("Without the required permissions, a user cannot list all projects.", async () => {
+    const notPermittedProject = {
+        ...baseProject,
+        permissions: {},
+      };
+    const result = await getAllVisible(ctx, alice,
+        {
+        ...baseRepository,
+        getAllProjects: async () => [notPermittedProject],
+    });
+
+    // No errors, but no projects visible:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.isEmpty(result);
+
+  });
+  it("With the required permissions, a user can list all projects.", async () => {
+    const result = await getAllVisible(ctx, alice, baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(result[0].id, projectId);
+
+  });
+
+  it("The root user doesn't need permission to list all projects.", async () => {
+    const result = await getAllVisible(ctx, root, baseRepository);
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(result[0].id, projectId);
+  });
+});

--- a/api/src/service/domain/workflow/project_permission_grant.spec.ts
+++ b/api/src/service/domain/workflow/project_permission_grant.spec.ts
@@ -1,0 +1,92 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import * as Project from "./project";
+import * as ProjectPermissionGrant from "./project_permission_grant";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const executingUser: ServiceUser = { id: "mstein", groups: [] };
+const testUser: ServiceUser = { id: "testUser", groups: [] };
+
+const permissions: Permissions = {
+  "project.viewSummary": ["testUser"],
+  "project.viewDetails": [],
+  "project.intent.revokePermission": ["testUser"],
+  "project.intent.grantPermission": ["mstein"],
+};
+
+const testProject: Project.Project = {
+  id: "testProject",
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: "unitTestName",
+  description: "",
+  projectedBudgets: [],
+  permissions,
+  log: [],
+  additionalData: {},
+  tags: [],
+};
+
+describe("grant project permissions", () => {
+  it("With the 'project.intent.grantPermission' permission, the user can grant project permissions", async () => {
+    const grantResult = await ProjectPermissionGrant.grantProjectPermission(
+      ctx,
+      executingUser,
+      testProject.id,
+      testUser.id,
+      "project.viewDetails",
+      {
+        getProject: async () => testProject,
+      },
+    );
+
+    if (Result.isErr(grantResult)) {
+      throw grantResult;
+    }
+    assert.lengthOf(grantResult, 1);
+    const grantEvent = grantResult[0];
+    const expectedEvent: BusinessEvent = {
+      type: "project_permission_granted",
+      source: ctx.source,
+      publisher: executingUser.id,
+      time: grantEvent.time,
+      projectId: testProject.id,
+      permission: "project.viewDetails",
+      grantee: testUser.id,
+    };
+    assert.deepEqual(expectedEvent, grantEvent);
+  });
+
+  it("Without the 'project.intent.grantPermission' permission, the user cannot grant project permissions", async () => {
+    const projectWithoutPermission: Project.Project = {
+      id: "testProject",
+      createdAt: new Date().toISOString(),
+      status: "open",
+      displayName: "unitTestName",
+      description: "",
+      projectedBudgets: [],
+      permissions: { "project.intent.grantPermission": [] },
+      log: [],
+      additionalData: {},
+      tags: [],
+    };
+    const grantResult = await ProjectPermissionGrant.grantProjectPermission(
+      ctx,
+      executingUser,
+      testProject.id,
+      testUser.id,
+      "project.viewDetails",
+      {
+        getProject: async () => projectWithoutPermission,
+      },
+    );
+
+    assert.isTrue(Result.isErr(grantResult));
+    assert.instanceOf(grantResult, NotAuthorized);
+  });
+});

--- a/api/src/service/domain/workflow/project_permissions_list.spec.ts
+++ b/api/src/service/domain/workflow/project_permissions_list.spec.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
 import { ServiceUser } from "../organization/service_user";
 import { Permissions } from "../permissions";
 import * as Project from "./project";
@@ -27,7 +28,7 @@ const baseProject: Project.Project = {
   tags: [],
 };
 
-const repository = returnedProject => {
+const repository = (returnedProject) => {
   return { getProject: async () => returnedProject };
 };
 
@@ -38,7 +39,7 @@ describe("List project permissions: authorization", () => {
     assert.equal(Result.unwrap(result), permissions);
   });
   it("Without the 'project.intent.listPermissions' permission, the user cannot list project permissions", async () => {
-    const projectWithoutPermissions = { ...baseProject, permissions: {} };
+    const projectWithoutPermissions: Project.Project = { ...baseProject, permissions: {} };
 
     const result = await getProjectPermissions(
       ctx,
@@ -48,5 +49,15 @@ describe("List project permissions: authorization", () => {
     );
     assert.isTrue(Result.isErr(result));
     assert.instanceOf(result, NotAuthorized);
+  });
+});
+
+describe("list project permissions: preconditions", () => {
+  it("Listing a project's permissions fails if the project cannot be found", async () => {
+    const result = await getProjectPermissions(ctx, bob, projectId, {
+      getProject: async () => new Error("some error"),
+    });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
   });
 });

--- a/api/src/service/domain/workflow/project_update.spec.ts
+++ b/api/src/service/domain/workflow/project_update.spec.ts
@@ -1,0 +1,352 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
+import { ServiceUser } from "../organization/service_user";
+import { Project } from "./project";
+import { updateProject } from "./project_update";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const charlie: ServiceUser = { id: "charlie", groups: ["alice_and_bob_and_charlie"] };
+const projectId = "dummy-project";
+const projectName = "dummy";
+
+const baseProject: Project = {
+    id: projectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: projectName,
+    description: projectName,
+    assignee: alice.id,
+    projectedBudgets: [],
+    permissions: { "project.update": [alice, bob, charlie].map(x => x.id) },
+    log: [],
+    tags: [],
+    additionalData: {},
+  };
+
+const baseRepository = {
+    getProject: async () => baseProject,
+    getUsersForIdentity: async (identity: string) => {
+    if (identity === "alice") return ["alice"];
+    if (identity === "bob") return ["bob"];
+    if (identity === "charlie") return ["charlie"];
+    if (identity === "alice_and_bob") return ["alice", "bob"];
+    if (identity === "alice_and_bob_and_charlie") return ["alice", "bob", "charlie"];
+    if (identity === "root") return ["root"];
+    throw Error(`unexpected identity: ${identity}`);
+  },
+};
+
+describe("update project: authorization", () => {
+  it("Without the project.update permission, a user cannot update a project", async () => {
+    const modification = {
+        displayName: projectName,
+      };
+
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      {
+        ...baseRepository,
+        getProject: async () => ({
+          ...baseProject,
+          permissions: {},
+        }),
+      },
+    );
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("The root user doesn't need permission to update a project", async () => {
+    const modification = {displayName: projectName};
+    const result = await updateProject(
+      ctx,
+      root,
+      projectId,
+      modification,
+      {
+        ...baseRepository,
+        getProject: async () => ({
+          ...baseProject,
+          permissions: {},
+        }),
+      },
+    );
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});
+
+describe("update project: how modifications are applied", () => {
+  it("An update that contains current values only is ignored", async () => {
+    const modification = {
+      displayName: projectName,
+      description: projectName,
+    };
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      baseRepository,
+    );
+
+    // It works:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    // But there are no new events:
+    assert.lengthOf(Result.unwrap(result), 0);
+  });
+
+  it("The description field can be cleared as an empty string is allowed there", async () => {
+    const modification = {
+      description: "",
+    };
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    // There are new events and the project's description has been cleared:
+    assert.isAtLeast(Result.unwrap(result).length, 1);
+    const {update} = result[0];
+    assert.equal(update.description, "");
+  });
+
+  it("The displayName field cannot be cleared as it is a required field", async () => {
+    const modification = {
+      displayName: "",
+    };
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isErr(result));
+    const error = Result.unwrap_err(result);
+    assert.match(error.message, /displayName.*\s+.*empty/);
+  });
+
+  it("An empty update is not allowed, as it must contain at least one of " +
+  "displayName, description, thumbnail, additionalData, tags", async () => {
+    const modification = {};
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isErr(result), (result as Error).message);
+    const error = Result.unwrap_err(result);
+  });
+
+  it("A closed project cannot be updated", async () => {
+    const modification = {
+      description: "Some update",
+    };
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      {
+        ...baseRepository,
+        getProject: async () => ({
+          ...baseProject,
+          status: "closed",
+          billingDate: "2019-03-20T10:33:18.856Z",
+          description: "A description.",
+        }),
+      },
+    );
+
+    assert.isTrue(Result.isErr(result));
+    const error = Result.unwrap_err(result);
+    assert.match(error.message, /status/);
+  });
+
+  it("An update to additional data adds new items and replaces existing ones", async () => {
+    const modification = {
+      additionalData: {
+        a: "updated value",
+        b: "new value",
+      },
+    };
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      {
+        ...baseRepository,
+        getProject: async () => ({
+          ...baseProject,
+          additionalData: {
+            a: "old value",
+          },
+        }),
+      },
+    );
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    const { update } = result[0];
+    assert.deepEqual(update.additionalData, {
+      a: "updated value",
+      b: "new value",
+    });
+  });
+
+  it("Updating fails for an invalid project ID", async () => {
+    const modification = {
+      description: "Some update",
+    };
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      {
+        ...baseRepository,
+        getProject: async () => new Error("some error"),
+      },
+    );
+
+    // NotFound error as the project cannot be fetched:
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
+  });
+});
+
+describe("update project: notifications", () => {
+  it("When a user updates an assigned project, a notification is issued to the assignee", async () => {
+    const modification = {
+      description: "New description.",
+    };
+    const result = await updateProject(
+      ctx,
+      alice,
+      projectId,
+      modification,
+      {
+        ...baseRepository,
+        getProject: async () => ({
+          ...baseProject,
+          description: "A description.",
+          assignee: bob.id,
+        }),
+      },
+    );
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    assert.isTrue(
+      Result.unwrap(result).some(
+        event => event.type === "notification_created"
+        && event.recipient === bob.id,
+      ),
+    );
+  });
+
+  it("When a user updates an unassigned project, no notifications are issued", async () => {
+    const modification = {
+      description: "New description.",
+    };
+    const result = await updateProject(
+        ctx,
+        alice,
+        projectId,
+        modification,
+        {
+          ...baseRepository,
+          getProject: async () => ({
+            ...baseProject,
+            description: "A description.",
+            assignee: undefined,
+          }),
+        },
+      );
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    assert.isFalse(
+        Result.unwrap(result).some(
+          event => event.type === "notification_created",
+        ),
+      );
+  });
+
+  it("When an update is ignored, no notifications are issued", async () => {
+    // an update that contains current values only is ignored
+    const modification = {
+        displayName: projectName,
+    };
+    const result = await updateProject(
+          ctx,
+          alice,
+          projectId,
+          modification,
+          baseRepository,
+        );
+
+    // It works:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    // But no notifications have been issued (in fact there are no new events at all):
+    assert.lengthOf(Result.unwrap(result), 0);
+  });
+
+  it(
+    "When a user updates a project that is assigned to a group, " +
+      "each member, except for the user that invoked the update, receives a notification",
+    async () => {
+      const modification = {
+        description: "New description.",
+      };
+      const result = await updateProject(
+        ctx,
+        alice,
+        projectId,
+        modification,
+        {
+          ...baseRepository,
+          getProject: async () => ({
+            ...baseProject,
+            description: "A description.",
+            assignee: "alice_and_bob_and_charlie",
+          }),
+        },
+      );
+
+      assert.isTrue(Result.isOk(result), (result as Error).message);
+      const res = Result.unwrap(result);
+
+      // A notification has been issued to both Bob and Charlie, but not to Alice, as she
+      // is the user who has updated the project:
+      function isNotificationFor(userId: string): (e: BusinessEvent) => boolean {
+        return event => event.type === "notification_created" && event.recipient === userId;
+      }
+
+      assert.isFalse(res.some(isNotificationFor("alice")));
+      assert.isTrue(res.some(isNotificationFor("bob")));
+      assert.isTrue(res.some(isNotificationFor("charlie")));
+    },
+  );
+ });

--- a/api/src/service/domain/workflow/project_update.spec.ts
+++ b/api/src/service/domain/workflow/project_update.spec.ts
@@ -8,6 +8,7 @@ import { NotFound } from "../errors/not_found";
 import { ServiceUser } from "../organization/service_user";
 import { Project } from "./project";
 import { updateProject } from "./project_update";
+import { Modification } from "./project_updated";
 
 const ctx: Ctx = { requestId: "", source: "test" };
 const root: ServiceUser = { id: "root", groups: [] };
@@ -46,7 +47,7 @@ const baseRepository = {
 
 describe("update project: authorization", () => {
   it("Without the project.update permission, a user cannot update a project", async () => {
-    const modification = {
+    const modification: Modification = {
         displayName: projectName,
       };
 
@@ -67,7 +68,7 @@ describe("update project: authorization", () => {
   });
 
   it("The root user doesn't need permission to update a project", async () => {
-    const modification = {displayName: projectName};
+    const modification: Modification = {displayName: projectName};
     const result = await updateProject(
       ctx,
       root,
@@ -87,7 +88,7 @@ describe("update project: authorization", () => {
 
 describe("update project: how modifications are applied", () => {
   it("An update that contains current values only is ignored", async () => {
-    const modification = {
+    const modification: Modification = {
       displayName: projectName,
       description: projectName,
     };
@@ -107,7 +108,7 @@ describe("update project: how modifications are applied", () => {
   });
 
   it("The description field can be cleared as an empty string is allowed there", async () => {
-    const modification = {
+    const modification: Modification = {
       description: "",
     };
     const result = await updateProject(
@@ -127,7 +128,7 @@ describe("update project: how modifications are applied", () => {
   });
 
   it("The displayName field cannot be cleared as it is a required field", async () => {
-    const modification = {
+    const modification: Modification = {
       displayName: "",
     };
     const result = await updateProject(
@@ -145,7 +146,7 @@ describe("update project: how modifications are applied", () => {
 
   it("An empty update is not allowed, as it must contain at least one of " +
   "displayName, description, thumbnail, additionalData, tags", async () => {
-    const modification = {};
+    const modification: Modification = {};
     const result = await updateProject(
       ctx,
       alice,
@@ -159,7 +160,7 @@ describe("update project: how modifications are applied", () => {
   });
 
   it("A closed project cannot be updated", async () => {
-    const modification = {
+    const modification: Modification = {
       description: "Some update",
     };
     const result = await updateProject(
@@ -184,7 +185,7 @@ describe("update project: how modifications are applied", () => {
   });
 
   it("An update to additional data adds new items and replaces existing ones", async () => {
-    const modification = {
+    const modification: Modification = {
       additionalData: {
         a: "updated value",
         b: "new value",
@@ -215,7 +216,7 @@ describe("update project: how modifications are applied", () => {
   });
 
   it("Updating fails for an invalid project ID", async () => {
-    const modification = {
+    const modification: Modification = {
       description: "Some update",
     };
     const result = await updateProject(
@@ -237,7 +238,7 @@ describe("update project: how modifications are applied", () => {
 
 describe("update project: notifications", () => {
   it("When a user updates an assigned project, a notification is issued to the assignee", async () => {
-    const modification = {
+    const modification: Modification = {
       description: "New description.",
     };
     const result = await updateProject(
@@ -266,7 +267,7 @@ describe("update project: notifications", () => {
   });
 
   it("When a user updates an unassigned project, no notifications are issued", async () => {
-    const modification = {
+    const modification: Modification = {
       description: "New description.",
     };
     const result = await updateProject(
@@ -295,7 +296,7 @@ describe("update project: notifications", () => {
 
   it("When an update is ignored, no notifications are issued", async () => {
     // an update that contains current values only is ignored
-    const modification = {
+    const modification: Modification = {
         displayName: projectName,
     };
     const result = await updateProject(
@@ -317,7 +318,7 @@ describe("update project: notifications", () => {
     "When a user updates a project that is assigned to a group, " +
       "each member, except for the user that invoked the update, receives a notification",
     async () => {
-      const modification = {
+      const modification: Modification = {
         description: "New description.",
       };
       const result = await updateProject(

--- a/api/src/service/domain/workflow/project_update.ts
+++ b/api/src/service/domain/workflow/project_update.ts
@@ -42,7 +42,11 @@ export async function updateProject(
   }
 
   // Create the new event:
-  const projectUpdated = ProjectUpdated.createEvent(ctx.source, issuer.id, projectId, data);
+  const projectUpdatedResult = ProjectUpdated.createEvent(ctx.source, issuer.id, projectId, data);
+  if (Result.isErr(projectUpdatedResult)) {
+    return new VError(projectUpdatedResult, "create update-event failed");
+  }
+  const projectUpdated = projectUpdatedResult;
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/workflow/project_updated.ts
+++ b/api/src/service/domain/workflow/project_updated.ts
@@ -55,7 +55,7 @@ export function createEvent(
   projectId: Project.Id,
   modification: Modification,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event>  {
   const event = {
     type: eventType,
     source,
@@ -66,7 +66,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/subproject_assign.spec.ts
+++ b/api/src/service/domain/workflow/subproject_assign.spec.ts
@@ -173,12 +173,11 @@ describe("assign subproject: preconditions", () => {
         projectId,
         subprojectId,
         assignee,
-        {
-          ...baseRepository,
-          getSubproject: async () => ({ ...baseSubproject, asignee: "" }),
-        });
+        baseRepository,
+        );
 
     // InvalidCommand error as the user ID is not valid:
+    console.log(result);
     assert.isTrue(Result.isErr(result));
 
     // Make TypeScript happy:

--- a/api/src/service/domain/workflow/subproject_assign.spec.ts
+++ b/api/src/service/domain/workflow/subproject_assign.spec.ts
@@ -177,7 +177,6 @@ describe("assign subproject: preconditions", () => {
         );
 
     // InvalidCommand error as the user ID is not valid:
-    console.log(result);
     assert.isTrue(Result.isErr(result));
 
     // Make TypeScript happy:

--- a/api/src/service/domain/workflow/subproject_assign.spec.ts
+++ b/api/src/service/domain/workflow/subproject_assign.spec.ts
@@ -1,0 +1,276 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
+import { ServiceUser } from "../organization/service_user";
+import { Subproject } from "./subproject";
+import { assignSubproject } from "./subproject_assign";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const charlie: ServiceUser = { id: "charlie", groups: ["alice_and_bob_and_charlie"] };
+const subprojectId = "dummy-subproject";
+const projectId = "dummy-project";
+
+const baseSubproject: Subproject = {
+  id: subprojectId,
+  projectId,
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: subprojectId,
+  description: subprojectId,
+  assignee: alice.id,
+  currency: "EUR",
+  projectedBudgets: [],
+  workflowitemOrdering: [],
+  permissions: { "subproject.assign": [alice, bob, charlie].map(x => x.id) },
+  log: [],
+  additionalData: {},
+};
+
+const baseRepository = {
+    getSubproject: async () => baseSubproject,
+    getUsersForIdentity: async (identity: string) => {
+      if (identity === "alice") return ["alice"];
+      if (identity === "bob") return ["bob"];
+      if (identity === "charlie") return ["charlie"];
+      if (identity === "alice_and_bob") return ["alice", "bob"];
+      if (identity === "alice_and_bob_and_charlie") return ["alice", "bob", "charlie"];
+      if (identity === "root") return ["root"];
+      throw Error(`unexpected identity: ${identity}`);
+    },
+  };
+
+describe("assign subproject: authorization", () => {
+  it("Without the subproject.assign permission, a user cannot change a subproject's assignee.", async () => {
+    const assigner = alice;
+    const assignee = bob;
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee.id,
+        {
+        ...baseRepository,
+        getSubproject: async () => ({ ...baseSubproject, permissions: {} }),
+      });
+
+    // NotAuthorized error due to the missing permissions:
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("The root user doesn't need permission to change a subproject's assignee.", async () => {
+    const assigner = root;
+    const assignee = bob;
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee.id,
+        {
+        ...baseRepository,
+        getSubproject: async () => ({ ...baseSubproject, permissions: {} }),
+      });
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});
+
+describe("assign subproject: preconditions", () => {
+  it("A user can assign a subproject to herself.", async () => {
+    const assigner = alice;
+    const assignee = alice;
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee.id,
+        baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("A user can assign a subproject to someone else.", async () => {
+    const assigner = alice;
+    const assignee = bob;
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee.id,
+        baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("Assigning an already assigned user works (but is a no-op).", async () => {
+    const assigner = alice;
+    const assignee = alice;
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee.id,
+        {
+            ...baseRepository,
+            getSubproject: async () => ({ ...baseSubproject, assignee: alice.id }),
+          });
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("A user can assign a subproject to a group.", async () => {
+    const assigner = alice;
+    const assignedGroup = "alice_and_bob";
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignedGroup,
+        baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("Assigning a user fails if the subproject cannot be found.", async () => {
+    const assigner = alice;
+    const assignee = alice;
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee.id,
+        {
+            ...baseRepository,
+            getSubproject: async () => new Error("some error"),
+          });
+
+    // NotFound error as the project cannot be fetched:
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
+  });
+
+  it("The assignee must not be empty.", async () => {
+    const assigner = alice;
+    const assignee = ""; // <- not a valid user ID
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee,
+        {
+          ...baseRepository,
+          getSubproject: async () => ({ ...baseSubproject, asignee: "" }),
+        });
+
+    // InvalidCommand error as the user ID is not valid:
+    assert.isTrue(Result.isErr(result));
+
+    // Make TypeScript happy:
+    if (Result.isOk(result)) {
+      throw result;
+    }
+    assert.match(result.message, /assignee.*\s+.*empty/);
+  });
+});
+
+describe("assign subproject: notifications", () => {
+  it("When a user assigns a subproject to someone else, a notification is issued to the new assignee.", async () => {
+    const assigner = alice;
+    const assignee = bob;
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee.id,
+        baseRepository);
+
+    // A notification has been issued to the assignee:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    // Make TypeScript happy:
+    if (Result.isErr(result)) {
+      throw result;
+    }
+    const { newEvents } = result;
+    assert.isTrue(
+      newEvents.some(
+        event => event.type === "notification_created" && event.recipient === assignee.id,
+      ),
+    );
+  });
+
+  it("When a user assignes a subproject to herself, no notifications are issued.", async () => {
+    const assigner = alice;
+    const assignee = alice;
+    const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignee.id,
+        {
+          ...baseRepository,
+          getSubproject: async () => ({ ...baseSubproject, assignee: "" }),
+        });
+
+    // There is an event representing the assignment, but no notification:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    // Make TypeScript happy:
+    if (Result.isErr(result)) {
+      throw result;
+    }
+    const { newEvents } = result;
+    assert.isTrue(newEvents.length > 0);
+    assert.isFalse(
+        newEvents.some(event => event.type === "notification_created"));
+  });
+
+  it(
+    "If a subproject gets assigned to a group, " +
+      "each member, except for the assigner, receives a notificaton.",
+    async () => {
+      const assigner = alice;
+      const assignedGroup = "alice_and_bob_and_charlie";
+      const result = await assignSubproject(
+        ctx,
+        assigner,
+        projectId,
+        subprojectId,
+        assignedGroup,
+        baseRepository);
+
+      assert.isTrue(Result.isOk(result), (result as Error).message);
+      // Make TypeScript happy:
+      if (Result.isErr(result)) {
+        throw result;
+      }
+      const { newEvents } = result;
+
+      // A notification has been issued to both Bob and Charlie, but not to Alice, as she
+      // is the user who has changed the project's assignee:
+      function isNotificationFor(userId: string): (e: BusinessEvent) => boolean {
+        return event => event.type === "notification_created" && event.recipient === userId;
+      }
+
+      assert.isFalse(newEvents.some(isNotificationFor("alice")));
+      assert.isTrue(newEvents.some(isNotificationFor("bob")));
+      assert.isTrue(newEvents.some(isNotificationFor("charlie")));
+    },
+  );
+ });

--- a/api/src/service/domain/workflow/subproject_assign.ts
+++ b/api/src/service/domain/workflow/subproject_assign.ts
@@ -38,16 +38,17 @@ export async function assignSubproject(
   }
 
   // Create the new event:
-  const subprojectAssigned = SubprojectAssigned.createEvent(
+  const subprojectAssignedResult = SubprojectAssigned.createEvent(
     ctx.source,
     issuer.id,
     projectId,
     subprojectId,
     assignee,
   );
-  if (Result.isErr(subprojectAssigned)) {
-    return new VError(subprojectAssigned, "failed to create event");
+  if (Result.isErr(subprojectAssignedResult)) {
+    return new VError(subprojectAssignedResult, "failed to create event");
   }
+  const subprojectAssigned = subprojectAssignedResult;
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/workflow/subproject_assigned.ts
+++ b/api/src/service/domain/workflow/subproject_assigned.ts
@@ -36,7 +36,7 @@ export function createEvent(
   subprojectId: Subproject.Id,
   assignee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -49,7 +49,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/subproject_close.spec.ts
+++ b/api/src/service/domain/workflow/subproject_close.spec.ts
@@ -1,0 +1,235 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
+import { PreconditionError } from "../errors/precondition_error";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import { Subproject } from "./subproject";
+import { closeSubproject } from "./subproject_close";
+import { Workflowitem } from "./workflowitem";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const charlie: ServiceUser = { id: "charlie", groups: ["alice_and_bob_and_charlie"] };
+const projectId = "dummy-project";
+const subprojectId = "dummy-subproject";
+const workflowitemId = "dummy-workflowitem";
+const baseSubproject: Subproject = {
+  id: subprojectId,
+  projectId,
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: "dummy",
+  description: "dummy",
+  assignee: alice.id,
+  currency: "EUR",
+  projectedBudgets: [],
+  workflowitemOrdering: [],
+  permissions: {},
+  log: [],
+  additionalData: {},
+};
+const baseWorkflowitem: Workflowitem = {
+  isRedacted: false,
+  id: workflowitemId,
+  subprojectId,
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: "dummy",
+  description: "dummy",
+  amountType: "N/A",
+  documents: [],
+  permissions: { "workflowitem.assign": [alice, bob, charlie].map((x) => x.id) },
+  log: [],
+  additionalData: {},
+  workflowitemType: "general",
+};
+
+const baseRepository = {
+  getSubproject: async () => baseSubproject,
+  getWorkflowitems: async () => [],
+  getUsersForIdentity: async (identity) => {
+    if (identity === "alice") return ["alice"];
+    if (identity === "bob") return ["bob"];
+    if (identity === "charlie") return ["charlie"];
+    if (identity === "alice_and_bob") return ["alice", "bob"];
+    if (identity === "alice_and_bob_and_charlie") return ["alice", "bob", "charlie"];
+    if (identity === "root") return ["root"];
+    throw Error(`unexpected identity: ${identity}`);
+  },
+};
+
+describe("close subproject", () => {
+  const workflowitem: Workflowitem = { ...baseWorkflowitem, status: "closed" };
+  it.only("Closing a subproject works if all workflowitems are closed.", async () => {
+    const result = await closeSubproject(ctx, root, projectId, subprojectId, {
+      ...baseRepository,
+      getWorkflowitems: async () => [workflowitem, workflowitem],
+    });
+
+    assert.isTrue(Result.isOk(result));
+  });
+
+  it("The root user doesn't need permission to close a subproject.", async () => {
+    const result = await closeSubproject(ctx, root, projectId, subprojectId, baseRepository);
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});
+
+describe("close subproject: authorization", () => {
+  it("Without the subproject.close permission, a user cannot close a subproject.", async () => {
+    const result = await closeSubproject(ctx, alice, projectId, subprojectId, baseRepository);
+
+    // NotAuthorized error due to the missing permissions:
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("The root user doesn't need permission to close a subproject.", async () => {
+    const result = await closeSubproject(ctx, root, projectId, subprojectId, baseRepository);
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});
+
+describe("close subproject: preconditions", () => {
+  it("A subproject may not be closed if there is at least one non-closed workflowitem.", async () => {
+    const result = await closeSubproject(ctx, root, projectId, subprojectId, {
+      ...baseRepository,
+      getWorkflowitems: async () => [baseWorkflowitem],
+    });
+
+    // PreconditionError due to open subproject:
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, PreconditionError);
+  });
+
+  it("Closing a subproject fails if the subproject cannot be found.", async () => {
+    const result = await closeSubproject(ctx, root, projectId, subprojectId, {
+      ...baseRepository,
+      getSubproject: async () => new NotFound(ctx, "subproject", subprojectId),
+    });
+
+    // NotFound error as the subproject cannot be fetched:
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
+  });
+});
+
+describe("close subproject: notifications", () => {
+  it.only("When a user closes a subproject, a notification is issued to the assignee.", async () => {
+    const permissions: Permissions = { "subproject.close": [bob.id] };
+    const subproject: Subproject = { ...baseSubproject, permissions };
+    const result = await closeSubproject(ctx, bob, projectId, subprojectId, {
+      ...baseRepository,
+      getSubproject: async () => subproject,
+    });
+
+    // A notification has been issued to the assignee:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    // Make TypeScript happy:
+    if (Result.isErr(result)) {
+      throw result;
+    }
+    const { newEvents } = result;
+
+    assert.isTrue(
+      newEvents.some(
+        (event) => event.type === "notification_created" && event.recipient === alice.id,
+      ),
+    );
+  });
+
+  it("Closing an already closed subproject works, but nothing happens and no notifications are issued.", async () => {
+    const closedSubproject: Subproject = { ...baseSubproject, status: "closed" };
+    const result = await closeSubproject(ctx, root, projectId, subprojectId, {
+      ...baseRepository,
+      getSubproject: async () => closedSubproject,
+    });
+
+    // It worked:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    // Make TypeScript happy:
+    if (Result.isErr(result)) throw result;
+    const { newEvents } = result;
+
+    // It's a no-op:
+    assert.lengthOf(newEvents, 0);
+  });
+
+  it("If there is no assignee when closing a subproject, no notifications are issued.", async () => {
+    const unassignedSubproject: Subproject = { ...baseSubproject, assignee: undefined };
+    const result = await closeSubproject(ctx, root, projectId, subprojectId, {
+      ...baseRepository,
+      getSubproject: async () => unassignedSubproject,
+    });
+
+    // There is an event representing the operation, but no notification:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    // Make TypeScript happy:
+    if (Result.isErr(result)) {
+      throw result;
+    }
+    const { newEvents } = result;
+    assert.isTrue(newEvents.length > 0);
+    assert.isFalse(newEvents.some((event) => event.type === "notification_created"));
+  });
+
+  it("If the user that closes a subproject is assigned to the subproject herself, no notifications are issued.", async () => {
+    const permissions: Permissions = { "subproject.close": [alice.id] };
+    const subproject: Subproject = { ...baseSubproject, permissions };
+    const result = await closeSubproject(ctx, alice, projectId, subprojectId, {
+      ...baseRepository,
+      getSubproject: async () => subproject,
+    });
+
+    // There is an event representing the operation, but no notification:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    // Make TypeScript happy:
+    if (Result.isErr(result)) {
+      throw result;
+    }
+    const { newEvents } = result;
+    assert.isTrue(newEvents.length > 0);
+    assert.isFalse(newEvents.some((event) => event.type === "notification_created"));
+  });
+
+  it(
+    "If a subproject is assigned to a group when closing it, " +
+      "each member, except for the user that closes it, receives a notificaton.",
+    async () => {
+      const permissions: Permissions = { "subproject.close": [alice.id] };
+      const assignee = "alice_and_bob_and_charlie";
+      const subproject: Subproject = { ...baseSubproject, permissions, assignee };
+      const result = await closeSubproject(ctx, alice, projectId, subprojectId, {
+        ...baseRepository,
+        getSubproject: async () => subproject,
+      });
+
+      assert.isTrue(Result.isOk(result), (result as Error).message);
+      // Make TypeScript happy:
+      if (Result.isErr(result)) {
+        throw result;
+      }
+      const { newEvents } = result;
+
+      // A notification has been issued to both Bob and Charlie, but not to Alice, as she
+      // is the user who closed the subproject:
+      function isNotificationFor(userId: string): (e: BusinessEvent) => boolean {
+        return (event) => event.type === "notification_created" && event.recipient === userId;
+      }
+
+      assert.isFalse(newEvents.some(isNotificationFor("alice")));
+      assert.isTrue(newEvents.some(isNotificationFor("bob")));
+      assert.isTrue(newEvents.some(isNotificationFor("charlie")));
+    },
+  );
+});

--- a/api/src/service/domain/workflow/subproject_close.spec.ts
+++ b/api/src/service/domain/workflow/subproject_close.spec.ts
@@ -66,7 +66,7 @@ const baseRepository = {
 
 describe("close subproject", () => {
   const workflowitem: Workflowitem = { ...baseWorkflowitem, status: "closed" };
-  it.only("Closing a subproject works if all workflowitems are closed.", async () => {
+  it("Closing a subproject works if all workflowitems are closed.", async () => {
     const result = await closeSubproject(ctx, root, projectId, subprojectId, {
       ...baseRepository,
       getWorkflowitems: async () => [workflowitem, workflowitem],
@@ -125,7 +125,7 @@ describe("close subproject: preconditions", () => {
 });
 
 describe("close subproject: notifications", () => {
-  it.only("When a user closes a subproject, a notification is issued to the assignee.", async () => {
+  it("When a user closes a subproject, a notification is issued to the assignee.", async () => {
     const permissions: Permissions = { "subproject.close": [bob.id] };
     const subproject: Subproject = { ...baseSubproject, permissions };
     const result = await closeSubproject(ctx, bob, projectId, subprojectId, {

--- a/api/src/service/domain/workflow/subproject_get.spec.ts
+++ b/api/src/service/domain/workflow/subproject_get.spec.ts
@@ -1,0 +1,69 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Subproject } from "./subproject";
+import { getSubproject } from "./subproject_get";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const subprojectId = "dummy-subproject";
+const subprojectName = "dummy-Name";
+
+const permissions = {
+    "subproject.viewSummary": ["alice"],
+    "subproject.viewDetails": ["alice"],
+  };
+
+const baseSubproject: Subproject = {
+    id: subprojectId,
+    projectId: subprojectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: subprojectName,
+    description: subprojectName,
+    assignee: alice.id,
+    currency: "EUR",
+    projectedBudgets: [],
+    permissions,
+    log: [],
+    workflowitemOrdering: [],
+    additionalData: {},
+  };
+
+const baseRepository = {
+    getSubproject: async () => baseSubproject,
+};
+
+describe("get subproject: authorization", () => {
+  it("Without the required permissions, a user cannot get a subproject.", async () => {
+    const notPermittedSubroject = {
+   ...baseSubproject,
+    permissions: {},
+      };
+    const result = await getSubproject(ctx, alice, subprojectId,
+        {
+        ...baseRepository,
+        getSubproject: async () => notPermittedSubroject,
+    });
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("With the required permissions, a user can get all subproject.", async () => {
+    const result = await getSubproject(ctx, alice, subprojectId, baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(Result.unwrap(result).id, subprojectId);
+  });
+
+  it("The root user doesn't need permission to get a subproject.", async () => {
+    const result = await getSubproject(ctx, alice, subprojectId, baseRepository);
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(Result.unwrap(result).id, subprojectId);
+  });
+});

--- a/api/src/service/domain/workflow/subproject_history_get.spec.ts
+++ b/api/src/service/domain/workflow/subproject_history_get.spec.ts
@@ -1,0 +1,71 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Subproject } from "./subproject";
+import { Filter, getHistory } from "./subproject_history_get";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const projectId = "dummy-project";
+const subprojectId = "dummy-subproject";
+const subprojectName = "dummy-Name";
+
+const filter: Filter = {
+    publisher: alice.id,
+    startAt: new Date().toISOString(),
+    endAt: new Date().toISOString(),
+    eventType: "subproject_created",
+};
+
+const permissions = {
+    "subproject.viewDetails": ["alice"],
+  };
+
+const baseSubproject: Subproject = {
+    id: subprojectId,
+    projectId: subprojectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: subprojectName,
+    description: subprojectName,
+    assignee: alice.id,
+    currency: "EUR",
+    projectedBudgets: [],
+    permissions,
+    log: [],
+    workflowitemOrdering: [],
+    additionalData: {},
+  };
+
+const baseRepository = {
+    getSubproject: async () => baseSubproject,
+};
+
+describe("get subproject history: authorization", () => {
+  it("Without the required permissions, a user cannot get a subproject's history.", async () => {
+    const notPermittedSubproject = {
+        ...baseSubproject,
+        permissions: {},
+      };
+    const result = await getHistory(ctx, alice, projectId, subprojectId, filter,
+        {
+        ...baseRepository,
+        getSubproject: async () => notPermittedSubproject,
+    });
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("With the required permissions, a user can get a subproject's history.", async () => {
+    const result = await getHistory(ctx, alice, projectId, subprojectId, filter, baseRepository);
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("The root user doesn't need permission to get a subproject's history.", async () => {
+    const result = await getHistory(ctx, alice, projectId, subprojectId, filter, baseRepository);
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});

--- a/api/src/service/domain/workflow/subproject_history_get.spec.ts
+++ b/api/src/service/domain/workflow/subproject_history_get.spec.ts
@@ -2,10 +2,14 @@ import { assert } from "chai";
 
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
 import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
 import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
 import { Subproject } from "./subproject";
 import { Filter, getHistory } from "./subproject_history_get";
+import { SubprojectTraceEvent } from "./subproject_trace_event";
 
 const ctx: Ctx = { requestId: "", source: "test" };
 const root: ServiceUser = { id: "root", groups: [] };
@@ -13,48 +17,73 @@ const alice: ServiceUser = { id: "alice", groups: [] };
 const projectId = "dummy-project";
 const subprojectId = "dummy-subproject";
 const subprojectName = "dummy-Name";
+const date = new Date().toISOString();
 
 const filter: Filter = {
-    publisher: alice.id,
-    startAt: new Date().toISOString(),
-    endAt: new Date().toISOString(),
-    eventType: "subproject_created",
+  publisher: alice.id,
+  startAt: date,
+  endAt: date,
+  eventType: "subproject_created",
 };
 
-const permissions = {
-    "subproject.viewDetails": ["alice"],
-  };
+const permissions: Permissions = {
+  "subproject.viewDetails": ["alice"],
+};
+
+const event: SubprojectTraceEvent = {
+  entityId: alice.id,
+  entityType: "subproject",
+  businessEvent: {
+    type: "subproject_created",
+    source: "",
+    time: date,
+    publisher: alice.id,
+    projectId,
+    subproject: {
+      id: subprojectId,
+      status: "open",
+      displayName: "subproject",
+      description: "some description",
+      currency: "",
+      projectedBudgets: [],
+      permissions: {},
+      additionalData: {},
+    },
+  },
+  snapshot: {
+    displayName: "",
+  },
+};
 
 const baseSubproject: Subproject = {
-    id: subprojectId,
-    projectId: subprojectId,
-    createdAt: new Date().toISOString(),
-    status: "open",
-    displayName: subprojectName,
-    description: subprojectName,
-    assignee: alice.id,
-    currency: "EUR",
-    projectedBudgets: [],
-    permissions,
-    log: [],
-    workflowitemOrdering: [],
-    additionalData: {},
-  };
+  id: subprojectId,
+  projectId: subprojectId,
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: subprojectName,
+  description: subprojectName,
+  assignee: alice.id,
+  currency: "EUR",
+  projectedBudgets: [],
+  permissions,
+  log: [event],
+  workflowitemOrdering: [],
+  additionalData: {},
+};
 
 const baseRepository = {
-    getSubproject: async () => baseSubproject,
+  getSubproject: async () => baseSubproject,
 };
 
 describe("get subproject history: authorization", () => {
   it("Without the required permissions, a user cannot get a subproject's history.", async () => {
-    const notPermittedSubproject = {
-        ...baseSubproject,
-        permissions: {},
-      };
-    const result = await getHistory(ctx, alice, projectId, subprojectId, filter,
-        {
-        ...baseRepository,
-        getSubproject: async () => notPermittedSubproject,
+    const notPermittedSubproject: Subproject = {
+      ...baseSubproject,
+      permissions: {},
+    };
+    const result = await getHistory(ctx, alice, projectId, subprojectId, filter, {
+      ...baseRepository,
+      getSubproject: async () => notPermittedSubproject,
     });
     assert.instanceOf(result, NotAuthorized);
   });
@@ -67,5 +96,68 @@ describe("get subproject history: authorization", () => {
   it("The root user doesn't need permission to get a subproject's history.", async () => {
     const result = await getHistory(ctx, alice, projectId, subprojectId, filter, baseRepository);
     assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});
+
+describe("get subproject history: preconditions", () => {
+  it("Getting a subproject's history fails if the subproject cannot be found", async () => {
+    const result = await getHistory(ctx, alice, projectId, subprojectId, filter, {
+      ...baseRepository,
+      getSubproject: async () => new Error("some error"),
+    });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
+  });
+
+  it("the properties of the filter must match the resulted properties exactly", async () => {
+    const result = await getHistory(ctx, root, projectId, subprojectId, filter, baseRepository);
+    assert.equal(result[0].businessEvent.publisher, alice.id);
+    assert.isTrue(result[0].businessEvent.time >= filter.startAt);
+    assert.isTrue(result[0].businessEvent.time <= filter.endAt);
+    assert.equal(result[0].businessEvent.type, filter.eventType);
+  });
+
+  it("if one property of the result doesn't match the filter the event is not returned", async () => {
+    const editedFilter: Filter = {
+      ...filter,
+      publisher: root.id,
+    };
+    const result = await getHistory(
+      ctx,
+      root,
+      projectId,
+      subprojectId,
+      editedFilter,
+      baseRepository,
+    );
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.isEmpty(result);
+  });
+  it("if there are more events in a subproject's history only the one matching the filter is returned", async () => {
+    const anotherBusinessEvent: BusinessEvent = {
+      type: "subproject_closed",
+      source: "",
+      time: date,
+      publisher: alice.id,
+      projectId,
+      subprojectId,
+    };
+    const newEvent: SubprojectTraceEvent = {
+      ...event,
+      businessEvent: anotherBusinessEvent,
+    };
+    const updatedSubproject: Subproject = {
+      ...baseSubproject,
+      log: [event, newEvent],
+    };
+
+    const result = await getHistory(ctx, root, projectId, subprojectId, filter, {
+      getSubproject: async () => updatedSubproject,
+    });
+    assert.equal(Result.unwrap(result).length, 1);
+    assert.equal(result[0].businessEvent.publisher, alice.id);
+    assert.isTrue(result[0].businessEvent.time >= filter.startAt);
+    assert.isTrue(result[0].businessEvent.time <= filter.endAt);
+    assert.equal(result[0].businessEvent.type, filter.eventType);
   });
 });

--- a/api/src/service/domain/workflow/subproject_list.spec.ts
+++ b/api/src/service/domain/workflow/subproject_list.spec.ts
@@ -1,0 +1,78 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { ServiceUser } from "../organization/service_user";
+import { Subproject } from './subproject';
+import { getAllVisible } from "./subproject_list";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const subprojectId = "dummy-subproject";
+const subprojectName = "dummy-Name";
+
+const permissions = {
+    "subproject.viewSummary": ["alice"],
+    "subproject.viewDetails": ["alice"],
+  };
+
+const baseSubproject: Subproject = {
+    id: subprojectId,
+    projectId: subprojectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: subprojectName,
+    description: subprojectName,
+    assignee: alice.id,
+    currency: "EUR",
+    projectedBudgets: [],
+    permissions,
+    log: [],
+    workflowitemOrdering: [],
+    additionalData: {},
+  };
+
+const baseRepository = {
+    getAllSubprojects: async () => [baseSubproject],
+    getWorkflowitems: async () => [],
+    getUsersForIdentity: async (identity: string) => {
+    if (identity === "alice") return ["alice"];
+    if (identity === "root") return ["root"];
+    throw Error(`unexpected identity: ${identity}`);
+  },
+};
+
+describe("list subprojects: authorization", () => {
+  it("Without the required permissions, a user cannot list all subprojects.", async () => {
+    const notPermittedSubroject = {
+   ...baseSubproject,
+    permissions: {},
+      };
+    const result = await getAllVisible(ctx, alice,
+        {
+        ...baseRepository,
+        getAllSubprojects: async () => [notPermittedSubroject],
+    });
+
+    // No errors, but no subprojects visible:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.isEmpty(result);
+
+  });
+  it("With the required permissions, a user can list all subprojects.", async () => {
+    const result = await getAllVisible(ctx, alice, baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(result[0].id, subprojectId);
+
+  });
+
+  it("The root user doesn't need permission to list all subprojects.", async () => {
+    const result = await getAllVisible(ctx, root, baseRepository);
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(result[0].id, subprojectId);
+  });
+});

--- a/api/src/service/domain/workflow/subproject_permission_grant.spec.ts
+++ b/api/src/service/domain/workflow/subproject_permission_grant.spec.ts
@@ -1,0 +1,103 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { PreconditionError } from "../errors/precondition_error";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import * as Subproject from "./subproject";
+import * as SubprojectPermissionGrant from "./subproject_permission_grant";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const executingUser: ServiceUser = { id: "mstein", groups: [] };
+const testUser: ServiceUser = { id: "testUser", groups: [] };
+
+const permissions: Permissions = {
+  "subproject.viewSummary": ["testUser"],
+  "subproject.viewDetails": [],
+  "subproject.intent.revokePermission": ["testUser"],
+  "subproject.intent.grantPermission": ["mstein"],
+};
+
+const testsubproject: Subproject.Subproject = {
+  id: "testsubproject",
+  projectId: "testProject",
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: "unitTestName",
+  description: "",
+  currency: "EUR",
+  workflowitemOrdering: [],
+  projectedBudgets: [],
+  permissions,
+  log: [],
+  additionalData: {},
+};
+
+describe("grant subproject permissions", () => {
+  it("With the 'subproject.intent.grantPermission' permission, the user can grant subproject permissions",
+  async () => {
+    const grantResult = await SubprojectPermissionGrant.grantSubprojectPermission(
+      ctx,
+      executingUser,
+      testsubproject.projectId,
+      testsubproject.id,
+      testUser.id,
+      "subproject.viewDetails",
+      {
+        getSubproject: async () => testsubproject,
+      },
+    );
+
+    if (Result.isErr(grantResult)) {
+      throw grantResult;
+    }
+    const newEvents = grantResult;
+    assert.lengthOf(newEvents, 1);
+    const grantEvent = newEvents[0];
+    const expectedEvent: BusinessEvent = {
+      type: "subproject_permission_granted",
+      source: ctx.source,
+      publisher: executingUser.id,
+      time: grantEvent.time,
+      projectId: testsubproject.projectId,
+      subprojectId: testsubproject.id,
+      permission: "subproject.viewDetails",
+      grantee: testUser.id,
+    };
+    assert.deepEqual(expectedEvent, grantEvent);
+  });
+
+  it("Without the 'subproject.intent.grantPermission' permission, the user cannot grant subproject permissions",
+  async () => {
+    const subprojectWithoutPermission: Subproject.Subproject = {
+      id: "testsubproject",
+      projectId: "testProject",
+      createdAt: new Date().toISOString(),
+      status: "open",
+      displayName: "unitTestName",
+      description: "",
+      currency: "EUR",
+      workflowitemOrdering: [],
+      projectedBudgets: [],
+      permissions: { "subproject.intent.grantPermission": [] },
+      log: [],
+      additionalData: {},
+    };
+    const grantResult = await SubprojectPermissionGrant.grantSubprojectPermission(
+      ctx,
+      executingUser,
+      testsubproject.projectId,
+      testsubproject.id,
+      testUser.id,
+      "subproject.viewDetails",
+      {
+        getSubproject: async () => subprojectWithoutPermission,
+      },
+    );
+
+    assert.isTrue(Result.isErr(grantResult));
+    assert.instanceOf(grantResult, NotAuthorized);
+  });
+});

--- a/api/src/service/domain/workflow/subproject_permission_grant.spec.ts
+++ b/api/src/service/domain/workflow/subproject_permission_grant.spec.ts
@@ -3,6 +3,7 @@ import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
 import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
 import { PreconditionError } from "../errors/precondition_error";
 import { ServiceUser } from "../organization/service_user";
 import { Permissions } from "../permissions";
@@ -36,8 +37,7 @@ const testsubproject: Subproject.Subproject = {
 };
 
 describe("grant subproject permissions", () => {
-  it("With the 'subproject.intent.grantPermission' permission, the user can grant subproject permissions",
-  async () => {
+  it("With the 'subproject.intent.grantPermission' permission, the user can grant subproject permissions", async () => {
     const grantResult = await SubprojectPermissionGrant.grantSubprojectPermission(
       ctx,
       executingUser,
@@ -69,8 +69,7 @@ describe("grant subproject permissions", () => {
     assert.deepEqual(expectedEvent, grantEvent);
   });
 
-  it("Without the 'subproject.intent.grantPermission' permission, the user cannot grant subproject permissions",
-  async () => {
+  it("Without the 'subproject.intent.grantPermission' permission, the user cannot grant subproject permissions", async () => {
     const subprojectWithoutPermission: Subproject.Subproject = {
       id: "testsubproject",
       projectId: "testProject",
@@ -99,5 +98,47 @@ describe("grant subproject permissions", () => {
 
     assert.isTrue(Result.isErr(grantResult));
     assert.instanceOf(grantResult, NotAuthorized);
+  });
+});
+describe("grant subproject permission: preconditions", () => {
+  it("Granting a subproject's permission fails if the subproject cannot be found", async () => {
+    const grantResult = await SubprojectPermissionGrant.grantSubprojectPermission(
+      ctx,
+      executingUser,
+      testsubproject.projectId,
+      testsubproject.id,
+      testUser.id,
+      "subproject.viewDetails",
+      {
+        getSubproject: async () => new Error("some error"),
+      },
+    );
+    assert.isTrue(Result.isErr(grantResult));
+    assert.instanceOf(grantResult, NotFound);
+  });
+  it("No changes to existing permissions emit no new events", async () => {
+    const existingPermissions: Permissions = {
+      "subproject.viewSummary": ["testUser"],
+      "subproject.viewDetails": ["testUser"],
+      "subproject.intent.revokePermission": ["testUser"],
+      "subproject.intent.grantPermission": ["mstein"],
+    };
+    const baseSubproject: Subproject.Subproject = {
+      ...testsubproject,
+      permissions: existingPermissions,
+    };
+    const grantResult = await SubprojectPermissionGrant.grantSubprojectPermission(
+      ctx,
+      executingUser,
+      testsubproject.projectId,
+      testsubproject.id,
+      testUser.id,
+      "subproject.viewDetails",
+      {
+        getSubproject: async () => baseSubproject,
+      },
+    );
+
+    assert.deepEqual([], grantResult);
   });
 });

--- a/api/src/service/domain/workflow/subproject_permissions_list.spec.ts
+++ b/api/src/service/domain/workflow/subproject_permissions_list.spec.ts
@@ -1,0 +1,71 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import { Subproject } from "./subproject";
+import { getSubprojectPermissions } from "./subproject_permissions_list";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const bob: ServiceUser = { id: "bob", groups: [] };
+const root: ServiceUser = { id: "root", groups: [] };
+const projectId = "dummy-project";
+const subprojectId = "dummy-subproject";
+const subprojectName = "dummy";
+
+const permissions: Permissions = {
+  "subproject.intent.listPermissions": ["bob"],
+};
+
+const baseSubproject: Subproject = {
+    id: subprojectId,
+    projectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: subprojectName,
+    description: subprojectName,
+    assignee: bob.id,
+    currency: "EUR",
+    projectedBudgets: [],
+    workflowitemOrdering: [],
+    permissions,
+    log: [],
+    additionalData: {},
+  };
+
+const repository = returnedSubproject => {
+  return { getSubproject: async () => returnedSubproject };
+};
+
+describe("List subproject permissions: authorization", () => {
+  it("With the 'subproject.intent.listPermissions' permission, the user can list project permissions", async () => {
+    const result = await getSubprojectPermissions(ctx, bob, projectId, subprojectId, repository(baseSubproject));
+
+    assert.isTrue(Result.isOk(result));
+    assert.equal(Result.unwrap(result), permissions);
+  });
+
+  it("Without the 'subproject.intent.listPermissions' permission," +
+  "the user cannot list subproject permissions", async () => {
+    const subprojectWithoutPermissions = { ...baseSubproject, permissions: {} };
+
+    const result = await getSubprojectPermissions(
+      ctx,
+      bob,
+      projectId,
+      subprojectId,
+      repository(subprojectWithoutPermissions),
+    );
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("The root user doesn't need permission to list project permissions", async () => {
+    const result = await getSubprojectPermissions(ctx, root, projectId, subprojectId, repository(baseSubproject));
+
+    assert.isTrue(Result.isOk(result));
+    assert.equal(Result.unwrap(result), permissions);
+  });
+});

--- a/api/src/service/domain/workflow/subproject_update.spec.ts
+++ b/api/src/service/domain/workflow/subproject_update.spec.ts
@@ -1,0 +1,364 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
+import { ServiceUser } from "../organization/service_user";
+import { Subproject } from "./subproject";
+import { updateSubproject } from "./subproject_update";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const bob: ServiceUser = { id: "bob", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const charlie: ServiceUser = { id: "charlie", groups: ["alice_and_bob_and_charlie"] };
+const projectId = "dummy-project";
+const subprojectId = "dummy-subproject";
+const subprojectName = "dummy";
+
+const baseSubproject: Subproject = {
+    id: subprojectId,
+    projectId,
+    createdAt: new Date().toISOString(),
+    status: "open",
+    displayName: subprojectName,
+    description: subprojectName,
+    assignee: alice.id,
+    currency: "EUR",
+    projectedBudgets: [],
+    workflowitemOrdering: [],
+    permissions: { "subproject.update": [alice, bob, charlie].map(x => x.id) },
+    log: [],
+    additionalData: {},
+  };
+
+const baseRepository = {
+    getSubproject: async () => baseSubproject,
+    getUsersForIdentity: async (identity: string) => {
+    if (identity === "alice") return ["alice"];
+    if (identity === "bob") return ["bob"];
+    if (identity === "charlie") return ["charlie"];
+    if (identity === "alice_and_bob") return ["alice", "bob"];
+    if (identity === "alice_and_bob_and_charlie") return ["alice", "bob", "charlie"];
+    if (identity === "root") return ["root"];
+    throw Error(`unexpected identity: ${identity}`);
+  },
+};
+
+describe("update subproject: authorization", () => {
+  it("Without the subproject.update permission, a user cannot update a subproject", async () => {
+    const modification = {};
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      {
+        ...baseRepository,
+        getSubproject: async () => ({
+          ...baseSubproject,
+          permissions: {},
+        }),
+      },
+    );
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("The root user doesn't need permission to update a subproject", async () => {
+    const modification = {};
+    const result = await updateSubproject(
+      ctx,
+      root,
+      projectId,
+      subprojectId,
+      modification,
+      {
+        ...baseRepository,
+        getSubproject: async () => ({
+          ...baseSubproject,
+          permissions: {},
+        }),
+      },
+    );
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});
+
+describe("update subproject: how modifications are applied", () => {
+  it("An empty update is ignored", async () => {
+    const modification = {};
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      baseRepository,
+    );
+
+    // It works:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    // But there are no new events:
+    assert.lengthOf(Result.unwrap(result), 0);
+  });
+
+  it("An update that contains current values only is ignored", async () => {
+    const modification = {
+      displayName: subprojectName,
+      description: subprojectName,
+    };
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      baseRepository,
+    );
+
+    // It works:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    // But there are no new events:
+    assert.lengthOf(Result.unwrap(result), 0);
+  });
+
+  it("The description field can be cleared as an empty string is allowed there", async () => {
+    const modification = {
+      description: "",
+    };
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    // There are new events and the subproject's description has been cleared:
+    assert.isAtLeast(Result.unwrap(result).length, 1);
+    const {update} = result[0];
+    assert.equal(update.description, "");
+  });
+
+  it("The displayName field cannot be cleared as it is a required field", async () => {
+    const modification = {
+      displayName: "",
+    };
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      baseRepository,
+    );
+
+    assert.isTrue(Result.isErr(result));
+    const error = Result.unwrap_err(result);
+    assert.match(error.message, /displayName.*\s+.*empty/);
+  });
+
+  it("A closed subproject cannot be updated", async () => {
+    const modification = {
+      description: "Some update",
+    };
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      {
+        ...baseRepository,
+        getSubproject: async () => ({
+          ...baseSubproject,
+          status: "closed",
+          billingDate: "2019-03-20T10:33:18.856Z",
+          description: "A description.",
+        }),
+      },
+    );
+
+    assert.isTrue(Result.isErr(result));
+    const error = Result.unwrap_err(result);
+    assert.match(error.message, /status/);
+  });
+
+  it("An update to additional data adds new items and replaces existing ones", async () => {
+    const modification = {
+      additionalData: {
+        a: "updated value",
+        b: "new value",
+      },
+    };
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      {
+        ...baseRepository,
+        getSubproject: async () => ({
+          ...baseSubproject,
+          additionalData: {
+            a: "old value",
+          },
+        }),
+      },
+    );
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    const { update } = result[0];
+    assert.deepEqual(update.additionalData, {
+      a: "updated value",
+      b: "new value",
+    });
+  });
+
+  it("Updating fails for an invalid subproject ID", async () => {
+    const modification = {
+      description: "Some update",
+    };
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      {
+        ...baseRepository,
+        getSubproject: async () => new Error("some error"),
+      },
+    );
+
+    // NotFound error as the subproject cannot be fetched:
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
+  });
+});
+
+describe("update subproject: notifications", () => {
+  it("When a user updates an assigned subproject, a notification is issued to the assignee", async () => {
+    const modification = {
+      description: "New description.",
+    };
+    const result = await updateSubproject(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      modification,
+      {
+        ...baseRepository,
+        getSubproject: async () => ({
+          ...baseSubproject,
+          description: "A description.",
+          assignee: bob.id,
+        }),
+      },
+    );
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    assert.isTrue(
+      Result.unwrap(result).some(
+        event => event.type === "notification_created"
+        && event.recipient === bob.id,
+      ),
+    );
+  });
+
+  it("When a user updates an unassigned subproject, no notifications are issued", async () => {
+    const modification = {
+      description: "New description.",
+    };
+    const result = await updateSubproject(
+        ctx,
+        alice,
+        projectId,
+        subprojectId,
+        modification,
+        {
+          ...baseRepository,
+          getSubproject: async () => ({
+            ...baseSubproject,
+            description: "A description.",
+            assignee: undefined,
+          }),
+        },
+      );
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    assert.isFalse(
+        Result.unwrap(result).some(
+          event => event.type === "notification_created",
+        ),
+      );
+  });
+
+  it("When an update is ignored, no notifications are issued", async () => {
+    // An empty modification is always ignored:
+    const modification = {};
+    const result = await updateSubproject(
+          ctx,
+          alice,
+          projectId,
+          subprojectId,
+          modification,
+          baseRepository,
+        );
+
+    // It works:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+
+    // But no notifications have been issued (in fact there are no new events at all):
+    assert.lengthOf(Result.unwrap(result), 0);
+  });
+
+  it(
+    "When a user updates a subproject that is assigned to a group, " +
+      "each member, except for the user that invoked the update, receives a notification",
+    async () => {
+      const modification = {
+        description: "New description.",
+      };
+      const result = await updateSubproject(
+        ctx,
+        alice,
+        projectId,
+        subprojectId,
+        modification,
+        {
+          ...baseRepository,
+          getSubproject: async () => ({
+            ...baseSubproject,
+            description: "A description.",
+            assignee: "alice_and_bob_and_charlie",
+          }),
+        },
+      );
+
+      assert.isTrue(Result.isOk(result), (result as Error).message);
+      const res = Result.unwrap(result);
+
+      // A notification has been issued to both Bob and Charlie, but not to Alice, as she
+      // is the user who has updated the subproject:
+      function isNotificationFor(userId: string): (e: BusinessEvent) => boolean {
+        return event => event.type === "notification_created" && event.recipient === userId;
+      }
+
+      assert.isFalse(res.some(isNotificationFor("alice")));
+      assert.isTrue(res.some(isNotificationFor("bob")));
+      assert.isTrue(res.some(isNotificationFor("charlie")));
+    },
+  );
+ });

--- a/api/src/service/domain/workflow/subproject_update.ts
+++ b/api/src/service/domain/workflow/subproject_update.ts
@@ -47,16 +47,17 @@ export async function updateSubproject(
   }
 
   // Create the new event:
-  const subprojectUpdated = SubprojectUpdated.createEvent(
+  const subprojectUpdatedResult = SubprojectUpdated.createEvent(
     ctx.source,
     issuer.id,
     projectId,
     subprojectId,
     data,
   );
-  if (Result.isErr(subprojectUpdated)) {
-    return new VError(subprojectUpdated, "failed to create event");
+  if (Result.isErr(subprojectUpdatedResult)) {
+    return new VError(subprojectUpdatedResult, "failed to create event");
   }
+  const subprojectUpdated = subprojectUpdatedResult;
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/workflow/subproject_updated.ts
+++ b/api/src/service/domain/workflow/subproject_updated.ts
@@ -54,7 +54,7 @@ export function createEvent(
   subprojectId: Subproject.Id,
   update: UpdatedData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -67,7 +67,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/workflowitem_get.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_get.spec.ts
@@ -1,0 +1,73 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Workflowitem } from "./workflowitem";
+import { getWorkflowitem } from "./workflowitem_get";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const subprojectId = "dummy-subproject";
+const projectId = "dummy-project";
+const workflowitemId = "dummy-workflowitem";
+
+const permissions = {
+    "workflowitem.view": ["alice"],
+  };
+
+const baseWorkflowitem: Workflowitem = {
+  isRedacted: false,
+  id: workflowitemId,
+  subprojectId,
+  createdAt: new Date().toISOString(),
+  dueDate: new Date().toISOString(),
+  status: "open",
+  displayName: "dummy",
+  description: "dummy",
+  amountType: "N/A",
+  documents: [],
+  permissions,
+  log: [],
+  additionalData: {},
+  workflowitemType: "general",
+};
+
+const baseRepository = {
+    getWorkflowitem: async () => baseWorkflowitem,
+  };
+
+describe("get workflowitems: authorization", () => {
+  it("Without the required permissions, a user cannot get a workflowitem.", async () => {
+    const notPermittedWorkflowitem = {
+        ...baseWorkflowitem,
+        permissions: {},
+      };
+    const result = await getWorkflowitem(ctx, alice, workflowitemId,
+        {
+        ...baseRepository,
+        getWorkflowitem: async () => notPermittedWorkflowitem,
+    });
+
+    assert.instanceOf(result, NotAuthorized);
+
+  });
+
+  it("With the required permissions, a user can get a workflowitem.", async () => {
+    const result = await getWorkflowitem(ctx, alice, workflowitemId, baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(Result.unwrap(result).id, workflowitemId);
+
+  });
+
+  it("The root user doesn't need permission to get a workflowitem.", async () => {
+    const result = await getWorkflowitem(ctx, root, workflowitemId, baseRepository);
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(Result.unwrap(result).id, workflowitemId);
+  });
+});

--- a/api/src/service/domain/workflow/workflowitem_history_get.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_history_get.spec.ts
@@ -1,0 +1,72 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Workflowitem } from "./workflowitem";
+import { Filter, getHistory } from "./workflowitem_history_get";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const projectId = "dummy-project";
+const subprojectId = "dummy-subproject";
+const workflowitemId = "dummy-workflowitem";
+
+const filter: Filter = {
+    publisher: alice.id,
+    startAt: new Date().toISOString(),
+    endAt: new Date().toISOString(),
+    eventType: "subproject_created",
+};
+
+const permissions = {
+    "workflowitem.view": ["alice"],
+  };
+
+const baseWorkflowitem: Workflowitem = {
+  isRedacted: false,
+  id: workflowitemId,
+  subprojectId,
+  createdAt: new Date().toISOString(),
+  dueDate: new Date().toISOString(),
+  status: "open",
+  displayName: "dummy",
+  description: "dummy",
+  amountType: "N/A",
+  documents: [],
+  permissions,
+  log: [],
+  additionalData: {},
+  workflowitemType: "general",
+};
+
+const baseRepository = {
+    getWorkflowitem: async () => baseWorkflowitem,
+};
+
+describe("get worklfowitem history: authorization", () => {
+  it("Without the required permissions, a user cannot get a worklfowitem's history.", async () => {
+    const notPermittedWorkflowitem = {
+        ...baseWorkflowitem,
+        permissions: {},
+      };
+    const result = await getHistory(ctx, alice, projectId, subprojectId, workflowitemId, filter,
+        {
+        ...baseRepository,
+        getWorkflowitem: async () => notPermittedWorkflowitem,
+    });
+    assert.instanceOf(result, NotAuthorized);
+  });
+
+  it("With the required permissions, a user can get a worklfowitem's history.", async () => {
+    const result = await getHistory(ctx, alice, projectId, subprojectId, workflowitemId, filter, baseRepository);
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("The root user doesn't need permission to get a worklfowitem's history.", async () => {
+    const result = await getHistory(ctx, root, projectId, subprojectId, workflowitemId, filter, baseRepository);
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});

--- a/api/src/service/domain/workflow/workflowitem_history_get.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_history_get.spec.ts
@@ -2,10 +2,14 @@ import { assert } from "chai";
 
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
 import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
 import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
 import { Workflowitem } from "./workflowitem";
 import { Filter, getHistory } from "./workflowitem_history_get";
+import { WorkflowitemTraceEvent } from "./workflowitem_trace_event";
 
 const ctx: Ctx = { requestId: "", source: "test" };
 const root: ServiceUser = { id: "root", groups: [] };
@@ -13,17 +17,48 @@ const alice: ServiceUser = { id: "alice", groups: [] };
 const projectId = "dummy-project";
 const subprojectId = "dummy-subproject";
 const workflowitemId = "dummy-workflowitem";
+const date = new Date().toISOString();
 
 const filter: Filter = {
-    publisher: alice.id,
-    startAt: new Date().toISOString(),
-    endAt: new Date().toISOString(),
-    eventType: "subproject_created",
+  publisher: alice.id,
+  startAt: date,
+  endAt: date,
+  eventType: "workflowitem_created",
 };
 
-const permissions = {
-    "workflowitem.view": ["alice"],
-  };
+const permissions: Permissions = {
+  "workflowitem.view": ["alice"],
+};
+
+const event: WorkflowitemTraceEvent = {
+  entityId: alice.id,
+  entityType: "workflowitem",
+  businessEvent: {
+    type: "workflowitem_created",
+    source: "",
+    time: date,
+    publisher: alice.id,
+    projectId,
+    subprojectId,
+    workflowitem: {
+      id: subprojectId,
+      status: "open",
+      displayName: "subproject",
+      description: "some description",
+      currency: "",
+      permissions: {},
+      additionalData: {},
+      amountType: "N/A",
+      documents: [],
+    },
+  },
+  snapshot: {
+    displayName: "",
+    amount: "",
+    currency: "string",
+    amountType: "",
+  },
+};
 
 const baseWorkflowitem: Workflowitem = {
   isRedacted: false,
@@ -37,36 +72,132 @@ const baseWorkflowitem: Workflowitem = {
   amountType: "N/A",
   documents: [],
   permissions,
-  log: [],
+  log: [event],
   additionalData: {},
   workflowitemType: "general",
 };
 
 const baseRepository = {
-    getWorkflowitem: async () => baseWorkflowitem,
+  getWorkflowitem: async () => baseWorkflowitem,
 };
 
 describe("get worklfowitem history: authorization", () => {
   it("Without the required permissions, a user cannot get a worklfowitem's history.", async () => {
-    const notPermittedWorkflowitem = {
-        ...baseWorkflowitem,
-        permissions: {},
-      };
-    const result = await getHistory(ctx, alice, projectId, subprojectId, workflowitemId, filter,
-        {
-        ...baseRepository,
-        getWorkflowitem: async () => notPermittedWorkflowitem,
+    const notPermittedWorkflowitem: Workflowitem = {
+      ...baseWorkflowitem,
+      permissions: {},
+    };
+    const result = await getHistory(ctx, alice, projectId, subprojectId, workflowitemId, filter, {
+      ...baseRepository,
+      getWorkflowitem: async () => notPermittedWorkflowitem,
     });
     assert.instanceOf(result, NotAuthorized);
   });
 
   it("With the required permissions, a user can get a worklfowitem's history.", async () => {
-    const result = await getHistory(ctx, alice, projectId, subprojectId, workflowitemId, filter, baseRepository);
+    const result = await getHistory(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      workflowitemId,
+      filter,
+      baseRepository,
+    );
     assert.isTrue(Result.isOk(result), (result as Error).message);
   });
 
   it("The root user doesn't need permission to get a worklfowitem's history.", async () => {
-    const result = await getHistory(ctx, root, projectId, subprojectId, workflowitemId, filter, baseRepository);
+    const result = await getHistory(
+      ctx,
+      root,
+      projectId,
+      subprojectId,
+      workflowitemId,
+      filter,
+      baseRepository,
+    );
     assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+});
+describe("get workflowitem history: preconditions", () => {
+  it("Getting a workflowitem's history fails if the workflowitem cannot be found", async () => {
+    const result = await getHistory(ctx, alice, projectId, subprojectId, workflowitemId, filter, {
+      ...baseRepository,
+      getWorkflowitem: async () => new Error("some error"),
+    });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
+  });
+
+  it("the properties of the filter must match the resulted properties exactly", async () => {
+    const result = await getHistory(
+      ctx,
+      root,
+      projectId,
+      subprojectId,
+      workflowitemId,
+      filter,
+      baseRepository,
+    );
+    assert.equal(result[0].businessEvent.publisher, alice.id);
+    assert.isTrue(result[0].businessEvent.time >= filter.startAt);
+    assert.isTrue(result[0].businessEvent.time <= filter.endAt);
+    assert.equal(result[0].businessEvent.type, filter.eventType);
+  });
+
+  it("if one property of the result doesn't match the filter the event is not returned", async () => {
+    const editedFilter: Filter = {
+      ...filter,
+      publisher: root.id,
+    };
+    const result = await getHistory(
+      ctx,
+      root,
+      projectId,
+      subprojectId,
+      workflowitemId,
+      editedFilter,
+      baseRepository,
+    );
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.isEmpty(result);
+  });
+  it("if there are more events in a workflowitem's history only the one matching the filter is returned", async () => {
+    const anotherBusinessEvent: BusinessEvent = {
+      type: "workflowitem_closed",
+      source: "",
+        time: date,
+        publisher: alice.id,
+        projectId,
+        subprojectId,
+        workflowitemId,
+    };
+    const newEvent: WorkflowitemTraceEvent = {
+      ...event,
+      businessEvent: anotherBusinessEvent,
+    };
+    const updatedWorkflowitem: Workflowitem = {
+        ...baseWorkflowitem,
+        log: [event, newEvent],
+    };
+
+    const result = await getHistory(
+      ctx,
+      root,
+      projectId,
+      subprojectId,
+      workflowitemId,
+      filter,
+      {
+        getWorkflowitem: async () => updatedWorkflowitem,
+
+      },
+    );
+    assert.equal(Result.unwrap(result).length, 1);
+    assert.equal(result[0].businessEvent.publisher, alice.id);
+    assert.isTrue(result[0].businessEvent.time >= filter.startAt);
+    assert.isTrue(result[0].businessEvent.time <= filter.endAt);
+    assert.equal(result[0].businessEvent.type, filter.eventType);
   });
 });

--- a/api/src/service/domain/workflow/workflowitem_list.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_list.spec.ts
@@ -2,7 +2,9 @@ import { assert } from "chai";
 
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
+import { NotFound } from "../errors/not_found";
 import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
 import { Workflowitem } from "./workflowitem";
 import { getAllVisible } from "./workflowitem_list";
 
@@ -13,9 +15,9 @@ const subprojectId = "dummy-subproject";
 const projectId = "dummy-project";
 const workflowitemId = "dummy-workflowitem";
 
-const permissions = {
-    "workflowitem.view": ["alice"],
-  };
+const permissions: Permissions = {
+  "workflowitem.view": ["alice"],
+};
 
 const baseWorkflowitem: Workflowitem = {
   isRedacted: false,
@@ -35,33 +37,44 @@ const baseWorkflowitem: Workflowitem = {
 };
 
 const baseRepository = {
-    getWorkflowitems: async () => [baseWorkflowitem],
-    getWorkflowitemOrdering: async () => [],
-  };
+  getWorkflowitems: async () => [baseWorkflowitem],
+  getWorkflowitemOrdering: async () => [],
+};
 
 describe("list workflowitems: authorization", () => {
   it("Without the required permissions, a user cannot list all workflowitems.", async () => {
-    const notPermittedWorkflowitem = {
-        ...baseWorkflowitem,
-        permissions: {},
-      };
+    const notPermittedWorkflowitem: Workflowitem = {
+      ...baseWorkflowitem,
+      permissions: {},
+    };
     const result = await getAllVisible(ctx, alice, projectId, subprojectId,
-        {
-        ...baseRepository,
-        getWorkflowitems: async () => [notPermittedWorkflowitem],
+      {
+      ...baseRepository,
+      getWorkflowitems: async () => [notPermittedWorkflowitem],
     });
 
     // No errors, but workflowitems should be redacted:
     assert.isTrue(Result.isOk(result), (result as Error).message);
     Result.unwrap(result).forEach(r => assert.equal(r.isRedacted, true));
-
   });
   it("With the required permissions, a user can list all workflowitems.", async () => {
     const result = await getAllVisible(ctx, alice, projectId, subprojectId, baseRepository);
 
     assert.isTrue(Result.isOk(result), (result as Error).message);
     assert.equal(result[0].id, workflowitemId);
+  });
 
+  it.only("If a user doesn't have permission to view a workflowitem, it is redacted when listed.", async () => {
+    const notPermittedWorkflowitem: Workflowitem = {
+      ...baseWorkflowitem,
+      permissions: {},
+    };
+    const result = await getAllVisible(ctx, alice, projectId, subprojectId, {
+      ...baseRepository,
+      getWorkflowitems: async () => [notPermittedWorkflowitem],
+    });
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.isTrue(result[0].isRedacted);
   });
 
   it("The root user doesn't need permission to list all workflowitems.", async () => {
@@ -70,5 +83,15 @@ describe("list workflowitems: authorization", () => {
     // No errors, despite the missing permissions:
     assert.isTrue(Result.isOk(result), (result as Error).message);
     assert.equal(result[0].id, workflowitemId);
+  });
+});
+describe("list workflowitems: preconditions", () => {
+  it("Listing all workflowitems fails if the workflowitem is not found.", async () => {
+    const result = await getAllVisible(ctx, alice, projectId, subprojectId, {
+      ...baseRepository,
+      getWorkflowitems: async () => new Error("some error"),
+    });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
   });
 });

--- a/api/src/service/domain/workflow/workflowitem_list.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_list.spec.ts
@@ -64,7 +64,7 @@ describe("list workflowitems: authorization", () => {
     assert.equal(result[0].id, workflowitemId);
   });
 
-  it.only("If a user doesn't have permission to view a workflowitem, it is redacted when listed.", async () => {
+  it("If a user doesn't have permission to view a workflowitem, it is redacted when listed.", async () => {
     const notPermittedWorkflowitem: Workflowitem = {
       ...baseWorkflowitem,
       permissions: {},

--- a/api/src/service/domain/workflow/workflowitem_list.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_list.spec.ts
@@ -1,0 +1,74 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { ServiceUser } from "../organization/service_user";
+import { Workflowitem } from "./workflowitem";
+import { getAllVisible } from "./workflowitem_list";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const root: ServiceUser = { id: "root", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: [] };
+const subprojectId = "dummy-subproject";
+const projectId = "dummy-project";
+const workflowitemId = "dummy-workflowitem";
+
+const permissions = {
+    "workflowitem.view": ["alice"],
+  };
+
+const baseWorkflowitem: Workflowitem = {
+  isRedacted: false,
+  id: workflowitemId,
+  subprojectId,
+  createdAt: new Date().toISOString(),
+  dueDate: new Date().toISOString(),
+  status: "open",
+  displayName: "dummy",
+  description: "dummy",
+  amountType: "N/A",
+  documents: [],
+  permissions,
+  log: [],
+  additionalData: {},
+  workflowitemType: "general",
+};
+
+const baseRepository = {
+    getWorkflowitems: async () => [baseWorkflowitem],
+    getWorkflowitemOrdering: async () => [],
+  };
+
+describe("list workflowitems: authorization", () => {
+  it("Without the required permissions, a user cannot list all workflowitems.", async () => {
+    const notPermittedWorkflowitem = {
+        ...baseWorkflowitem,
+        permissions: {},
+      };
+    const result = await getAllVisible(ctx, alice, projectId, subprojectId,
+        {
+        ...baseRepository,
+        getWorkflowitems: async () => [notPermittedWorkflowitem],
+    });
+
+    // No errors, but workflowitems should be redacted:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    Result.unwrap(result).forEach(r => assert.equal(r.isRedacted, true));
+
+  });
+  it("With the required permissions, a user can list all workflowitems.", async () => {
+    const result = await getAllVisible(ctx, alice, projectId, subprojectId, baseRepository);
+
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(result[0].id, workflowitemId);
+
+  });
+
+  it("The root user doesn't need permission to list all workflowitems.", async () => {
+    const result = await getAllVisible(ctx, root, projectId, subprojectId, baseRepository);
+
+    // No errors, despite the missing permissions:
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+    assert.equal(result[0].id, workflowitemId);
+  });
+});

--- a/api/src/service/domain/workflow/workflowitem_permission_grant.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_grant.spec.ts
@@ -1,0 +1,107 @@
+import { assert } from "chai";
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { BusinessEvent } from "../business_event";
+import { NotAuthorized } from "../errors/not_authorized";
+import { PreconditionError } from "../errors/precondition_error";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import * as Workflowitem from "./workflowitem";
+import * as WorkflowitemPermissionGrant from "./workflowitem_permission_grant";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const executingUser: ServiceUser = { id: "mstein", groups: [] };
+const testUser: ServiceUser = { id: "testUser", groups: [] };
+const projectId = "testProject";
+
+const permissions: Permissions = {
+  "workflowitem.view": [],
+  "workflowitem.assign": [],
+  "workflowitem.intent.revokePermission": ["testUser"],
+  "workflowitem.intent.grantPermission": ["mstein"],
+};
+
+const testworkflowitem: Workflowitem.Workflowitem = {
+  isRedacted: false,
+  id: "testworkflowitem",
+  subprojectId: "testSubproject",
+  createdAt: new Date().toISOString(),
+  status: "open",
+  displayName: "unitTestName",
+  description: "",
+  amountType: "N/A",
+  documents: [],
+  permissions,
+  log: [],
+  additionalData: {},
+};
+
+describe("grant workflowitem permissions", () => {
+  it("With the 'workflowitem.intent.grantPermission' permission, the user can grant workflowitem permissions",
+  async () => {
+    const grantResult = await WorkflowitemPermissionGrant.grantWorkflowitemPermission(
+      ctx,
+      executingUser,
+      projectId,
+      testworkflowitem.subprojectId,
+      testworkflowitem.id,
+      testUser.id,
+      "workflowitem.assign",
+      {
+        getWorkflowitem: async () => testworkflowitem,
+      },
+    );
+
+    if (Result.isErr(grantResult)) {
+      throw grantResult;
+    }
+    const newEvents = grantResult;
+    assert.lengthOf(newEvents, 1);
+    const grantEvent = newEvents[0];
+    const expectedEvent: BusinessEvent = {
+      type: "workflowitem_permission_granted",
+      source: ctx.source,
+      publisher: executingUser.id,
+      time: grantEvent.time,
+      projectId: projectId,
+      subprojectId: testworkflowitem.subprojectId,
+      workflowitemId: testworkflowitem.id,
+      permission: "workflowitem.assign",
+      grantee: testUser.id,
+    };
+    assert.deepEqual(expectedEvent, grantEvent);
+  });
+
+  it("Without the 'workflowitem.intent.grantPermission' permission, the user cannot grant workflowitem permissions",
+  async () => {
+    const workflowitemWithoutPermission: Workflowitem.Workflowitem = {
+      isRedacted: false,
+      id: "testworkflowitem",
+      subprojectId: "testsubProject",
+      createdAt: new Date().toISOString(),
+      status: "open",
+      displayName: "unitTestName",
+      amountType: "N/A",
+      description: "",
+      documents: [],
+      permissions: { "workflowitem.intent.grantPermission": [] },
+      log: [],
+      additionalData: {},
+    };
+    const grantResult = await WorkflowitemPermissionGrant.grantWorkflowitemPermission(
+      ctx,
+      executingUser,
+      projectId,
+      testworkflowitem.subprojectId,
+      testworkflowitem.id,
+      testUser.id,
+      "workflowitem.view",
+      {
+        getWorkflowitem: async () => workflowitemWithoutPermission,
+      },
+    );
+
+    assert.isTrue(Result.isErr(grantResult));
+    assert.instanceOf(grantResult, NotAuthorized);
+  });
+});

--- a/api/src/service/domain/workflow/workflowitem_permissions_list.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_permissions_list.spec.ts
@@ -1,0 +1,79 @@
+import { assert } from "chai";
+
+import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
+import { NotAuthorized } from "../errors/not_authorized";
+import { ServiceUser } from "../organization/service_user";
+import { Permissions } from "../permissions";
+import { Workflowitem } from "./workflowitem";
+import { getAll } from "./workflowitem_permissions_list";
+
+const ctx: Ctx = { requestId: "", source: "test" };
+const bob: ServiceUser = { id: "bob", groups: [] };
+const alice: ServiceUser = { id: "alice", groups: ["alice_and_bob", "alice_and_bob_and_charlie"] };
+const projectId = "dummy-project";
+const subprojectId = "dummy-subproject";
+const subprojectName = "dummy";
+const workflowitemId = "dummy-workflowitem";
+
+const permissions: Permissions = {
+  "workflowitem.intent.listPermissions": ["bob"],
+};
+
+const baseWorkflowitem: Workflowitem = {
+  isRedacted: false,
+  id: workflowitemId,
+  subprojectId,
+  createdAt: new Date().toISOString(),
+  dueDate: new Date().toISOString(),
+  status: "open",
+  displayName: "dummy",
+  description: "dummy",
+  amountType: "N/A",
+  documents: [],
+  permissions,
+  log: [],
+  additionalData: {},
+  workflowitemType: "general",
+};
+
+const baseRepository = {
+    applyWorkflowitemType: () => [],
+    getWorkflowitem: async () => baseWorkflowitem,
+
+  };
+
+describe("List workflowitem permissions: authorization", () => {
+  it("With the 'workflowitem.intent.listPermissions' permission, " +
+  "the user can list workflowitem permissions", async () => {
+    const result = await getAll(ctx, bob, projectId, subprojectId, workflowitemId, baseRepository);
+
+    assert.isTrue(Result.isOk(result));
+    assert.equal(Result.unwrap(result), permissions);
+  });
+
+  it("Without the 'workflowitem.intent.listPermissions' permission," +
+  "the user cannot list workflowitem permissions", async () => {
+    const result = await getAll(ctx,
+        bob,
+        projectId,
+        subprojectId,
+        workflowitemId,
+        {
+            ...baseRepository,
+            getWorkflowitem: async _workflowitemId => ({
+              ...baseWorkflowitem,
+              permissions: {},
+            }),
+          });
+
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotAuthorized);
+  });
+  it("The root user doesn't need permission to list workflowitem permissions", async () => {
+    const result = await getAll(ctx, bob, projectId, subprojectId, workflowitemId, baseRepository);
+
+    assert.isTrue(Result.isOk(result));
+    assert.equal(Result.unwrap(result), permissions);
+  });
+});

--- a/api/src/service/domain/workflow/workflowitem_permissions_list.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_permissions_list.spec.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { NotAuthorized } from "../errors/not_authorized";
+import { NotFound } from "../errors/not_found";
 import { ServiceUser } from "../organization/service_user";
 import { Permissions } from "../permissions";
 import { Workflowitem } from "./workflowitem";
@@ -75,5 +76,20 @@ describe("List workflowitem permissions: authorization", () => {
 
     assert.isTrue(Result.isOk(result));
     assert.equal(Result.unwrap(result), permissions);
+  });
+});
+describe("list workflowitem permissions: preconditions", () => {
+  it("Listing a workflowitem's permissions fails if the workflowitem cannot be found", async () => {
+    const result = await getAll(ctx,
+      bob,
+      projectId,
+      subprojectId,
+      workflowitemId,
+      {
+          ...baseRepository,
+          getWorkflowitem: async _workflowitemId => new Error("some error"),
+        });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, NotFound);
   });
 });


### PR DESCRIPTION
### Description
Currently only a few domain layer functions like  `global.permission.grant`  or `project.create` are tested. All domain layer functions have to be tested to ensure Trubudget api stability.

### TODO

- [x] subproject.close
. . .


Closes #530 