### PR TITLE
ui: Fix joi validation of dueDate

### DIFF
--- a/frontend/src/pages/Confirmation/validation.js
+++ b/frontend/src/pages/Confirmation/validation.js
@@ -57,11 +57,13 @@ schemes
         description: Joi.string().allow(""),
         documents: Joi.array().items({
           id: Joi.string().required(),
-          base64: Joi.string().required(),
+          base64: Joi.string()
+            .required()
+            .allow(""),
           fileName: Joi.string().allow("")
         }),
         status: Joi.string().valid("open"),
-        dueDate: Joi.string().allow(""),
+        dueDate: Joi.date().allow(null),
         workflowitemType: Joi.string().valid("restricted", "general"),
         projectDisplayName: Joi.string().required(),
         subprojectDisplayName: Joi.string().required(),


### PR DESCRIPTION
### Checklist


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).

### Description

The Joi Validation of dueDate on frontend/client side is set to string(empty Value `""`) instead of date (empty Value `null`).
This PR solves the currently failing e2e-tests.
The validation additionally allows empty base64 values for documents