### PR TITLE
unhandled error in request handler

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,22 @@
       "request": "attach",
       "name": "Attach by Process ID",
       "processId": "${command:PickProcess}"
+    },
+    {
+      "name": "Launch provisioning",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/provisioning",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "debug"
+      ],
+      "env": {
+        "NODE_ENV": "development",
+        "API_PORT": "8080",
+        "ORGANIZATION": "ACMECoro"
+      }
     }
   ]
 }

--- a/provisioning/package.json
+++ b/provisioning/package.json
@@ -19,7 +19,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "debug": "node src/index.js --inspect"
   },
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
Closes #561 

There was an unhandled exception in `getOrganizationAddressItem` in `api/src/organization/organization.ts` - multichain is `undefined`;
Perhaps it would be good to handle it in upper function call, `authenticateRoot` could check if it's not passing `undefined` arguments to  functions it calls. 

To replicate the bug, one way is to temporarily replace  in `api/src/index.ts`
`  const db = Multichain.init(rpcSettings);`   with   `const db = {};` and launch provisioning.

Provisioning exited fast, so it was not possible to attach a debugger. Added a launch configuration for debugging the service.