### PR TITLE
added recommendation for extensions in workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ DOCKER_REGISTRY_PASSWORD
 /.env
 *~
 *-audit.json
-.vscode/*
 Untitled*
 node_modules
 yarn-error.log

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,21 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "aaron-bond.better-comments",
+    "CoenraadS.bracket-pair-colorizer",
+    "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig",
+    "eg2.tslint",
+    "esbenp.prettier-vscode",
+    "pmneo.tsimporter",
+    "rbbit.typescript-hero",
+    "xabikos.JavaScriptSnippets",
+    "EditorConfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false
+}

--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -7,7 +7,7 @@ env:
 parser: "@typescript-eslint/parser"
 parserOptions:
   ecmaVersion: 6
-  project: './tsconfig.json';
+  project: './tsconfig.json'
   sourceType: module
 rules:
   generator-star-spacing:


### PR DESCRIPTION
Closes #592 

Added recommended extension to workspace configuration for vscode.
`.vscode` was included in gitgnore

Restart of vscode might be needed after pulling the changes.