### PR TITLE
Contributor guide update

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "start": "node dist/",
     "build": "rimraf dist && tsc",
-    "dev": "rimraf dist && tsc --watch & nodemon dist",
+    "dev": "rimraf dist && tsc --watch & (sleep 10 && nodemon dist)",
     "test": "nyc mocha --require ts-node/register \"src/**/*.spec.ts\"",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "generate-report": "nyc report --reporter=html",

--- a/doc/tutorials/contribute/Contributor-Guide.md
+++ b/doc/tutorials/contribute/Contributor-Guide.md
@@ -121,6 +121,10 @@ sh setupGitSecrets.sh
 
 If you want to start developing on Trubudget, you need to setup the application locally. This guide tells you how to start the blockchain, start the API, load up some test data and start the frontend.
 
+### TypeScript
+
+If you are using global installation of TypeScript, please make sure you have at least 4.0.2 version.
+
 ### Blockchain
 
 The blockchain works as data layer for the Trubudget application. Therefore, we start by creating an instance of the blockchain.
@@ -189,6 +193,13 @@ SET ORGANIZATION_VAULT_SECRET="asdf"
 ```
 
 2. Install node-modules
+
+- (Linux/Mac) Depending on your machine configuration, it might be necessary to install `autoconf` and `automake`
+
+```bash
+brew install autoconf
+brew install automake
+```
 
 ```bash
 npm install


### PR DESCRIPTION
Changes to the contribution guide were needed for successful launch in DEV mode.Necessity of changes was confirmed by new contributors also working on macs.
Although typescript is listed in dependencies, I had an older version of TS compiler installed globally and in PATH, which resulted in incorrect transpiling of source to JS, namely optional chaining wasn't recognized by node 14 (which it should?), so I added a memo.

Issue #589 

