### PR TITLE
Bugfix: Exception when granting workflowitem permission on group

### DIFF
--- a/api/src/service/domain/workflow/workflowitem_permission_grant.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_grant.ts
@@ -126,7 +126,7 @@ async function getOrganizations(
   const organizations: string[] = [];
 
   // check if grantee is user, get the user's organization
-  if (repository.userExists(grantee)) {
+  if (await repository.userExists(grantee)) {
     const user = await repository.getUser(grantee);
     if (Result.isErr(user)) {
       return new VError(user, "failed to get user");
@@ -135,7 +135,7 @@ async function getOrganizations(
     organizations.push(organization);
 
     // check if grantee is group, get the organizations of all group members
-  } else if (repository.groupExists(grantee)) {
+  } else if (await repository.groupExists(grantee)) {
     const group = await repository.getGroup(grantee);
     if (Result.isErr(group)) {
       return new VError(group, "failed to get group");


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [ ] I fixed all necessary PR warnings
- [ ] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [ ] I did a self review before requesting a review from another team member

### Description

When granting a permission on a workflowitem with attached document to a group. An Error will be thrown.

### Steps to reproduce

1) Start Trubudget With Document Storage Service Feature
2) Login as Admin
3) Create a Group and add 1 Test User
4) Create a Project & Sub-Project
5) Create a Workflow-Item and attach a document in the creation process
6) Try to give the created group any permission (for example view permission) on that workflow-item

Exception will Occur
![Group-permission](https://user-images.githubusercontent.com/44588135/130577911-c6841ad1-33ce-441e-930d-514afb911f19.png)


Closes #938"
