### PR TITLE
E2E tests for item closing

### DIFF
--- a/e2e-test/cypress/integration/subproject_close_spec.js
+++ b/e2e-test/cypress/integration/subproject_close_spec.js
@@ -1,0 +1,92 @@
+describe("Subproject Close", function() {
+  let projectId;
+  let subprojectId;
+  let baseUrl, apiRoute;
+
+  before(() => {
+    baseUrl = Cypress.env("API_BASE_URL") || `${Cypress.config("baseUrl")}/test`;
+    apiRoute = baseUrl.toLowerCase().includes("test") ? "/test/api" : "/api";
+    cy.login();
+    cy.createProject("sp-close", "Project for test of suproject closing")
+      .then(({ id }) => {
+        projectId = id;
+        cy.createSubproject(projectId, "Subproject no. 1").then(({ id }) => {
+          subprojectId = id;
+        });
+      });
+  });
+
+  beforeEach(function() {
+    cy.login();
+    cy.visit(`/projects/${projectId}/${subprojectId}`);
+  });
+
+  it("When closing the subproject, a dialog pops up", function() {
+    cy.get("[data-test=spc-button]").should("be.visible");
+
+    // Cancel closing the subproject
+    cy.get("[data-test=spc-button]").click();
+    cy.get("[data-test=confirmation-dialog]").should("be.visible");
+    cy.get("[data-test=confirmation-dialog-cancel]").click();
+    cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+
+    // Close subproject
+    cy.get("[data-test=spc-button]").click();
+    cy.get("[data-test=confirmation-dialog]").should("be.visible");
+    cy.get("[data-test=confirmation-dialog-confirm]").click();
+    cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+    cy.get("[data-test=spc-button]").should("not.be.visible");
+
+    // Go to superior project
+    cy.visit(`/projects/${projectId}`);
+    cy.get("[data-test=pc-button]").should("be.enabled");
+  });
+
+  it("Closing a subproject including closed workflow items is possible", function() {
+    cy.createSubproject(projectId, "Subproject no. 2").then(({ id }) => {
+      subprojectId = id;
+      cy.createWorkflowitem(projectId, subprojectId, "Contract with Ministry of foreign affairs").then(({ id }) => {
+        let workflowitemId = id;
+
+        cy.server();
+        cy.route("POST", apiRoute + `/workflowitem.close`).as("workflowitemClose");
+        cy.route("GET", apiRoute + "/subproject.viewDetails*").as("viewDetails");
+
+        cy.visit(`/projects/${projectId}`);
+        cy.get("[data-test=pc-button]").should("be.disabled");
+        cy.visit(`/projects/${projectId}/${subprojectId}`);
+
+        // Closing a subproject with open workflow item is not possible
+        cy.get("[data-test=spc-button]").should("be.disabled");
+
+        // Close workflow item
+        cy.get("[data-test=close-workflowitem]")
+          .last()
+          .click({ force: true });
+        cy.get("[data-test=confirmation-dialog-confirm]").click();
+        cy.wait("@workflowitemClose")
+          .wait("@viewDetails")
+          .get("[data-test^=workflowitem-]")
+          .get(`[data-test=workflowitem-info-button-${workflowitemId}]`)
+          .click()
+          .get("[data-test=workflowitem-status]")
+          .should("contain", "Closed")
+          .get("[data-test=workflowdetails-close]")
+          .click();
+
+        // Cancel closing the subproject
+        cy.get("[data-test=spc-button]").scrollIntoView().click();
+        cy.get("[data-test=confirmation-dialog]").should("be.visible");
+        cy.get("[data-test=confirmation-dialog-cancel]").click();
+        cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+
+        // Close subproject
+        cy.get("[data-test=spc-button]").click();
+        cy.get("[data-test=confirmation-dialog]").should("be.visible");
+        cy.get("[data-test=confirmation-dialog-confirm]").click();
+        cy.get("[data-test=confirmation-dialog]").should("not.be.visible");
+        cy.get("[data-test=spc-button]").should("not.be.visible");
+      });
+    });
+  });
+});

--- a/e2e-test/cypress/integration/workflowitem_close_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_close_spec.js
@@ -1,4 +1,4 @@
-describe("Workflowitem edit", function() {
+describe("Workflowitem close", function() {
   let projectId;
   let subprojectId;
   let workflowitemId;
@@ -11,10 +11,10 @@ describe("Workflowitem edit", function() {
     apiRoute = baseUrl.toLowerCase().includes("test") ? "/test/api" : "/api";
     cy.login();
 
-    cy.createProject("workflowitem edit test project", "workflowitem edit test").then(({ id }) => {
+    cy.createProject("workflowitem close test project", "workflowitem close test").then(({ id }) => {
       projectId = id;
       cy.grantProjectPermission(projectId, "project.viewDetails", testUser.id);
-      cy.createSubproject(projectId, "workflowitem edit test", "EUR").then(({ id }) => {
+      cy.createSubproject(projectId, "workflowitem close test", "EUR").then(({ id }) => {
         subprojectId = id;
         cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testUser.id);
       });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).

### Description

<!-- Describe in detail what the PR is fixing or implementing -->

* E2E tests for closing subproject were added 
* E2E tests for closing a project and workflow item already there

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #623 
