### PR TITLE
frontend/fixed issue with workflowitemtype label

### DIFF
--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -234,7 +234,7 @@ const fr = {
     workflowitem_type: "Type de l’étape de workflow",
     workflowitem_type_general: "Créer une étape de workflow de type général.",
     workflowitem_type_restricted:
-      "Assurez-vous de ne pas fournir d'informations personnelles (nom, prénom(s), matricule, adresse email) en remplissant ce formulaire.\nEn cliquant sur \"SOUMETTRE\", vous nous autorisez à sauvegarder vos données de façon permanente et vous confirmez la réception de l'avis de confidentialité."
+      "Lors de l'attribution d'un workflow restreint, les autorisations sont automatiquement accordées et révoquées. Le cédant ne conservera que les autorisations de visualisation"
   },
 
   snackbar: {
@@ -269,7 +269,7 @@ const fr = {
     password_conditions_number: "Contenir au moins un chiffre",
     password_conditions_preface: "Votre mot de passe doit:",
     privacy_notice:
-      'Assurez-vous de ne pas fournir d\'informations personnelles (nom, prénom(s), matricule, adresse mail) en remplissant ce formulaire. En cliquant sur "SOUMETTRE" vous nous autorisez à sauvegarder vos données de façon permanente et vous confirmez avoir lu le présent avis de confidentialité.',
+      "Assurez-vous de ne pas fournir d'informations personnelles (nom, prénom(s), matricule, adresse email) en remplissant ce formulaire.\nEn cliquant sur \"SOUMETTRE\", vous nous autorisez à sauvegarder vos données de façon permanente et vous confirmez la réception de l'avis de confidentialité.",
     type_current_password: "Tapez le mot de passe actuel pour {0}",
     type_new_password: "Tapez le nouveau mot de passe pour {0}",
     user_created: "Utilisateur créé avec succès",

--- a/frontend/src/pages/SubProjects/SubprojectDialogContent.js
+++ b/frontend/src/pages/SubProjects/SubprojectDialogContent.js
@@ -12,11 +12,6 @@ import CancelIcon from "@material-ui/icons/Cancel";
 import IconButton from "@material-ui/core/IconButton";
 
 const subprojectWorkflowItemTypes = ["any", "general", "restricted"];
-const subprojectWorkflowItemTypesDescription = {
-  any: strings.subproject.subproject_any_workflowitem_type,
-  general: strings.subproject.subproject_general_workflowitem_type,
-  restricted: strings.subproject.subproject_restricted_workflowitem_type
-};
 
 const styles = {
   dropdown: {
@@ -76,21 +71,28 @@ const getDropdownValidator = users => {
   });
 };
 
-const getWorkflowitemTypeInfo = type => {
-  switch (type) {
-    case "any":
-      return subprojectWorkflowItemTypesDescription.any;
-    case "general":
-      return subprojectWorkflowItemTypesDescription.general;
-    case "restricted":
-      return subprojectWorkflowItemTypesDescription.restricted;
-    default:
-      return subprojectWorkflowItemTypesDescription.any;
-  }
-};
-
 const SubprojectDialogContent = props => {
   const currencies = getCurrencies();
+
+  const subprojectWorkflowItemTypesDescription = {
+    any: strings.subproject.subproject_any_workflowitem_type,
+    general: strings.subproject.subproject_general_workflowitem_type,
+    restricted: strings.subproject.subproject_restricted_workflowitem_type
+  };
+
+  const getWorkflowitemTypeInfo = type => {
+    switch (type) {
+      case "any":
+        return subprojectWorkflowItemTypesDescription.any;
+      case "general":
+        return subprojectWorkflowItemTypesDescription.general;
+      case "restricted":
+        return subprojectWorkflowItemTypesDescription.restricted;
+      default:
+        return subprojectWorkflowItemTypesDescription.any;
+    }
+  };
+
   return (
     <div>
       <div>

--- a/frontend/src/pages/Workflows/WorkflowDialog.js
+++ b/frontend/src/pages/Workflows/WorkflowDialog.js
@@ -15,7 +15,8 @@ import AssigneeSelection from "../Common/AssigneeSelection";
 import DocumentUpload from "../Documents/DocumentUpload";
 import { compareWorkflowItems } from "./compareWorkflowItems";
 import WorkflowDialogAmount from "./WorkflowDialogAmount";
-import { types, typesDescription } from "./workflowitemTypes";
+
+const types = ["general", "restricted"];
 
 const styles = {
   container: {
@@ -137,17 +138,6 @@ const getDropdownMenuItems = types => {
   });
 };
 
-const getWorkflowitemTypeInfo = type => {
-  switch (type) {
-    case "general":
-      return typesDescription.general;
-    case "restricted":
-      return typesDescription.restricted;
-    default:
-      return typesDescription.general;
-  }
-};
-
 const Content = props => {
   const { workflowitemType } = props.workflowToAdd;
   const {
@@ -162,6 +152,23 @@ const Content = props => {
     hasFixedWorkflowitemType,
     fixedWorkflowitemType
   } = props;
+
+  const typesDescription = {
+    general: strings.workflow.workflowitem_type_general,
+    restricted: strings.workflow.workflowitem_type_restricted
+  };
+
+  const getWorkflowitemTypeInfo = type => {
+    switch (type) {
+      case "general":
+        return typesDescription.general;
+      case "restricted":
+        return typesDescription.restricted;
+      default:
+        return typesDescription.general;
+    }
+  };
+
   return (
     <div className={classes.container} data-test={"workflow-dialog-content"}>
       <div className={classes.container}>

--- a/frontend/src/pages/Workflows/workflowitemTypes.js
+++ b/frontend/src/pages/Workflows/workflowitemTypes.js
@@ -1,8 +1,0 @@
-import strings from "../../localizeStrings";
-
-export const types = ["general", "restricted"];
-
-export const typesDescription = {
-  general: strings.workflow.workflowitem_type_general,
-  restricted: strings.workflow.workflowitem_type_restricted
-};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md), but I used a past tense in commit description instead of present

### Description

<!-- Describe in detail what the PR is fixing or implementing -->

According to issue #647 labels in wrong language were displayed when hovering over 'i' icon. 
There are actually two issues: 
- String localization was running in a different context than the application. I moved the logic inside a React component to ensure its evaluation in proper context. 
- Localized string for key 'workflowitem_type_restricted' for FR was incorrect. I have been able only to partially "fix" it. Person responsible for French translation should provide a proper translation.

This PR adds/modifies/destroys ...

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #647 
