### PR TITLE
api: use result and return errors in api functions

### DIFF
--- a/api/src/service/domain/network/node_registered.ts
+++ b/api/src/service/domain/network/node_registered.ts
@@ -35,7 +35,7 @@ export function createEvent(
   address: string,
   organization: string,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event>  {
   const event = {
     type: eventType,
     source,
@@ -46,7 +46,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/group_create.ts
+++ b/api/src/service/domain/organization/group_create.ts
@@ -60,6 +60,9 @@ export async function createGroup(
     permissions: newDefaultPermissionsFor(creatingUser),
     additionalData: data.additionalData || {},
   });
+  if (Result.isErr(createEvent)) {
+    return new VError(createEvent, "failed to create group created event");
+  }
 
   const groupExistsResult = await repository.groupExists(createEvent.group.id);
   if (Result.isErr(groupExistsResult)) {

--- a/api/src/service/domain/organization/group_created.ts
+++ b/api/src/service/domain/organization/group_created.ts
@@ -56,7 +56,7 @@ export function createEvent(
   publisher: Identity,
   group: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -66,7 +66,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/group_get.ts
+++ b/api/src/service/domain/organization/group_get.ts
@@ -1,4 +1,5 @@
 import { Ctx } from "../../../lib/ctx";
+import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
 import { NotFound } from "../errors/not_found";
 import * as Group from "./group";
@@ -14,7 +15,7 @@ export async function getOneGroup(
   user: ServiceUser,
   groupId: Group.Id,
   repository: Repository,
-): Promise<Group.Group> {
+): Promise<Result.Type<Group.Group>> {
   const allEvents = await repository.getGroupEvents();
   // Errors are ignored here:
   const { groups } = sourceGroups(ctx, allEvents);

--- a/api/src/service/domain/organization/group_member_add.ts
+++ b/api/src/service/domain/organization/group_member_add.ts
@@ -1,3 +1,4 @@
+import { VError } from "verror";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
@@ -31,7 +32,9 @@ export async function addMember(
 
   // Create the new event:
   const memberAdded = GroupMemberAdded.createEvent(ctx.source, issuer.id, groupId, newMember);
-
+  if (Result.isErr(memberAdded)) {
+    return new VError(memberAdded, "failed to create group added event");
+  }
   // Check authorization (if not root):
   if (issuer.id !== "root") {
     const intent = "group.addUser";
@@ -43,7 +46,7 @@ export async function addMember(
   // Check that the new event is indeed valid:
   const { errors } = sourceGroups(ctx, groupEvents.concat([memberAdded]));
   if (errors.length > 0) {
-    return new InvalidCommand(ctx, memberAdded, errors)
+    return new InvalidCommand(ctx, memberAdded, errors);
   }
 
   return memberAdded;

--- a/api/src/service/domain/organization/group_member_added.ts
+++ b/api/src/service/domain/organization/group_member_added.ts
@@ -36,7 +36,7 @@ export function createEvent(
   groupId: Group.Id,
   newMember: Group.Member,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event>  {
   const event = {
     type: eventType,
     source,
@@ -47,7 +47,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/group_member_remove.ts
+++ b/api/src/service/domain/organization/group_member_remove.ts
@@ -1,3 +1,4 @@
+import { VError } from "verror";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
@@ -30,12 +31,14 @@ export async function removeMember(
 
   // Create the new event:
   const memberRemoved = GroupMemberRemoved.createEvent(ctx.source, issuer.id, groupId, newMember);
-
+  if (Result.isErr(memberRemoved)) {
+    return new VError(memberRemoved, "failed to create group member removed event");
+  }
   // Check authorization (if not root):
   if (issuer.id !== "root") {
     const intent = "group.removeUser";
     if (!Group.permits(group, issuer, [intent])) {
-      return new NotAuthorized({ ctx, userId: issuer.id, intent, target: group })
+      return new NotAuthorized({ ctx, userId: issuer.id, intent, target: group });
     }
   }
 

--- a/api/src/service/domain/organization/group_member_removed.ts
+++ b/api/src/service/domain/organization/group_member_removed.ts
@@ -36,7 +36,7 @@ export function createEvent(
   groupId: Group.Id,
   member: Group.Member,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -47,7 +47,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/group_permissions_granted.ts
+++ b/api/src/service/domain/organization/group_permissions_granted.ts
@@ -40,7 +40,7 @@ export function createEvent(
   permission: Intent,
   grantee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -52,7 +52,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/group_permissions_revoked.ts
+++ b/api/src/service/domain/organization/group_permissions_revoked.ts
@@ -40,7 +40,7 @@ export function createEvent(
   permission: Intent,
   revokee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -52,7 +52,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/user_created.ts
+++ b/api/src/service/domain/organization/user_created.ts
@@ -60,7 +60,7 @@ export function createEvent(
   publisher: Identity,
   user: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -70,7 +70,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/user_disable.ts
+++ b/api/src/service/domain/organization/user_disable.ts
@@ -58,6 +58,9 @@ export async function disableUser(
   const userDisabled = UserDisabled.createEvent(source, publisher, {
     id: userToDisable,
   });
+  if (Result.isErr(userDisabled)) {
+    return new VError(userDisabled, "failed to create user disabled event");
+  }
 
   if (Result.isErr(validationResult)) {
     return new PreconditionError(ctx, userDisabled, validationResult.message);

--- a/api/src/service/domain/organization/user_disabled.ts
+++ b/api/src/service/domain/organization/user_disabled.ts
@@ -37,7 +37,7 @@ export function createEvent(
   publisher: Identity,
   user: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -47,7 +47,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }
@@ -69,7 +69,7 @@ export function validate(input: any): Result.Type<Event> {
  */
 export function mutate(user: UserRecord.UserRecord, event: Event): Result.Type<void> {
   if (event.type !== "user_disabled") {
-    throw new VError(`illegal event type: ${event.type}`);
+    return new VError(`illegal event type: ${event.type}`);
   }
 
   // Disabling user

--- a/api/src/service/domain/organization/user_enable.ts
+++ b/api/src/service/domain/organization/user_enable.ts
@@ -53,6 +53,9 @@ export async function enableUser(
   const userEnabled = UserEnabled.createEvent(source, publisher, {
     id: data.userId,
   });
+  if (Result.isErr(userEnabled)) {
+    return new VError(userEnabled, "failed to create user enabled event");
+  }
 
   if (Result.isErr(validationResult)) {
     return new PreconditionError(ctx, userEnabled, validationResult.message);

--- a/api/src/service/domain/organization/user_enabled.ts
+++ b/api/src/service/domain/organization/user_enabled.ts
@@ -37,7 +37,7 @@ export function createEvent(
   publisher: Identity,
   user: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -47,7 +47,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }
@@ -69,7 +69,7 @@ export function validate(input: any): Result.Type<Event> {
  */
 export function mutate(user: UserRecord.UserRecord, event: Event): Result.Type<void> {
   if (event.type !== "user_enabled") {
-    throw new VError(`illegal event type: ${event.type}`);
+    return new VError(`illegal event type: ${event.type}`);
   }
 
   // Enabling user

--- a/api/src/service/domain/organization/user_eventsourcing.ts
+++ b/api/src/service/domain/organization/user_eventsourcing.ts
@@ -120,7 +120,7 @@ function getUserId(event: BusinessEvent): Result.Type<UserRecord.Id> {
 type EventModule = {
   mutate: (user: UserRecord.UserRecord, event: BusinessEvent) => Result.Type<void>;
 };
-function getEventModule(event: BusinessEvent): EventModule {
+function getEventModule(event: BusinessEvent): Result.Type<EventModule> {
   switch (event.type) {
     case "user_password_changed":
       return UserPasswordChanged;
@@ -133,7 +133,7 @@ function getEventModule(event: BusinessEvent): EventModule {
     case "user_disabled":
       return UserDisabled;
     default:
-      throw new VError(`unknown user event ${event.type}`);
+      return new VError(`unknown user event ${event.type}`);
   }
 }
 
@@ -144,7 +144,9 @@ export function newUserFromEvent(
   event: BusinessEvent,
 ): Result.Type<UserRecord.UserRecord> {
   const eventModule = getEventModule(event);
-
+  if (Result.isErr(eventModule)) {
+    return eventModule;
+  }
   // Ensure that we never modify user or event in-place by passing copies. When
   // copying the user, its event log is omitted for performance reasons.
   const eventCopy = deepcopy(event);

--- a/api/src/service/domain/organization/user_password_change.ts
+++ b/api/src/service/domain/organization/user_password_change.ts
@@ -1,5 +1,6 @@
 import Joi = require("joi");
 
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -51,6 +52,9 @@ export async function changeUserPassword(
     id: data.userId,
     passwordHash: await repository.hash(data.newPassword),
   });
+  if (Result.isErr(passwordChanged)) {
+    return new VError(passwordChanged, "failed to create user password changed event");
+  }
   if (Result.isErr(validationResult)) {
     return new PreconditionError(ctx, passwordChanged, validationResult.message);
   }

--- a/api/src/service/domain/organization/user_password_changed.ts
+++ b/api/src/service/domain/organization/user_password_changed.ts
@@ -39,7 +39,7 @@ export function createEvent(
   publisher: Identity,
   user: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -49,7 +49,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/user_permission_grant.ts
+++ b/api/src/service/domain/organization/user_permission_grant.ts
@@ -1,5 +1,6 @@
 import isEqual = require("lodash.isequal");
 
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -42,6 +43,9 @@ export async function grantUserPermission(
     intent,
     grantee,
   );
+  if (Result.isErr(permissionGranted)) {
+    return new VError(permissionGranted, "failed to create user permission granted event");
+  }
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/organization/user_permission_granted.ts
+++ b/api/src/service/domain/organization/user_permission_granted.ts
@@ -36,7 +36,7 @@ export function createEvent(
   permission: Intent,
   grantee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -48,7 +48,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/organization/user_permission_revoke.ts
+++ b/api/src/service/domain/organization/user_permission_revoke.ts
@@ -1,5 +1,6 @@
 import isEqual = require("lodash.isequal");
 
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -39,6 +40,9 @@ export async function revokeUserPermission(
     intent,
     revokee,
   );
+  if (Result.isErr(permissionRevoked)) {
+    return new VError(permissionRevoked, "failed to create permission revoked event");
+  }
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/organization/user_permission_revoked.ts
+++ b/api/src/service/domain/organization/user_permission_revoked.ts
@@ -36,7 +36,7 @@ export function createEvent(
   permission: Intent,
   revokee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -48,7 +48,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/global_permission_grant.ts
+++ b/api/src/service/domain/workflow/global_permission_grant.ts
@@ -32,7 +32,9 @@ export async function grantGlobalPermission(
     intent,
     grantee,
   );
-
+  if (Result.isErr(globalPermissionGranted)) {
+    return new VError(globalPermissionGranted, "failed to create global permission granted event");
+  }
   const grantIntent = "global.grantPermission";
   const globalPermissionsResult = await repository.getGlobalPermissions();
   if (Result.isErr(globalPermissionsResult)) {

--- a/api/src/service/domain/workflow/global_permission_granted.ts
+++ b/api/src/service/domain/workflow/global_permission_granted.ts
@@ -36,7 +36,7 @@ export function createEvent(
   permission: Intent,
   grantee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -47,7 +47,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/global_permission_revoke.ts
+++ b/api/src/service/domain/workflow/global_permission_revoke.ts
@@ -32,7 +32,9 @@ export async function revokeGlobalPermission(
     intent,
     revokee,
   );
-
+  if (Result.isErr(globalPermissionRevoked)) {
+    return new VError(globalPermissionRevoked, "failed to create global permission revoked event");
+  }
   const revokeIntent = "global.revokePermission";
   const currentGlobalPermissionsResult = await repository.getGlobalPermissions();
   if (Result.isErr(currentGlobalPermissionsResult)) {

--- a/api/src/service/domain/workflow/global_permission_revoked.ts
+++ b/api/src/service/domain/workflow/global_permission_revoked.ts
@@ -36,7 +36,7 @@ export function createEvent(
   permission: Intent,
   revokee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event>  {
   const event = {
     type: eventType,
     source,
@@ -47,7 +47,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/notification_created.ts
+++ b/api/src/service/domain/workflow/notification_created.ts
@@ -54,7 +54,7 @@ export function createEvent(
   subprojectId?: Subproject.Id,
   workflowitemId?: Workflowitem.Id,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -70,7 +70,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/notification_mark_read.ts
+++ b/api/src/service/domain/workflow/notification_mark_read.ts
@@ -39,6 +39,9 @@ export async function markRead(
     notificationId,
     notification.recipient,
   );
+  if (Result.isErr(markedRead)) {
+    return new VError(markedRead, "failed to create notification marked read event");
+  }
 
   // Already read
   if (notification.isRead) {

--- a/api/src/service/domain/workflow/notification_marked_read.ts
+++ b/api/src/service/domain/workflow/notification_marked_read.ts
@@ -39,7 +39,7 @@ export function createEvent(
   notificationId: Notification.Id,
   recipient: UserRecord.Id,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -51,7 +51,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/project_close.ts
+++ b/api/src/service/domain/workflow/project_close.ts
@@ -80,12 +80,22 @@ export async function closeProject(
   const notifications = recipientsResult.reduce((notifications, recipient) => {
     // The issuer doesn't receive a notification:
     if (recipient !== issuer.id) {
-      notifications.push(
-        NotificationCreated.createEvent(ctx.source, issuer.id, recipient, projectClosed, projectId),
+      const notification = NotificationCreated.createEvent(
+        ctx.source,
+        issuer.id,
+        recipient,
+        projectClosed,
+        projectId,
       );
+      if (Result.isErr(notification)) {
+        return new VError(notification, "failed to create notification event");
+      }
+      notifications.push(notification);
     }
     return notifications;
   }, [] as NotificationCreated.Event[]);
-
+  if (Result.isErr(notifications)) {
+    return new VError(notifications, "failed to create notification events");
+  }
   return { newEvents: [projectClosed, ...notifications], project };
 }

--- a/api/src/service/domain/workflow/project_create.ts
+++ b/api/src/service/domain/workflow/project_create.ts
@@ -78,6 +78,9 @@ export async function createProject(
     additionalData: data.additionalData || {},
     tags: data.tags || [],
   });
+  if (Result.isErr(createEvent)) {
+    return new VError(createEvent, "failed to create project created event");
+  }
 
   // Make sure for each organization and currency there is only one entry:
   const badEntry = findDuplicateBudgetEntry(createEvent.project.projectedBudgets);

--- a/api/src/service/domain/workflow/project_created.ts
+++ b/api/src/service/domain/workflow/project_created.ts
@@ -69,7 +69,7 @@ export function createEvent(
   publisher: Identity,
   project: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -79,7 +79,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/project_eventsourcing.ts
+++ b/api/src/service/domain/workflow/project_eventsourcing.ts
@@ -127,7 +127,9 @@ export function newProjectFromEvent(
   event: BusinessEvent,
 ): Result.Type<Project.Project> {
   const eventModule = getEventModule(event);
-
+  if (Result.isErr(eventModule)) {
+    return eventModule;
+  }
   // Ensure that we never modify project or event in-place by passing copies. When
   // copying the project, its event log is omitted for performance reasons.
   const eventCopy = deepcopy(event);
@@ -155,7 +157,7 @@ export function newProjectFromEvent(
 type EventModule = {
   mutate: (project: Project.Project, event: BusinessEvent) => Result.Type<void>;
 };
-function getEventModule(event: BusinessEvent): EventModule {
+function getEventModule(event: BusinessEvent): Result.Type<EventModule> {
   switch (event.type) {
     case "project_updated":
       return ProjectUpdated;
@@ -179,7 +181,7 @@ function getEventModule(event: BusinessEvent): EventModule {
       return ProjectProjectedBudgetDeleted;
 
     default:
-      throw new VError(`unknown project event ${event.type}`);
+      return new VError(`unknown project event ${event.type}`);
   }
 }
 

--- a/api/src/service/domain/workflow/project_permission_grant.ts
+++ b/api/src/service/domain/workflow/project_permission_grant.ts
@@ -1,5 +1,5 @@
 import isEqual = require("lodash.isequal");
-
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -39,6 +39,9 @@ export async function grantProjectPermission(
     intent,
     grantee,
   );
+  if (Result.isErr(permissionGranted)) {
+    return new VError(permissionGranted, "failed to create permission granted event");
+  }
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/workflow/project_permission_granted.ts
+++ b/api/src/service/domain/workflow/project_permission_granted.ts
@@ -36,7 +36,7 @@ export function createEvent(
   permission: Intent,
   grantee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -48,7 +48,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/project_permission_revoke.ts
+++ b/api/src/service/domain/workflow/project_permission_revoke.ts
@@ -1,5 +1,5 @@
 import isEqual = require("lodash.isequal");
-
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -40,6 +40,9 @@ export async function revokeProjectPermission(
     intent,
     revokee,
   );
+  if (Result.isErr(permissionRevoked)) {
+    return new VError(permissionRevoked, "failed to create permission revoked event");
+  }
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/workflow/project_permission_revoked.ts
+++ b/api/src/service/domain/workflow/project_permission_revoked.ts
@@ -36,7 +36,7 @@ export function createEvent(
   permission: Intent,
   revokee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -48,7 +48,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/project_projected_budget_deleted.ts
+++ b/api/src/service/domain/workflow/project_projected_budget_deleted.ts
@@ -36,7 +36,7 @@ export function createEvent(
   organization: string,
   currencyCode: CurrencyCode,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -48,7 +48,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/project_projected_budget_update.ts
+++ b/api/src/service/domain/workflow/project_projected_budget_update.ts
@@ -46,6 +46,9 @@ export async function updateProjectedBudget(
     value,
     currencyCode,
   );
+  if (Result.isErr(budgetUpdated)) {
+    return new VError(budgetUpdated, "failed to create projected budget updated event");
+  }
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {
@@ -75,18 +78,23 @@ export async function updateProjectedBudget(
     const notifications = recipientsResult.reduce((notifications, recipient) => {
       // The issuer doesn't receive a notification:
       if (recipient !== issuer.id) {
-        notifications.push(
-          NotificationCreated.createEvent(
-            ctx.source,
-            issuer.id,
-            recipient,
-            budgetUpdated,
-            projectId,
-          ),
+        const notification = NotificationCreated.createEvent(
+          ctx.source,
+          issuer.id,
+          recipient,
+          budgetUpdated,
+          projectId,
         );
+        if (Result.isErr(notification)) {
+          return new VError(notification, "failed to create  event");
+        }
+        notifications.push(notification);
       }
       return notifications;
     }, [] as NotificationCreated.Event[]);
+    if (Result.isErr(notifications)) {
+      return new VError(notifications, "failed to create notification events");
+    }
     return {
       newEvents: [budgetUpdated, ...notifications],
       projectedBudgets: result.projectedBudgets,

--- a/api/src/service/domain/workflow/project_projected_budget_updated.ts
+++ b/api/src/service/domain/workflow/project_projected_budget_updated.ts
@@ -39,7 +39,7 @@ export function createEvent(
   value: string,
   currencyCode: CurrencyCode,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -52,7 +52,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/subproject_assign.ts
+++ b/api/src/service/domain/workflow/subproject_assign.ts
@@ -77,19 +77,22 @@ export async function assignSubproject(
   const notifications = recipientsResult.reduce((notifications, recipient) => {
     // The issuer doesn't receive a notification:
     if (recipient !== issuer.id) {
-      notifications.push(
-        NotificationCreated.createEvent(
+      const notification = NotificationCreated.createEvent(
           ctx.source,
           issuer.id,
           recipient,
           subprojectAssigned,
           projectId,
-          subprojectId,
-        ),
-      );
+        );
+      if (Result.isErr(notification)) {
+          return new VError(notification, "failed to create notification event");
+        }
+      notifications.push(notification);
     }
     return notifications;
   }, [] as NotificationCreated.Event[]);
-
+  if (Result.isErr(notifications)) {
+    return new VError(notifications, "failed to create notification events");
+  }
   return { newEvents: [subprojectAssigned, ...notifications], subproject };
 }

--- a/api/src/service/domain/workflow/subproject_close.ts
+++ b/api/src/service/domain/workflow/subproject_close.ts
@@ -98,19 +98,22 @@ export async function closeSubproject(
   const notifications = recipientsResult.reduce((notifications, recipient) => {
     // The issuer doesn't receive a notification:
     if (recipient !== issuer.id) {
-      notifications.push(
-        NotificationCreated.createEvent(
-          ctx.source,
-          issuer.id,
-          recipient,
-          subprojectClosed,
-          projectId,
-          subprojectId,
-        ),
+      const notification = NotificationCreated.createEvent(
+        ctx.source,
+        issuer.id,
+        recipient,
+        subprojectClosed,
+        projectId,
       );
+      if (Result.isErr(notification)) {
+        return new VError(notification, "failed to create event");
+      }
+      notifications.push(notification);
     }
     return notifications;
   }, [] as NotificationCreated.Event[]);
-
+  if (Result.isErr(notifications)) {
+    return new VError(notifications, "failed to create notification events");
+  }
   return { newEvents: [subprojectClosed, ...notifications], subproject };
 }

--- a/api/src/service/domain/workflow/subproject_closed.ts
+++ b/api/src/service/domain/workflow/subproject_closed.ts
@@ -33,7 +33,7 @@ export function createEvent(
   projectId: Project.Id,
   subprojectId: Subproject.Id,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -44,7 +44,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/subproject_create.ts
+++ b/api/src/service/domain/workflow/subproject_create.ts
@@ -1,5 +1,5 @@
 import Joi = require("joi");
-
+import { VError } from "verror";
 import Intent, { subprojectIntents } from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -74,6 +74,9 @@ export async function createSubproject(
     permissions: newDefaultPermissionsFor(creatingUser.id),
     additionalData: reqData.additionalData || {},
   });
+  if (Result.isErr(createEvent)) {
+    return new VError(createEvent, "failed to create subproject created event");
+  }
 
   // Make sure for each organization and currency there is only one entry:
   const badEntry = findDuplicateBudgetEntry(createEvent.subproject.projectedBudgets);

--- a/api/src/service/domain/workflow/subproject_created.ts
+++ b/api/src/service/domain/workflow/subproject_created.ts
@@ -72,7 +72,7 @@ export function createEvent(
   projectId: Project.Id,
   subproject: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event>  {
   const event = {
     type: eventType,
     source,
@@ -83,7 +83,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/subproject_eventsourcing.ts
+++ b/api/src/service/domain/workflow/subproject_eventsourcing.ts
@@ -132,7 +132,9 @@ export function newSubprojectFromEvent(
   event: BusinessEvent,
 ): Result.Type<Subproject.Subproject> {
   const eventModule = getEventModule(event);
-
+  if (Result.isErr(eventModule)) {
+    return eventModule;
+  }
   // Ensure that we never modify subproject or event in-place by passing copies. When
   // copying the subproject, its event log is omitted for performance reasons.
   const eventCopy = deepcopy(event);
@@ -160,7 +162,7 @@ export function newSubprojectFromEvent(
 type EventModule = {
   mutate: (subproject: Subproject.Subproject, event: BusinessEvent) => Result.Type<void>;
 };
-function getEventModule(event: BusinessEvent): EventModule {
+function getEventModule(event: BusinessEvent): Result.Type<EventModule> {
   switch (event.type) {
     case "subproject_updated":
       return SubprojectUpdated;
@@ -187,7 +189,7 @@ function getEventModule(event: BusinessEvent): EventModule {
       return WorkflowitemsReordered;
 
     default:
-      throw new VError(`unknown subproject event ${event.type}`);
+      return new VError(`unknown subproject event ${event.type}`);
   }
 }
 

--- a/api/src/service/domain/workflow/subproject_permission_grant.ts
+++ b/api/src/service/domain/workflow/subproject_permission_grant.ts
@@ -1,5 +1,6 @@
 import isEqual = require("lodash.isequal");
 
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -45,7 +46,9 @@ export async function grantSubprojectPermission(
     intent,
     grantee,
   );
-
+  if (Result.isErr(permissionGranted)) {
+    return new VError(permissionGranted, "failed to create permission granted event");
+  }
   // Check authorization (if not root):
   if (issuer.id !== "root") {
     const grantIntent = "subproject.intent.grantPermission";

--- a/api/src/service/domain/workflow/subproject_permission_granted.ts
+++ b/api/src/service/domain/workflow/subproject_permission_granted.ts
@@ -40,7 +40,7 @@ export function createEvent(
   permission: Intent,
   grantee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -54,7 +54,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/subproject_permission_revoke.ts
+++ b/api/src/service/domain/workflow/subproject_permission_revoke.ts
@@ -1,5 +1,6 @@
 import isEqual = require("lodash.isequal");
 
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -46,7 +47,9 @@ export async function revokeSubprojectPermission(
     intent,
     revokee,
   );
-
+  if (Result.isErr(permissionRevoked)) {
+    return new VError(permissionRevoked, "failed to create permission revoked event");
+  }
   // Check authorization (if not root):
   if (issuer.id !== "root") {
     const revokeIntent = "subproject.intent.revokePermission";

--- a/api/src/service/domain/workflow/subproject_permission_revoked.ts
+++ b/api/src/service/domain/workflow/subproject_permission_revoked.ts
@@ -40,7 +40,7 @@ export function createEvent(
   permission: Intent,
   revokee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -54,7 +54,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/subproject_projected_budget_delete.ts
+++ b/api/src/service/domain/workflow/subproject_projected_budget_delete.ts
@@ -47,7 +47,9 @@ export async function deleteProjectedBudget(
     organization,
     currencyCode,
   );
-
+  if (Result.isErr(budgetDeleted)) {
+    return new VError(budgetDeleted, "failed to create projected budget deleted event");
+  }
   // Check authorization (if not root):
   if (issuer.id !== "root") {
     const intent = "subproject.budget.deleteProjected";
@@ -76,19 +78,23 @@ export async function deleteProjectedBudget(
     const notifications = recipientsResult.reduce((notifications, recipient) => {
       // The issuer doesn't receive a notification:
       if (recipient !== issuer.id) {
-        notifications.push(
-          NotificationCreated.createEvent(
-            ctx.source,
-            issuer.id,
-            recipient,
-            budgetDeleted,
-            projectId,
-            subprojectId,
-          ),
+        const notification = NotificationCreated.createEvent(
+          ctx.source,
+          issuer.id,
+          recipient,
+          budgetDeleted,
+          projectId,
         );
+        if (Result.isErr(notification)) {
+          return new VError(notification, "failed to create  event");
+        }
+        notifications.push(notification);
       }
       return notifications;
     }, [] as NotificationCreated.Event[]);
+    if (Result.isErr(notifications)) {
+      return new VError(notifications, "failed to create notification events");
+    }
     return {
       newEvents: [budgetDeleted, ...notifications],
       projectedBudgets: result.projectedBudgets,

--- a/api/src/service/domain/workflow/subproject_projected_budget_deleted.ts
+++ b/api/src/service/domain/workflow/subproject_projected_budget_deleted.ts
@@ -40,7 +40,7 @@ export function createEvent(
   organization: string,
   currencyCode: CurrencyCode,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -53,7 +53,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/subproject_projected_budget_updated.ts
+++ b/api/src/service/domain/workflow/subproject_projected_budget_updated.ts
@@ -43,7 +43,7 @@ export function createEvent(
   value: string,
   currencyCode: CurrencyCode,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -57,7 +57,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/workflowitem_create.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.ts
@@ -123,6 +123,9 @@ export async function createWorkflowitem(
       workflowitemType: reqData.workflowitemType || "general",
     },
   );
+  if (Result.isErr(workflowitemCreated)) {
+    return new VError(workflowitemCreated, "failed to create workflowitem created event");
+  }
 
   // Check if workflowitemId already exists
   if (
@@ -185,6 +188,9 @@ export async function createWorkflowitem(
       workflowitemId,
       docToUpload,
     );
+    if (Result.isErr(workflowitemEvent)) {
+      return new VError(workflowitemEvent, "failed to create event");
+    }
 
     // Check that the event is valid:
     const result = WorkflowitemDocumentUploaded.createFrom(ctx, workflowitemEvent);

--- a/api/src/service/domain/workflow/workflowitem_created.ts
+++ b/api/src/service/domain/workflow/workflowitem_created.ts
@@ -80,7 +80,7 @@ export function createEvent(
   subprojectId: Subproject.Id,
   workflowitem: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event>  {
   const event = {
     type: eventType,
     source,
@@ -92,7 +92,7 @@ export function createEvent(
   };
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/workflowitem_document_uploaded.ts
+++ b/api/src/service/domain/workflow/workflowitem_document_uploaded.ts
@@ -53,7 +53,7 @@ export function createEvent(
   workflowitemId: Workflowitem.Id,
   document: InitialData,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -67,7 +67,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
 
   return event;

--- a/api/src/service/domain/workflow/workflowitem_eventsourcing.ts
+++ b/api/src/service/domain/workflow/workflowitem_eventsourcing.ts
@@ -131,6 +131,9 @@ export function newWorkflowitemFromEvent(
   event: BusinessEvent,
 ): Result.Type<Workflowitem.Workflowitem> {
   const eventModule = getEventModule(event);
+  if (Result.isErr(eventModule)) {
+    return eventModule;
+  }
 
   // Ensure that we never modify workflowitem or event in-place by passing copies. When
   // copying the workflowitem, its event log is omitted for performance reasons.
@@ -159,7 +162,7 @@ export function newWorkflowitemFromEvent(
 type EventModule = {
   mutate: (workflowitem: Workflowitem.Workflowitem, event: BusinessEvent) => Result.Type<void>;
 };
-function getEventModule(event: BusinessEvent): EventModule {
+function getEventModule(event: BusinessEvent): Result.Type<EventModule> {
   switch (event.type) {
     case "workflowitem_updated":
       return WorkflowitemUpdated;
@@ -177,7 +180,7 @@ function getEventModule(event: BusinessEvent): EventModule {
       return WorkflowitemPermissionRevoked;
 
     default:
-      throw new VError(`unknown workflowitem event ${event.type}`);
+      return new VError(`unknown workflowitem event ${event.type}`);
   }
 }
 

--- a/api/src/service/domain/workflow/workflowitem_ordering.ts
+++ b/api/src/service/domain/workflow/workflowitem_ordering.ts
@@ -70,11 +70,11 @@ function isClosed(item: Workflowitem.ScrubbedWorkflowitem): boolean {
   return item.status === "closed";
 }
 
-function closedAt(item: Workflowitem.ScrubbedWorkflowitem): string {
+function closedAt(item: Workflowitem.ScrubbedWorkflowitem): any {
   const traceEvent = item.log.find(e => e.businessEvent.type === "workflowitem_closed");
 
   if (traceEvent === undefined || traceEvent.businessEvent.type !== "workflowitem_closed") {
-    throw new AssertionError({ message: `Expected close event for workflowitem ${item.id}` });
+    return new AssertionError({ message: `Expected close event for workflowitem ${item.id}` });
   }
   const closeEvent = traceEvent.businessEvent;
 

--- a/api/src/service/domain/workflow/workflowitem_permission_grant.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_grant.ts
@@ -1,5 +1,6 @@
 import isEqual = require("lodash.isequal");
 
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -48,6 +49,9 @@ export async function grantWorkflowitemPermission(
     intent,
     grantee,
   );
+  if (Result.isErr(permissionGranted)) {
+    return new VError(permissionGranted, "failed to create permission granted event");
+  }
 
   if (issuer.id !== "root") {
     const grantIntent = "workflowitem.intent.grantPermission";

--- a/api/src/service/domain/workflow/workflowitem_permission_granted.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_granted.ts
@@ -44,7 +44,7 @@ export function createEvent(
   permission: Intent,
   grantee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -59,7 +59,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/workflowitem_permission_revoke.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_revoke.ts
@@ -1,5 +1,6 @@
 import isEqual = require("lodash.isequal");
 
+import { VError } from "verror";
 import Intent from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
@@ -50,6 +51,9 @@ export async function revokeWorkflowitemPermission(
     intent,
     revokee,
   );
+  if (Result.isErr(permissionRevoked)) {
+    return new VError(permissionRevoked, "failed to create permission revoked event");
+  }
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/workflow/workflowitem_permission_revoked.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_revoked.ts
@@ -44,7 +44,7 @@ export function createEvent(
   permission: Intent,
   revokee: Identity,
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -59,7 +59,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/domain/workflow/workflowitems_reorder.ts
+++ b/api/src/service/domain/workflow/workflowitems_reorder.ts
@@ -1,5 +1,6 @@
 import isEqual = require("lodash.isequal");
 
+import { VError } from "verror";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { BusinessEvent } from "../business_event";
@@ -10,8 +11,8 @@ import { ServiceUser } from "../organization/service_user";
 import * as Project from "./project";
 import * as Subproject from "./subproject";
 import * as SubprojectEventSourcing from "./subproject_eventsourcing";
-import * as WorkflowitemsReordered from "./workflowitems_reordered";
 import * as WorkflowitemOrdering from "./workflowitem_ordering";
+import * as WorkflowitemsReordered from "./workflowitems_reordered";
 
 interface Repository {
   getSubproject(
@@ -46,6 +47,9 @@ export async function setWorkflowitemOrdering(
     subprojectId,
     ordering,
   );
+  if (Result.isErr(reorderEvent)) {
+    return new VError(reorderEvent, "failed to create reorder event");
+  }
 
   // Check authorization (if not root):
   if (issuer.id !== "root") {

--- a/api/src/service/domain/workflow/workflowitems_reordered.ts
+++ b/api/src/service/domain/workflow/workflowitems_reordered.ts
@@ -37,7 +37,7 @@ export function createEvent(
   subprojectId: Subproject.Id,
   ordering: Workflowitem.Id[],
   time: string = new Date().toISOString(),
-): Event {
+): Result.Type<Event> {
   const event = {
     type: eventType,
     source,
@@ -50,7 +50,7 @@ export function createEvent(
 
   const validationResult = validate(event);
   if (Result.isErr(validationResult)) {
-    throw new VError(validationResult, `not a valid ${eventType} event`);
+    return new VError(validationResult, `not a valid ${eventType} event`);
   }
   return event;
 }

--- a/api/src/service/store.ts
+++ b/api/src/service/store.ts
@@ -145,7 +145,7 @@ async function ensureStreamExists(conn: ConnToken, ctx: Ctx, name: string, kind:
         // Code -705 means the stream already exists - that's fine.
         return;
       }
-      throw new VError(err, `could not create ${kind} stream "${name}"`);
+      return new VError(err, `could not create ${kind} stream "${name}"`);
     });
 }
 

--- a/api/src/service/user_authenticate.ts
+++ b/api/src/service/user_authenticate.ts
@@ -106,7 +106,7 @@ async function authenticateUser(
 
   // Check if user has user.authenticate intent
   if (!UserRecord.permits(userRecord, rootUser, ["user.authenticate"])) {
-    throw new NotAuthorized({ ctx, userId, intent: "user.authenticate" });
+    return new NotAuthorized({ ctx, userId, intent: "user.authenticate" });
   }
 
   // Every user has an address and an associated private key. Importing the private key

--- a/blockchain/package-lock.json
+++ b/blockchain/package-lock.json
@@ -470,46 +470,6 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
-    "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -1673,7 +1633,7 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4102,6 +4062,23 @@
         "readable-stream": "^3.1.1"
       },
       "dependencies": {
+        "bl": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            }
+          }
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",


### PR DESCRIPTION
some domain layer functions (createEvent, event sourcing and others) now have a Result return type and return errors instead of throwing them
Closes #531