### PR TITLE
ui: fix additional listPermission requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Fixed -->
 
+### Fixed
+
+- Fixed a bug in the confirmation dialog because of missing additional actions [#761](https://github.com/openkfw/TruBudget/issues/761)
+
 <!-- ### Security -->
 
 ## [1.18.0] - 2021-01-14

--- a/e2e-test/cypress/integration/subproject_permissions_spec.js
+++ b/e2e-test/cypress/integration/subproject_permissions_spec.js
@@ -72,15 +72,14 @@ describe("Subproject Permissions", function() {
   /**
    * @param {boolean} listPermIncluded    If set to true subproject.intent.listPermissions is also added
    */
-  function addViewPermissions(permissions, identity, listPermIncluded = true) {
+  function addViewPermissions(permissions, identity) {
     const permissionsCopy = _cloneDeep(permissions);
     addPermission(permissionsCopy.project, "project.viewSummary", identity);
     addPermission(permissionsCopy.project, "project.viewDetails", identity);
+    addPermission(permissionsCopy.project, "project.intent.listPermissions", identity);
     addPermission(permissionsCopy.subproject, "subproject.viewSummary", identity);
     addPermission(permissionsCopy.subproject, "subproject.viewDetails", identity);
-    if (listPermIncluded) {
-      addPermission(permissionsCopy.subproject, "subproject.intent.listPermissions", identity);
-    }
+    addPermission(permissionsCopy.subproject, "subproject.intent.listPermissions", identity);
     return permissionsCopy;
   }
 
@@ -348,7 +347,7 @@ describe("Subproject Permissions", function() {
     cy.get("[data-test=actions-table-body]")
       .should("be.visible")
       .children()
-      .should("have.length", 5);
+      .should("have.length", 6);
   });
 
   it("Granting view permissions doesn't additionally view the same permission", function() {
@@ -411,7 +410,7 @@ describe("Subproject Permissions", function() {
       .get("[data-test=actions-table-body]")
       .should("be.visible")
       .children()
-      .should("have.length", 5);
+      .should("have.length", 6);
     cy.get("[data-test=confirmation-dialog-confirm]")
       .should("be.visible")
       .click();
@@ -466,7 +465,7 @@ describe("Subproject Permissions", function() {
         .get("[data-test=actions-table-body]")
         .should("be.visible")
         .children()
-        .should("have.length", 5);
+        .should("have.length", 6);
       // Confirm additional actions
       cy.get("[data-test=confirmation-dialog-confirm]").click();
 
@@ -500,7 +499,7 @@ describe("Subproject Permissions", function() {
     cy.get("[data-test=actions-table-body]")
       .should("be.visible")
       .children()
-      .should("have.length", 5)
+      .should("have.length", 6)
       .find("td")
       .contains("view permissions")
       .should("have.length", 1);
@@ -538,8 +537,8 @@ describe("Subproject Permissions", function() {
       .scrollIntoView({ offset: { top: 150, left: 0 } })
       .should("be.visible")
       .children()
-      // 4 permissions per user/group granted
-      .should("have.length", 4 * 3);
+      // 6 permissions per user/group granted
+      .should("have.length", 6 * 3);
     // Confirm additional actions
     cy.get("[data-test=confirmation-dialog-confirm]").click();
 
@@ -551,7 +550,7 @@ describe("Subproject Permissions", function() {
     cy.wrap(testIds)
       .each(id => {
         permissionsBeforeTesting.subproject["subproject.createWorkflowitem"].push(id);
-        permissionsBeforeTesting = addViewPermissions(permissionsBeforeTesting, id, false);
+        permissionsBeforeTesting = addViewPermissions(permissionsBeforeTesting, id);
       })
       .then(() => {
         // Push identities in specific order so assertion doesn't fail


### PR DESCRIPTION
In the confirmation dialog, the listpermission which may be required for other intents were not set correctly.

- [x] Check which intents require listPermissions
- [x] Add code to generate additional actions for listPermissions in confirmation dialog
- [x] ~~Add e2e-test~~ since refactoring is in progress, e2e tests will be added in PR #714 

Following intents are affected for listPermissions:
```
subproject.createWorkflowitem 
subproject.assign 
subproject.intent.grantPermission
subproject.intent.revokePermission

project.createSubproject
project.assign
project.intent.grantPermission
project.intent.revokePermission

workflowitem.assign
workflowitem.intent.grantPermission
workflowitem.intent.revokePermission
```

Closes #738 