### PR TITLE
api: Add overrides for default prefer-as-const rul

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -264,8 +264,3 @@ rules:
 
   ## @typescript-eslint/indent should stay disabled because it messes with formatting
   "@typescript-eslint/indent": 0
-
-  ## this rule is on by default
-  ## and changes among others "const TRUE = true as true;"" to "const TRUE = true as const;"
-  ## which probably is not desired
-  "@typescript-eslint/prefer-as-const": 0

--- a/api/src/notification_list.ts
+++ b/api/src/notification_list.ts
@@ -189,8 +189,9 @@ interface Service {
   ): Promise<Result.Type<Workflowitem.Workflowitem>>;
 }
 
-// C'mon, TypeScript!
+// eslint-disable-next-line @typescript-eslint/prefer-as-const
 const TRUE = true as true;
+// eslint-disable-next-line @typescript-eslint/prefer-as-const
 const FALSE = false as false;
 
 async function getProjectMetadata(

--- a/api/src/service/domain/workflow/workflowitem_ordering.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_ordering.spec.ts
@@ -9,7 +9,9 @@ import * as WorkflowitemClosed from "./workflowitem_closed";
 import { sortWorkflowitems } from "./workflowitem_ordering";
 import { WorkflowitemTraceEvent } from "./workflowitem_trace_event";
 
+// eslint-disable-next-line @typescript-eslint/prefer-as-const
 const OPEN = "open" as "open";
+// eslint-disable-next-line @typescript-eslint/prefer-as-const
 const CLOSED = "closed" as "closed";
 
 const ctx: Ctx = { requestId: "", source: "test" };

--- a/api/src/service/domain/workflow/workflowitem_update.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_update.spec.ts
@@ -268,6 +268,7 @@ describe("update workflowitem: how modifications are applied", () => {
       'are cleared if the amountType is set to "N/A" by the update',
     async () => {
       const modification = {
+        // eslint-disable-next-line @typescript-eslint/prefer-as-const
         amountType: "N/A" as "N/A",
       };
       const result = await updateWorkflowitem(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).

### Description

<!-- Describe in detail what the PR is fixing or implementing -->

This PR removes @typescript-eslint/prefer-as-const: 0 from global eslint overrides in api, in favor of local overrides.
Rule has been deleted from eslintrc file, because it is 2 by default in our current configuration. No need to explicitly set rule level to 2.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #729 
