### PR TITLE
Fix minio and storage-service synchronization

### DIFF
--- a/scripts/development/docker-compose.yml
+++ b/scripts/development/docker-compose.yml
@@ -146,7 +146,7 @@ services:
     command: ["npm", "run", "watch"]
     # volume for hot reloading
     volumes:
-      - "../storage-service/src:/home/node/src:delegated"
+      - "../../storage-service/src:/home/node/src:delegated"
     ports:
       - "${STORAGE_SERVICE_PORT}:${STORAGE_SERVICE_PORT}"
 

--- a/storage-service/src/minio.ts
+++ b/storage-service/src/minio.ts
@@ -57,7 +57,7 @@ const makeBucket = (bucket: string, cb: Function) => {
   });
 };
 
-export const makeBucketAsPromised = (bucket: string) => {
+const makeBucketAsPromised = (bucket: string) => {
   return new Promise((resolve, reject) => {
     makeBucket(bucket, (err) => {
       if (err) return reject(err);
@@ -74,7 +74,7 @@ const upload = (
   cb: Function,
 ) => {
   const s = new Readable();
-  s._read = () => {};
+  s._read = () => { };
   s.push(content);
   s.push(null);
 
@@ -103,11 +103,12 @@ const upload = (
  * @param metaData
  * @returns {string} document secret
  */
-export const uploadAsPromised = (
+export const uploadAsPromised = async (
   file: string,
   content: string,
   metaData: Metadata = { fileName: "default", docId: "123" },
 ): Promise<string> => {
+  await verifyMinioBucket();
   return new Promise((resolve, reject) => {
     const secret = v4();
     upload(file, content, { ...metaData, secret }, (err) => {
@@ -140,7 +141,8 @@ const download = (file: string, cb: Function) => {
   });
 };
 
-export const downloadAsPromised = (file: string): Promise<FileWithMeta> => {
+export const downloadAsPromised = async (file: string): Promise<FileWithMeta> => {
+  await verifyMinioBucket();
   return new Promise((resolve, reject) => {
     download(file, (err, fileContent: FileWithMeta) => {
       if (err) return reject(err);
@@ -160,7 +162,7 @@ const getMetadata = (fileHash: string, cb: Function) => {
   });
 };
 
-export const getMetadataAsPromised = (
+const getMetadataAsPromised = (
   fileHash: string,
 ): Promise<MetadataWithName> => {
   return new Promise((resolve, reject) => {
@@ -199,16 +201,23 @@ const establishConnection = async () => {
     }
   }
 };
-export const getReadiness = async () => {
-  minioClient.listBuckets(function (err, buckets) {
-    if (err) return console.log(err);
+
+export const verifyMinioBucket = (): Promise<boolean> => {
+  return new Promise((resolve, reject) => {
+    minioClient.listBuckets(async function (err, buckets) {
+      if (err) {
+        console.log(err);
+        reject(err);
+      }
+      if (buckets.length === 0) {
+        await establishConnection();
+      }
+      resolve(true);
+    });
   });
 };
 
-if (config.storage.host) {
-  establishConnection();
-} else {
-  console.log("MINIO_ENDPOINT not set. Defaulting to chain storage.");
-}
+
+
 
 export default minioClient;


### PR DESCRIPTION
### Description

When restarting minio without persisted data, the storage-service does not re-create the bucket (its like a database-name) on minio, which leads to an error. 

### Solution

Storage-service should always check if the bucket exists on minio. If it does not exist, re-create it.

### Reproduce the problem
To reproduce the problem (for testing), see #946

Closes #946
