### PR TITLE
ui:fixing incorrect state for groups

### DIFF
--- a/frontend/src/pages/Workflows/WorkflowBatchEditContainer.js
+++ b/frontend/src/pages/Workflows/WorkflowBatchEditContainer.js
@@ -36,7 +36,7 @@ const mapStateToProps = state => {
     currentWorkflowitemPermissions: state.getIn(["workflow", "permissions"]),
     permissions: state.getIn(["workflow", "permissions", "workflowitem"]),
     users: state.getIn(["login", "enabledUsers"]),
-    groups: state.getIn(["login", "groups"]),
+    groups: state.getIn(["login", "groupList"]),
     workflowActions: state.getIn(["workflow", "workflowActions"]),
     submittedWorkflowItems: state.getIn(["workflow", "submittedWorkflowItems"]),
     failedWorkflowItem: state.getIn(["workflow", "failedWorkflowItem"]),

--- a/frontend/src/pages/Workflows/WorkflowEditDrawer.js
+++ b/frontend/src/pages/Workflows/WorkflowEditDrawer.js
@@ -83,10 +83,9 @@ const WorkflowEditDrawer = props => {
   };
 
   const isOpen = !_isEmpty(selectedWorkflowItems);
-
   const usersAndGroups = [
     ...users,
-    ...groups.map(group => ({ ...group, id: group.groupId, isGroup: true, permissions: {} }))
+    ...groups
   ];
 
   // Only render the drawer if there are elements selected


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [c] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).

### Description

<!-- Describe in detail what the PR is fixing or implementing -->

Fixing bug in already closed tasks #612 
Selecting correct groups from state.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #680 

