### PR TITLE
ui: added groups to batch permission assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added a close button in user selections [#614](https://github.com/openkfw/TruBudget/issues/614)
 - Added a search field in the validator selection [#639](https://github.com/openkfw/TruBudget/issues/639)
-
+- Added groups to batch permission assignment [#612](https://github.com/openkfw/TruBudget/issues/612)
 <!-- ### Changed -->
 
 <!-- ### Deprecated -->

--- a/frontend/src/pages/Workflows/WorkflowBatchEditContainer.js
+++ b/frontend/src/pages/Workflows/WorkflowBatchEditContainer.js
@@ -36,6 +36,7 @@ const mapStateToProps = state => {
     currentWorkflowitemPermissions: state.getIn(["workflow", "permissions"]),
     permissions: state.getIn(["workflow", "permissions", "workflowitem"]),
     users: state.getIn(["login", "enabledUsers"]),
+    groups: state.getIn(["login", "groups"]),
     workflowActions: state.getIn(["workflow", "workflowActions"]),
     submittedWorkflowItems: state.getIn(["workflow", "submittedWorkflowItems"]),
     failedWorkflowItem: state.getIn(["workflow", "failedWorkflowItem"]),

--- a/frontend/src/pages/Workflows/WorkflowEditDrawer.js
+++ b/frontend/src/pages/Workflows/WorkflowEditDrawer.js
@@ -51,6 +51,7 @@ const WorkflowEditDrawer = props => {
     showWorkflowItemPreview,
     storePermissions,
     users,
+    groups,
     disableWorkflowEdit,
     tempDrawerAssignee,
     tempDrawerPermissions,
@@ -82,6 +83,11 @@ const WorkflowEditDrawer = props => {
   };
 
   const isOpen = !_isEmpty(selectedWorkflowItems);
+
+  const usersAndGroups = [
+    ...users,
+    ...groups.map(group => ({ ...group, id: group.groupId, isGroup: true, permissions: {} }))
+  ];
 
   // Only render the drawer if there are elements selected
   if (!isOpen) return null;
@@ -133,7 +139,7 @@ const WorkflowEditDrawer = props => {
         <PermissionTable
           permissions={permissions}
           intentOrder={workflowItemIntentOrder}
-          userList={users}
+          userList={usersAndGroups}
           addTemporaryPermission={grantPermission}
           removeTemporaryPermission={revokePermission}
           temporaryPermissions={permissions}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).

### Description

<!-- Describe in detail what the PR is fixing or implementing -->

Added groups to batch permission assignment. One or more groups could be set for multiple workflowitems.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #612 
