### PR TITLE
ui: fix width of dropdown in workflowitem-batch edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- Fixed the width of dropdowns in workflowitem batch edit [#678](https://github.com/openkfw/TruBudget/issues/678)
 
 <!-- ### Security -->
 

--- a/e2e-test/cypress/integration/project_assignee_spec.js
+++ b/e2e-test/cypress/integration/project_assignee_spec.js
@@ -3,12 +3,15 @@ describe("Project Assignee", function() {
   const testUser = "jdoe";
   let projectId;
   let permissionsBeforeTesting;
+  const longUserId = `long_test_user_${Math.floor(Math.random() * 1000000)}`;
+  const longUserName = "Z22-Testuser-with-a-very-very-very-very-very-very-long-name";
 
   before(() => {
     cy.login();
     cy.createProject("p-assign", "project assign test").then(({ id }) => {
       projectId = id;
     });
+    cy.addUser(longUserName, longUserId, "test");
   });
 
   beforeEach(function() {
@@ -204,5 +207,16 @@ describe("Project Assignee", function() {
       .should("be.visible")
       .click();
     cy.get("[data-test=single-select-list]").should("not.be.visible");
+  });
+
+  it("If the assignee name is too long, an ellipses with tooltip is shown", function() {
+    cy.get("[data-test=single-select-list]").should("be.visible");
+    cy.get(`[data-test=single-select-name-${longUserName}]`)
+      .contains(longUserName)
+      .trigger("mouseover");
+    // show tooltip
+    cy.get("[data-test=overflow-tooltip]")
+      .should("be.visible")
+      .contains(longUserName);
   });
 });

--- a/e2e-test/cypress/integration/workflowitem_types_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_types_spec.js
@@ -47,7 +47,7 @@ describe("Workflowitem types", function() {
       .get("[data-test=single-select-container]")
       .last()
       .click();
-    cy.get("[data-test=single-select-name]")
+    cy.get("[data-test^=single-select-name]")
       .first()
       .click();
     cy.get("[data-test=confirmation-dialog-confirm]")

--- a/frontend/src/pages/Common/OverflowTooltip.js
+++ b/frontend/src/pages/Common/OverflowTooltip.js
@@ -1,0 +1,37 @@
+import React, { useRef, useEffect, useState } from "react";
+import Tooltip from "@material-ui/core/Tooltip";
+
+const OverflowTooltip = ({ text }) => {
+  const textElementRef = useRef();
+  const [isOverflowed, setIsOverflowed] = useState(false);
+
+  const compareSize = () => {
+    setIsOverflowed(textElementRef.current.scrollWidth > textElementRef.current.clientWidth);
+  };
+
+  // compare once and add resize listener
+  useEffect(() => {
+    compareSize();
+    window.addEventListener("resize", compareSize);
+    return () => {
+      window.removeEventListener("resize", compareSize);
+    };
+  }, []);
+
+  return (
+    <Tooltip data-test="overflow-tooltip" title={text} disableHoverListener={!isOverflowed}>
+      <div
+        ref={textElementRef}
+        style={{
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis"
+        }}
+      >
+        {text}
+      </div>
+    </Tooltip>
+  );
+};
+
+export default OverflowTooltip;

--- a/frontend/src/pages/Common/Permissions/PermissionSelection.js
+++ b/frontend/src/pages/Common/Permissions/PermissionSelection.js
@@ -16,6 +16,7 @@ import React, { Component } from "react";
 import strings from "../../../localizeStrings";
 import CloseIcon from "@material-ui/icons/Close";
 import ActionButton from "../ActionButton";
+import OverflowTooltip from "../OverflowTooltip";
 
 const styles = {
   closeButtonContainer: { float: "right", marginTop: -8 },
@@ -31,6 +32,9 @@ const styles = {
     display: "flex",
     margin: 16,
     justifyContent: "flex-start"
+  },
+  nameContainer: {
+    maxWidth: "200px"
   }
 };
 
@@ -45,7 +49,9 @@ const renderSelection = (user, permissionedUser, intent, grant, revoke, myself, 
         onClick={checked ? () => revoke(intent, u.id) : () => grant(intent, u.id)}
       >
         <Checkbox checked={checked} disabled={(u.id === myself && checked) || disabled} />
-        <ListItemText primary={u.displayName} />
+        <ListItemText style={styles.nameContainer}>
+          <OverflowTooltip text={u.displayName} />
+        </ListItemText>
       </MenuItem>
     );
   });

--- a/frontend/src/pages/Common/SingleSelection.js
+++ b/frontend/src/pages/Common/SingleSelection.js
@@ -17,10 +17,12 @@ import React, { Component } from "react";
 
 import strings from "../../localizeStrings";
 import ActionButton from "./ActionButton";
+import OverflowTooltip from "./OverflowTooltip";
 
 const styles = {
   formControl: {
-    width: "100%"
+    minWidth: "200px",
+    maxWidth: "200px"
   },
   radioButton: {
     height: "10px"
@@ -37,6 +39,7 @@ const styles = {
     justifyContent: "flex-start"
   },
   select: {
+    maxWidth: "200px",
     "&$disabled": {
       cursor: "-webkit-grab"
     }
@@ -44,6 +47,9 @@ const styles = {
   assigneeTypography: {
     overflow: "hidden",
     textOverflow: "ellipsis"
+  },
+  nameContainer: {
+    maxWidth: "200px"
   },
   listSubHeader: { top: "auto" },
   disabled: {},
@@ -78,7 +84,9 @@ class SingleSelection extends Component {
           onClick={() => (id !== selectId ? this.props.onSelect(id, displayName) : undefined)}
         >
           <Radio className={classes.radioButton} disabled={disabled} checked={id === selectId} />
-          <ListItemText data-test="single-select-name" primary={displayName} />
+          <ListItemText data-test={`single-select-name-${displayName}`} className={classes.nameContainer}>
+            <OverflowTooltip text={displayName} />
+          </ListItemText>
         </MenuItem>
       );
     });

--- a/frontend/src/pages/Workflows/WorkflowEditDrawer.js
+++ b/frontend/src/pages/Workflows/WorkflowEditDrawer.js
@@ -34,6 +34,9 @@ const styles = {
     paddingTop: "36px",
     align: "center",
     textAlign: "center"
+  },
+  assigneeContainer: {
+    padding: "32px"
   }
 };
 
@@ -83,10 +86,7 @@ const WorkflowEditDrawer = props => {
   };
 
   const isOpen = !_isEmpty(selectedWorkflowItems);
-  const usersAndGroups = [
-    ...users,
-    ...groups
-  ];
+  const usersAndGroups = [...users, ...groups];
 
   // Only render the drawer if there are elements selected
   if (!isOpen) return null;
@@ -126,7 +126,7 @@ const WorkflowEditDrawer = props => {
       <div>
         <Card style={styles.assigneeCard}>
           <CardHeader subheader="Assignee" />
-          <CardContent>
+          <CardContent style={styles.assigneeContainer}>
             <SingleSelection
               disabled={hasSubprojectValidator}
               selectId={hasSubprojectValidator ? subprojectValidator : tempDrawerAssignee}


### PR DESCRIPTION
### Checklist

- [x] Refactor CSS to reduce width of assignee selection in workflowitem batch edit
- [x] Additional: Add component to show a ToolTip if the name is overflowing
- [x] Write e2e-test

### Description
The assignee selection in workflowitem batch editing is too wide.

Closes #678 
