### PR TITLE
Improve logging in the api

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -841,7 +841,10 @@ server.listen(port, "0.0.0.0", async (err) => {
   while (
     !(await ensureOrganizationStream(multichainClient, organization!, organizationVaultSecret!)
       .then(() => true)
-      .catch(() => false))
+      .catch((error) => {
+        logger.info(error); //TODO: log the error here - for example if the organizationVaultSecret is not correct this would be shown here
+        return false;
+      }))
   ) {
     logger.info(
       { multichainClient, organization },


### PR DESCRIPTION
### TODOs

- [ ] log the error in case the **organization vault secret** is incorrect ( to reproduce: start api with an organization vault secret, then stop the api and restart it with another one)

Closes #916 
