### PR TITLE
e2e-test: Add timeout to the createBackup request

### DIFF
--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -612,9 +612,9 @@ Cypress.Commands.add("createBackup", () => {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`
-    }
+    },
+    timeout: 60000
   })
-  .its("headers")
-  .then(headers => Cypress.Promise.resolve(headers))
-
+    .its("headers")
+    .then(headers => Cypress.Promise.resolve(headers));
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).

### Description

<!-- Describe in detail what the PR is fixing or implementing -->

This PR fixes the timeout issue in the backup_spec e2e-test, by increasing the timeout from the default 30 seconds to 60 seconds. Sometimes the request might take more than 30 seconds to finish, which is why the test failed.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #630 
