### PR TITLE
api: Fix deprecated buffer and remov rule override

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -116,10 +116,6 @@ rules:
   ## turn the rule on and add inline overrides
   no-continue: 0
 
-  ## no-buffer-constructor: 2
-  ## TODO api/src/workflowitem_download_document.ts
-  no-buffer-constructor: 0
-
   ## consistent-return can stay turned off, little value in TS
   consistent-return: 0
 

--- a/api/src/workflowitem_download_document.ts
+++ b/api/src/workflowitem_download_document.ts
@@ -132,7 +132,7 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
           "Content-Disposition": `attachment; filename="${documentResult.fileName}"`,
         });
 
-        reply.status(code).send(new Buffer(documentResult.base64, "base64"));
+        reply.status(code).send(Buffer.from(documentResult.base64, "base64"));
       } catch (err) {
         const { code, body } = toHttpError(err);
         reply.status(code).send(body);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).

### Description

new Buffer() expression was deprecated and replaced with Buffer.from() 
I updated the code and manually tested to verify the functionality is the same. 
To test, dowload a document attached to workflowitem.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #681 
