### PR TITLE
api: Add check for viewHistory permissions

### DIFF
--- a/api/src/service/domain/workflow/project_history_get.spec.ts
+++ b/api/src/service/domain/workflow/project_history_get.spec.ts
@@ -89,6 +89,30 @@ describe("get project history: authorization", () => {
     assert.isTrue(Result.isOk(result), (result as Error).message);
   });
 
+  it("With only viewDetails permissions, a user can still get a project's history.", async () => {
+    const modifiedProject: Project = {
+      ...baseProject,
+      permissions: { "project.viewDetails": ["alice"] },
+    };
+    const result = await getHistory(ctx, alice, projectId, {
+      ...baseRepository,
+      getProject: async () => modifiedProject,
+    });
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("With only viewHistory permissions, a user can still get a project's history.", async () => {
+    const modifiedProject: Project = {
+      ...baseProject,
+      permissions: {"project.viewHistory": ["alice"] },
+    };
+    const result = await getHistory(ctx, alice, projectId, {
+      ...baseRepository,
+      getProject: async () => modifiedProject,
+    });
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
   it("The root user doesn't need permission to get a project's history.", async () => {
     const result = await getHistory(ctx, alice, projectId, baseRepository);
     assert.isTrue(Result.isOk(result), (result as Error).message);

--- a/api/src/service/domain/workflow/project_history_get.spec.ts
+++ b/api/src/service/domain/workflow/project_history_get.spec.ts
@@ -28,6 +28,7 @@ const filter: Filter = {
 
 const permissions: Permissions = {
   "project.viewDetails": ["alice"],
+  "project.viewHistory": ["alice"],
 };
 
 const event: ProjectTraceEvent = {

--- a/api/src/service/domain/workflow/project_history_get.ts
+++ b/api/src/service/domain/workflow/project_history_get.ts
@@ -26,8 +26,9 @@ export const getHistory = async (
   }
 
   if (user.id !== "root") {
-    const intents: Intent[] = ["project.viewDetails"];
-    if (!Project.permits(project, user, intents)) {
+    const intents: Intent[] = ["project.viewDetails", "project.viewHistory"];
+    if (!(Project.permits(project, user, [intents[0]]) ||
+    Project.permits(project, user, [intents[1]]))) {
       return new NotAuthorized({ ctx, userId: user.id, intent: intents, target: project });
     }
   }

--- a/api/src/service/domain/workflow/subproject_history_get.spec.ts
+++ b/api/src/service/domain/workflow/subproject_history_get.spec.ts
@@ -29,6 +29,7 @@ const filter: Filter = {
 
 const permissions: Permissions = {
   "subproject.viewDetails": ["alice"],
+  "subproject.viewHistory": ["alice"],
 };
 
 const event: SubprojectTraceEvent = {

--- a/api/src/service/domain/workflow/subproject_history_get.spec.ts
+++ b/api/src/service/domain/workflow/subproject_history_get.spec.ts
@@ -95,6 +95,30 @@ describe("get subproject history: authorization", () => {
     assert.isTrue(Result.isOk(result), (result as Error).message);
   });
 
+  it("With only viewDetials permissions, a user can still get a subproject's history.", async () => {
+    const modifiedSubproject: Subproject = {
+      ...baseSubproject,
+      permissions: { "subproject.viewDetails": ["alice"]},
+    };
+    const result = await getHistory(ctx, alice, projectId, subprojectId, {
+      ...baseRepository,
+      getSubproject: async () => modifiedSubproject,
+    });
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("With only viewHistory permissions, a user can still get a subproject's history.", async () => {
+    const modifiedSubproject: Subproject = {
+      ...baseSubproject,
+      permissions: {"subproject.viewHistory": ["alice"] },
+    };
+    const result = await getHistory(ctx, alice, projectId, subprojectId, {
+      ...baseRepository,
+      getSubproject: async () => modifiedSubproject,
+    });
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
   it("The root user doesn't need permission to get a subproject's history.", async () => {
     const result = await getHistory(ctx, alice, projectId, subprojectId, baseRepository);
     assert.isTrue(Result.isOk(result), (result as Error).message);

--- a/api/src/service/domain/workflow/subproject_history_get.ts
+++ b/api/src/service/domain/workflow/subproject_history_get.ts
@@ -27,8 +27,9 @@ export const getHistory = async (
   }
 
   if (user.id !== "root") {
-    const intents: Intent[] = ["subproject.viewDetails"];
-    if (!Subproject.permits(subproject, user, intents)) {
+    const intents: Intent[] = ["subproject.viewDetails", "subproject.viewHistory"];
+    if (!(Subproject.permits(subproject, user, [intents[0]]) ||
+    Subproject.permits(subproject, user, [intents[1]]))) {
       return new NotAuthorized({ ctx, userId: user.id, intent: intents, target: subproject });
     }
   }

--- a/api/src/service/domain/workflow/workflowitem_create.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.ts
@@ -1,6 +1,6 @@
 import Joi = require("joi");
 import { VError } from "verror";
-import Intent from "../../../authz/intents";
+import Intent, { workflowitemIntents } from "../../../authz/intents";
 import { Ctx } from "../../../lib/ctx";
 import * as Result from "../../../result";
 import { randomString } from "../../hash";
@@ -213,17 +213,7 @@ export async function createWorkflowitem(
   function newDefaultPermissionsFor(userId: string): Permissions {
     // The user can always do anything anyway:
     if (userId === "root") return {};
-
-    const intents: Intent[] = [
-      "workflowitem.intent.listPermissions",
-      "workflowitem.intent.grantPermission",
-      "workflowitem.intent.revokePermission",
-      "workflowitem.view",
-      "workflowitem.assign",
-      "workflowitem.update",
-      "workflowitem.close",
-      "workflowitem.archive",
-    ];
+    const intents: Intent[] = workflowitemIntents;
     return intents.reduce((obj, intent) => ({ ...obj, [intent]: [userId] }), {});
   }
 }

--- a/api/src/service/domain/workflow/workflowitem_history_get.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_history_get.spec.ts
@@ -108,6 +108,44 @@ describe("get worklfowitem history: authorization", () => {
     assert.isTrue(Result.isOk(result), (result as Error).message);
   });
 
+  it("With only view permissions, a user can still get a worklfowitem's history.", async () => {
+    const modifiedWorkflowitem: Workflowitem = {
+      ...baseWorkflowitem,
+      permissions: { "workflowitem.view": ["alice"]},
+    };
+    const result = await getHistory(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      workflowitemId,
+      {
+        ...baseRepository,
+        getWorkflowitem: async () => modifiedWorkflowitem,
+      },
+    );
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
+  it("With only viewHistory permissions, a user can still get a worklfowitem's history.", async () => {
+    const modifiedWorkflowitem: Workflowitem = {
+      ...baseWorkflowitem,
+      permissions: { "workflowitem.viewHistory": ["alice"]},
+    };
+    const result = await getHistory(
+      ctx,
+      alice,
+      projectId,
+      subprojectId,
+      workflowitemId,
+      {
+        ...baseRepository,
+        getWorkflowitem: async () => modifiedWorkflowitem,
+      },
+    );
+    assert.isTrue(Result.isOk(result), (result as Error).message);
+  });
+
   it("The root user doesn't need permission to get a worklfowitem's history.", async () => {
     const result = await getHistory(
       ctx,

--- a/api/src/service/domain/workflow/workflowitem_history_get.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_history_get.spec.ts
@@ -29,6 +29,7 @@ const filter: Filter = {
 
 const permissions: Permissions = {
   "workflowitem.view": ["alice"],
+  "workflowitem.viewHistory": ["alice"],
 };
 
 const event: WorkflowitemTraceEvent = {

--- a/api/src/service/domain/workflow/workflowitem_history_get.ts
+++ b/api/src/service/domain/workflow/workflowitem_history_get.ts
@@ -32,9 +32,10 @@ export const getHistory = async (
   }
 
   if (user.id !== "root") {
-    const intents: Intent[] = ["workflowitem.view"];
-    if (!Workflowitem.permits(workflowitem, user, intents)) {
-      return new NotAuthorized({ ctx, userId: user.id, intent: intents, target: workflowitem });
+    const intents: Intent[] = ["workflowitem.view", "workflowitem.viewHistory" ];
+    if (!(Workflowitem.permits(workflowitem, user, [intents[0]]) ||
+     Workflowitem.permits(workflowitem, user, [intents[1] ])) ) {
+       return new NotAuthorized({ ctx, userId: user.id, intent: intents, target: workflowitem });
     }
   }
 


### PR DESCRIPTION
### Description
For viewing the history, only the intents project.viewHistory, subproject.viewHistory or workflowitem.viewHistory should be used on api level. Currently, to view the history, the api only checks for permissions on workflowitem.view, subproject.viewDetails or project.viewDetails.

### Solution
To avoid a breaking change the api should allow the request with viewDetails or viewHistory permissions. In Trubudget 2.0.0 this should be changed to only allow the request with viewHistory permission -> #547 

Closes #486