### PR TITLE
Fix file size limit - 50mb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
 
 <!-- ### Added -->
 
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- Fixed a bug where it was not possible to upload files bigger than ~10MB
 
 ## [1.22.0] - 2021-06-02
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -178,8 +178,9 @@ let storageServiceSettings: AxiosRequestConfig;
 if (documentFeatureEnabled) {
   storageServiceSettings = {
     baseURL: `http://${storageService.host}:${storageService.port}`,
-    // 2.5 seconds request timeout
-    timeout: 2500,
+    // 10 seconds request timeout
+    timeout: 10000,
+    maxBodyLength: 67000000, //  ~50mb in base64
   };
 } else {
   storageServiceSettings = {

--- a/api/src/service/RpcClient.ts
+++ b/api/src/service/RpcClient.ts
@@ -74,6 +74,7 @@ export class RpcClient {
       headers: { "Content-Type": "application/json" },
       withCredentials: true,
       maxContentLength: 104857600,
+      maxBodyLength: 67000000, // ~50mb in base64
       auth: {
         username: settings.username || "multichainrpc",
         password: settings.password,

--- a/api/src/service/domain/document/document.ts
+++ b/api/src/service/domain/document/document.ts
@@ -44,7 +44,8 @@ export const uploadedDocumentSchema = Joi.object({
   id: Joi.string().required(),
   base64: Joi.string()
     .required()
-    .error(() => new Error("Document can't be an empty file")),
+    .max(67000000)
+    .error(() => new Error("Document is not valid")),
   fileName: Joi.string(),
 });
 


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [ ] I fixed all necessary PR warnings
- [ ] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [ ] I did a self review before requesting a review from another team member

### Description
Files over 10mb could not be uploaded. By default, axios sets its maxBodyLength at 10mb, so this had to be increased. But since the files are sent to the api as base64, and multichain only accepts files up to 50mb, the limit had to be the equivalent of 50mb base64.

TODOs:

- [x] increase limit of maxBodyLength of requests in the axios clients (RpcClient and StorageServiceClient)
- [x] the limit represents ~8mb, representing the size of a base64 encoded ~50mb large file (larger files are not accepted by multichain)
- [x] add this check to the Joi validation of documents

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #843 
