### PR TITLE
Fix falsy permission fetching in Confirmation Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
 
+- Fixed a bug where the user needed list-permissions that are not necessary [#562](https://github.com/openkfw/TruBudget/issues/562)
+- Fixed a bug where the confirmation dialog persists after pressing the browser's back button [#544](https://github.com/openkfw/TruBudget/issues/544)
 <!-- ### Security -->
 
 ## [1.16.0] - 2020-11-12

--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ In the node section you should see that you need to approve a new node and organ
 
 ## Using TruBudget programatically through its API
 
-TruBudget comes with a frontend, but we greatly encourage to create own frontends or attach your existing systems to TruBudget. Therefore everything you can do in TruBudget can be done through a well documented HTTP/JSON interface. You can access and test-drive the API using the swagger documentation which is exposed by the TruBudget API under the route `/api/documentation/index.html`. Since we have already two nodes running, lets access the API documentation of the node we deployed in the first step.
+TruBudget comes with a frontend, but we greatly encourage to create own frontends or attach your existing systems to TruBudget. Therefore everything you can do in TruBudget can be done through a well documented HTTP/JSON interface. You can access and test-drive the API using the swagger documentation which is exposed by the TruBudget API under the route `/api/documentation/static/index.html`. Since we have already two nodes running, lets access the API documentation of the node we deployed in the first step.
 
 ```
 For the prod network:
-http://localhost:8080/api/documentation/index.html
+http://localhost:8080/api/documentation/static/index.html
 
 For the test network:
-http://localhost:8081/api/documentation/index.html
+http://localhost:8081/api/documentation/static/index.html
 ```
 
 ## Hints and Pitfalls

--- a/doc/tutorials/working-with-the-api/working-with-the-api.md
+++ b/doc/tutorials/working-with-the-api/working-with-the-api.md
@@ -16,11 +16,11 @@ curl -X GET http://localhost:8080/api/readiness
 
 which returns `OK`.
 
-The documentation for this endpoints is generated with each deployment of the API and can be accessed via the browser. It is usually deployed at `http://address.of.deployment/test/api/documentation/index.html`, here are some examples:
+The documentation for this endpoints is generated with each deployment of the API and can be accessed via the browser. It is usually deployed at `http://address.of.deployment/test/api/documentation/static/index.html`, here are some examples:
 
-- Developer setup: http://localhost:8080/api/documentation/index.html
-- Local deployment via Docker-Compose: http://localhost/test/api/documentation/index.html
-- Deployment on server: http://52.52.52.52/test/api/documentation/index.html
+- Developer setup: http://localhost:8080/api/documentation/static/index.html
+- Local deployment via Docker-Compose: http://localhost/test/api/documentation/static/index.html
+- Deployment on server: http://52.52.52.52/test/api/documentation/static/index.html
 
 ### Using Postman
 

--- a/e2e-test/cypress/integration/workflowitem_edit_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_edit_spec.js
@@ -22,6 +22,28 @@ describe("Workflowitem edit", function() {
     cy.visit(`/projects/${projectId}/${subprojectId}`);
   });
 
+  it("The workflowitem can be closed with only the view and close permissions", function() {
+    const assignee = "auditUser";
+    cy.createWorkflowitem(projectId, subprojectId, "workflowitem edit test").then(({ id }) => {
+      workflowitemId = id;
+      cy.grantProjectPermission(projectId, "project.viewSummary", assignee);
+      cy.grantProjectPermission(projectId, "project.viewDetails", assignee);
+      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewSummary", assignee);
+      cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", assignee);
+      cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.view", assignee);
+      cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.close", assignee);
+      cy.login(assignee);
+      cy.visit(`/projects/${projectId}/${subprojectId}`);
+      // Close workflow item
+      cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test=close-workflowitem]")
+        .scrollIntoView()
+        .click();
+      cy.get("[data-test=confirmation-dialog-confirm]")
+        .should("be.visible")
+        .click();
+    });
+  });
+
   it(
     "When editing a workflow item with a different currency than the subproject currency, " +
       "the selected currency is displayed",
@@ -29,7 +51,6 @@ describe("Workflowitem edit", function() {
       cy.server();
       cy.route("POST", apiRoute + "/subproject.createWorkflowitem*").as("create");
       cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
-
       // Create a workflow item and select a different currency
       cy.get("[data-test=createWorkflowitem]").click();
       cy.get("[data-test=nameinput]").type("Test");
@@ -42,7 +63,6 @@ describe("Workflowitem edit", function() {
       cy.get("[data-test=rateinput] input").type("1.5");
       cy.get("[data-test=next]").click();
       cy.get("[data-test=submit]").click();
-
       // Verify the selected values
       cy.wait("@create")
         .wait("@viewDetails")
@@ -53,7 +73,6 @@ describe("Workflowitem edit", function() {
         .last()
         .should("have.attr", "title")
         .should("contain", "$");
-
       // Open edit workflow item dialog
       cy.get("[data-test=edit-workflowitem]")
         .last()
@@ -62,6 +81,7 @@ describe("Workflowitem edit", function() {
       cy.get("[data-test=dropdown-currencies-click]").should("contain", "USD");
     }
   );
+
   it("When the due-date is not exceeded, the info icon badge is not displayed ", function() {
     // Create a workflowitem
     const tomorrow = getTomorrowsIsoDate();
@@ -70,7 +90,6 @@ describe("Workflowitem edit", function() {
     }).then(({ id }) => {
       workflowitemId = id;
       cy.visit(`/projects/${projectId}/${subprojectId}`);
-
       // Check if info icon badge is displayed
       cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test^='info-warning-badge-disabled-']").should(
@@ -90,7 +109,6 @@ describe("Workflowitem edit", function() {
     }).then(({ id }) => {
       workflowitemId = id;
       cy.visit(`/projects/${projectId}/${subprojectId}`);
-
       // Check if info icon badge is displayed
       cy.get("[data-test=workflowitem-" + workflowitemId + "]").should("be.visible");
       cy.get("[data-test=workflowitem-" + workflowitemId + "] [data-test^='info-warning-badge-disabled-']").should(

--- a/frontend/src/pages/Confirmation/ConfirmationDialog.js
+++ b/frontend/src/pages/Confirmation/ConfirmationDialog.js
@@ -55,9 +55,8 @@ const ConfirmationDialog = props => {
     requestedPermissions,
     failedAction,
     onCancel,
-    listPermissionsRequired,
+    isListPermissionsRequiredFromApi,
     isFetchingPermissions,
-    permissionsEmpty,
     userList,
     fetchUserAssignments,
     cleanUserAssignments,
@@ -70,16 +69,15 @@ const ConfirmationDialog = props => {
     setHasAssignments(hasUserAssignments(userAssignments));
   }, [userAssignments]);
 
-  const isPermissionNeeded = originalActions.some(
-    action =>
-      !_isEmpty(action.payload.project) ||
-      !_isEmpty(action.payload.subproject) ||
-      !_isEmpty(action.payload.workflowitem)
-  );
-
   // If permissions are not fetched yet show Loading indicator
-  if ((isFetchingPermissions || permissionsEmpty || listPermissionsRequired) && isPermissionNeeded) {
-    return buildDialogWithLoadingIndicator(classes, open, listPermissionsRequired, onCancel, requestedPermissions);
+  if (isFetchingPermissions) {
+    return buildDialogWithLoadingIndicator(
+      classes,
+      open,
+      isListPermissionsRequiredFromApi,
+      onCancel,
+      requestedPermissions
+    );
   }
 
   let title, content;
@@ -381,10 +379,16 @@ const ConfirmationDialog = props => {
   );
 };
 
-function buildDialogWithLoadingIndicator(classes, open, listPermissionsRequired, onCancel, requestedPermissions) {
+function buildDialogWithLoadingIndicator(
+  classes,
+  open,
+  isListPermissionsRequiredFromApi,
+  onCancel,
+  requestedPermissions
+) {
   return (
     <Dialog classes={{ paper: classes.paperRoot }} open={open} data-test="confirmation-dialog">
-      {listPermissionsRequired ? (
+      {isListPermissionsRequiredFromApi ? (
         <React.Fragment>
           <DialogTitle data-test="confirmation-dialog-title">{strings.confirmation.permissions_required}</DialogTitle>
           <DialogContent className={classes.dialogContent}>

--- a/frontend/src/pages/Confirmation/reducer.js
+++ b/frontend/src/pages/Confirmation/reducer.js
@@ -55,9 +55,9 @@ import {
 // additional Actions = view/list permission intents which are required to execute all original actions
 const defaultState = fromJS({
   open: false,
-  project: {},
-  subproject: {},
-  workflowitem: {},
+  project: { listPermissionsNeeded: false },
+  subproject: { listPermissionsNeeded: false },
+  workflowitem: { listPermissionsNeeded: false },
   permissions: { project: {}, subproject: {}, workflowitem: {} },
   isFetchingProjectPermissions: false,
   isFetchingSubprojectPermissions: false,
@@ -70,7 +70,7 @@ const defaultState = fromJS({
   executedAdditionalActions: [],
   additionalActionsExecuted: false,
   executingAdditionalActions: false,
-  listPermissionsRequired: false,
+  isListPermissionsRequiredFromApi: false,
   failedAction: {},
   requestedPermissions: {}
 });
@@ -184,7 +184,8 @@ export default function confirmationReducer(state = defaultState, action) {
     case FETCH_PROJECT_PERMISSIONS_FAILURE:
     case FETCH_SUBPROJECT_PERMISSIONS_FAILURE:
     case FETCH_WORKFLOWITEM_PERMISSIONS_FAILURE:
-      if (action.message === "Request failed with status code 403") return state.set("listPermissionsRequired", true);
+      if (action.message === "Request failed with status code 403")
+        return state.set("isListPermissionsRequiredFromApi", true);
       return state;
     case STORE_REQUESTED_PERMISSIONS:
       return state.set("requestedPermissions", action.permissions);

--- a/frontend/src/sagas.js
+++ b/frontend/src/sagas.js
@@ -86,7 +86,7 @@ import {
   MARK_NOTIFICATION_AS_READ_SUCCESS,
   SHOW_SNACKBAR,
   SNACKBAR_MESSAGE,
-  TIME_OUT_FLY_IN,
+  TIME_OUT_FLY_IN
 } from "./pages/Notifications/actions";
 import {
   CREATE_PROJECT,
@@ -1578,7 +1578,7 @@ export function* grantProjectPermissionsSaga({
         intent: "project.intent.grantPermission",
         payload: {
           intent,
-          project: { id: projectId, displayName: projectDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
           grantee: { id: granteeId, displayName: granteeDisplayName }
         }
       });
@@ -1626,7 +1626,7 @@ export function* revokeProjectPermissionsSaga({
         intent: "project.intent.revokePermission",
         payload: {
           intent,
-          project: { id: projectId, displayName: projectDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
           revokee: { id: revokeeId, displayName: revokeeDisplayName }
         }
       });
@@ -1675,8 +1675,8 @@ export function* grantSubProjectPermissionsSaga({
         intent: "subproject.intent.grantPermission",
         payload: {
           intent,
-          project: { id: projectId, displayName: projectDisplayName },
-          subproject: { id: subprojectId, displayName: subprojectDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
+          subproject: { id: subprojectId, displayName: subprojectDisplayName, listPermissionsNeeded: true },
           grantee: { id: granteeId, displayName: granteeDisplayName }
         }
       });
@@ -1728,8 +1728,8 @@ export function* revokeSubProjectPermissionsSaga({
         intent: "subproject.intent.revokePermission",
         payload: {
           intent,
-          project: { id: projectId, displayName: projectDisplayName },
-          subproject: { id: subprojectId, displayName: subprojectDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
+          subproject: { id: subprojectId, displayName: subprojectDisplayName, listPermissionsNeeded: true },
           revokee: { id: revokeeId, displayName: revokeeDisplayName }
         }
       });
@@ -1783,9 +1783,9 @@ export function* grantWorkflowItemPermissionsSaga({
         intent: "workflowitem.intent.grantPermission",
         payload: {
           intent,
-          project: { id: projectId, displayName: projectDisplayName },
-          subproject: { id: subprojectId, displayName: subprojectDisplayName },
-          workflowitem: { id: workflowitemId, displayName: workflowitemDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
+          subproject: { id: subprojectId, displayName: subprojectDisplayName, listPermissionsNeeded: true },
+          workflowitem: { id: workflowitemId, displayName: workflowitemDisplayName, listPermissionsNeeded: true },
           grantee: { id: granteeId, displayName: granteeDisplayName }
         }
       });
@@ -1840,9 +1840,9 @@ export function* revokeWorkflowItemPermissionsSaga({
         intent: "workflowitem.intent.revokePermission",
         payload: {
           intent,
-          project: { id: projectId, displayName: projectDisplayName },
-          subproject: { id: subprojectId, displayName: subprojectDisplayName },
-          workflowitem: { id: workflowitemId, displayName: workflowitemDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
+          subproject: { id: subprojectId, displayName: subprojectDisplayName, listPermissionsNeeded: true },
+          workflowitem: { id: workflowitemId, displayName: workflowitemDisplayName, listPermissionsNeeded: true },
           revokee: { id: revokeeId, displayName: revokeeDisplayName }
         }
       });
@@ -2102,9 +2102,9 @@ export function* assignWorkflowItemSaga({
         type: CONFIRMATION_REQUIRED,
         intent: "workflowitem.assign",
         payload: {
-          project: { id: projectId, displayName: projectDisplayName },
-          subproject: { id: subprojectId, displayName: subprojectDisplayName },
-          workflowitem: { id: workflowitemId, displayName: workflowitemDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
+          subproject: { id: subprojectId, displayName: subprojectDisplayName, listPermissionsNeeded: true },
+          workflowitem: { id: workflowitemId, displayName: workflowitemDisplayName, listPermissionsNeeded: true },
           assignee: { id: assigneeId, displayName: assigneeDisplayName }
         }
       });
@@ -2151,8 +2151,8 @@ export function* assignSubprojectSaga({
         type: CONFIRMATION_REQUIRED,
         intent: "subproject.assign",
         payload: {
-          project: { id: projectId, displayName: projectDisplayName },
-          subproject: { id: subprojectId, displayName: subprojectDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
+          subproject: { id: subprojectId, displayName: subprojectDisplayName, listPermissionsNeeded: true },
           assignee: { id: assigneeId, displayName: assigneeDisplayName }
         }
       });
@@ -2193,7 +2193,7 @@ export function* assignProjectSaga({ projectId, projectDisplayName, assigneeId, 
         type: CONFIRMATION_REQUIRED,
         intent: "project.assign",
         payload: {
-          project: { id: projectId, displayName: projectDisplayName },
+          project: { id: projectId, displayName: projectDisplayName, listPermissionsNeeded: true },
           assignee: { id: assigneeId, displayName: assigneeDisplayName }
         }
       });
@@ -2249,11 +2249,11 @@ export function* createBackupSaga({ showLoading = true }) {
     const data = yield callApi(api.createBackup);
     saveAs(data, "backup.gz");
     yield put({
-      type: CREATE_BACKUP_SUCCESS,
+      type: CREATE_BACKUP_SUCCESS
     });
   }, showLoading);
   yield put({
-    type: ENABLE_ALL_LIVE_UPDATES,
+    type: ENABLE_ALL_LIVE_UPDATES
   });
 }
 
@@ -2267,14 +2267,14 @@ export function* restoreBackupSaga({ file, showLoading = true }) {
     const prefix = env === "Test" ? "/test" : "/prod";
     yield call(api.restoreFromBackup, prefix, token, file);
     yield put({
-      type: RESTORE_BACKUP_SUCCESS,
+      type: RESTORE_BACKUP_SUCCESS
     });
     yield put({
       type: LOGOUT
     });
   }, showLoading);
   yield put({
-    type: ENABLE_ALL_LIVE_UPDATES,
+    type: ENABLE_ALL_LIVE_UPDATES
   });
 }
 


### PR DESCRIPTION
If a user has permission to close a workflowitem BUT no permission to list permissions of the workflowitem (workflowitem.intent.listPermissions), the confirmation dialog throws an error. The reason is that the confirmation dialog fetches permission of workflowitem by default, which is not necessary for the closing a   workflowitem. This also applies to project, subproject

Closes #562 
Closes #544 