### PR TITLE
frontend: Set eslint semi rules and paren space

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -38,6 +38,13 @@
     "react-hooks/exhaustive-deps": "warn",
     "no-var": 1,
     "no-console": 1,
-    "import/named": 2
+    "import/named": 2,
+    "semi-style": ["error", "last"],
+    "semi": [2, "always"],
+    "space-before-function-paren": ["error", {
+      "anonymous": "always",
+      "named": "never",
+      "asyncArrow": "always"
+  }]
   }
 }

--- a/frontend/src/pages/Common/DatePicker.js
+++ b/frontend/src/pages/Common/DatePicker.js
@@ -31,8 +31,8 @@ function DatePicker({ classes, name, label, onChange, onDelete, datetime, id = "
 
   const handleOnBlur = (date, name) => {
     const modifiedDate = dayjs(date).isValid() ? dayjs(date).format("YYYY-MM-DD") : null;
-    onChange(modifiedDate, name)
-  }
+    onChange(modifiedDate, name);
+  };
 
   return (
     <div className={classes.searchField}>

--- a/frontend/src/pages/Confirmation/validation.js
+++ b/frontend/src/pages/Confirmation/validation.js
@@ -167,7 +167,9 @@ export const validate = (intent, payload) => {
   if (!validatePayload.error) {
     return false;
   }
+  // eslint-disable-next-line no-console
   console.error("validation error", validatePayload.error);
+  // eslint-disable-next-line no-console
   console.log("validation values", validatePayload.value);
   return true;
 };

--- a/frontend/src/pages/Login/PrivateRoute.js
+++ b/frontend/src/pages/Login/PrivateRoute.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import {
   Route, Redirect,
-} from 'react-router'
+} from 'react-router';
 
 
 class PrivateRoute extends Component {
@@ -18,19 +18,19 @@ class PrivateRoute extends Component {
             <Redirect to={{ pathname: '/login', state: { from: props.location } }} />
           )
       )} />
-    )
+    );
   }
 }
 
 const mapStateToProps = (state) => {
   return {
     jwt: state.getIn(['login', 'jwt']),
-  }
-}
+  };
+};
 const mapDispatchToProps = (dispatch) => {
   return {
-  }
-}
+  };
+};
 
 
 export default connect(mapStateToProps, mapDispatchToProps)(PrivateRoute);

--- a/frontend/src/pages/Main/Footer.js
+++ b/frontend/src/pages/Main/Footer.js
@@ -6,6 +6,6 @@ const Footer = () => (
 
   </div>
 
-)
+);
 
 export default Footer;

--- a/frontend/src/pages/Main/Placeholder.js
+++ b/frontend/src/pages/Main/Placeholder.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect } from 'react-router'
+import { Redirect } from 'react-router';
 
 const Placeholder = (props) => <Redirect to="/projects" />;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).

### Description

<!-- Describe in detail what the PR is fixing or implementing -->

This PR adds eslint rules for semicolons and spaces before function params. 
Rules are set up in a way to conform to existing style, and enforce it where it doesn't.
Contains also fixes of those few files.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #740 
