### PR TITLE
Fix simultaneous document upload

### DIFF
--- a/api/src/service/domain/workflow/project_permission_revoke.ts
+++ b/api/src/service/domain/workflow/project_permission_revoke.ts
@@ -61,9 +61,9 @@ export async function revokeProjectPermission(
   // Prevent revoking grant permission of last user
   const intents: Intent[] = ["project.intent.grantPermission"];
   if (
+    intent &&
     intents.includes(intent) &&
-    project.permissions[`${intent}`] !== undefined &&
-    project.permissions[`${intent}`].length === 1
+    project?.permissions[intent]?.length === 1
   ) {
     return new PreconditionError(
       ctx,

--- a/api/src/service/domain/workflow/subproject_permission_revoke.ts
+++ b/api/src/service/domain/workflow/subproject_permission_revoke.ts
@@ -76,9 +76,9 @@ export async function revokeSubprojectPermission(
   // Prevent revoking grant permission of last user
   const intents: Intent[] = ["subproject.intent.grantPermission"];
   if (
+    intent &&
     intents.includes(intent) &&
-    subproject.permissions[`${intent}`] !== undefined &&
-    subproject.permissions[`${intent}`].length === 1
+    subproject?.permissions[intent]?.length === 1
   ) {
     return new PreconditionError(
       ctx,

--- a/api/src/service/domain/workflow/workflowitem_permission_revoke.ts
+++ b/api/src/service/domain/workflow/workflowitem_permission_revoke.ts
@@ -81,9 +81,9 @@ export async function revokeWorkflowitemPermission(
   // Prevent revoking grant permission of last user
   const intents: Intent[] = ["workflowitem.intent.grantPermission"];
   if (
+    intent &&
     intents.includes(intent) &&
-    workflowitem.permissions[`${intent}`] !== undefined &&
-    workflowitem.permissions[`${intent}`].length === 1
+    workflowitem?.permissions[intent]?.length === 1
   ) {
     return new PreconditionError(
       ctx,

--- a/storage-service/src/index.ts
+++ b/storage-service/src/index.ts
@@ -97,6 +97,9 @@ app.post(
       });
       res.send({ docId, secret: result }).end();
     })().catch((error) => {
+      if (error.code === "NoSuchBucket") {
+        console.log("ERROR: NoSuchBucket at /upload. Please restart storage-service to create a new bucket at minio")
+      }
       res.status(500).send(error).end();
     });
   },
@@ -129,6 +132,9 @@ app.get(
         res.send(result).end();
       }
     })().catch((error) => {
+      if (error.code === "NoSuchBucket") {
+        console.log("ERROR: NoSuchBucket at /download. Please restart storage-service to create a new bucket at minio")
+      }
       res.status(404).end();
     });
   },

--- a/storage-service/src/index.ts
+++ b/storage-service/src/index.ts
@@ -1,5 +1,9 @@
 import * as URL from "url";
-import { uploadAsPromised, downloadAsPromised } from "./minio";
+import {
+  uploadAsPromised,
+  downloadAsPromised,
+  establishConnection,
+} from "./minio";
 import config from "./config";
 import * as express from "express";
 import * as cors from "cors";
@@ -98,7 +102,9 @@ app.post(
       res.send({ docId, secret: result }).end();
     })().catch((error) => {
       if (error.code === "NoSuchBucket") {
-        console.log("ERROR: NoSuchBucket at /upload. Please restart storage-service to create a new bucket at minio")
+        console.log(
+          "ERROR: NoSuchBucket at /upload. Please restart storage-service to create a new bucket at minio",
+        );
       }
       res.status(500).send(error).end();
     });
@@ -133,13 +139,16 @@ app.get(
       }
     })().catch((error) => {
       if (error.code === "NoSuchBucket") {
-        console.log("ERROR: NoSuchBucket at /download. Please restart storage-service to create a new bucket at minio")
+        console.log(
+          "ERROR: NoSuchBucket at /download. Please restart storage-service to create a new bucket at minio",
+        );
       }
       res.status(404).end();
     });
   },
 );
 
-app.listen(config.port, () => {
+app.listen(config.port, async () => {
   console.log(`Starting TruBudget storage server on ${config.port}`);
+  await establishConnection();
 });

--- a/storage-service/src/minio.ts
+++ b/storage-service/src/minio.ts
@@ -57,7 +57,7 @@ const makeBucket = (bucket: string, cb: Function) => {
   });
 };
 
-const makeBucketAsPromised = (bucket: string) => {
+export const makeBucketAsPromised = (bucket: string) => {
   return new Promise((resolve, reject) => {
     makeBucket(bucket, (err) => {
       if (err) return reject(err);
@@ -103,12 +103,11 @@ const upload = (
  * @param metaData
  * @returns {string} document secret
  */
-export const uploadAsPromised = async (
+export const uploadAsPromised = (
   file: string,
   content: string,
   metaData: Metadata = { fileName: "default", docId: "123" },
 ): Promise<string> => {
-  await verifyMinioBucket();
   return new Promise((resolve, reject) => {
     const secret = v4();
     upload(file, content, { ...metaData, secret }, (err) => {
@@ -141,8 +140,7 @@ const download = (file: string, cb: Function) => {
   });
 };
 
-export const downloadAsPromised = async (file: string): Promise<FileWithMeta> => {
-  await verifyMinioBucket();
+export const downloadAsPromised = (file: string): Promise<FileWithMeta> => {
   return new Promise((resolve, reject) => {
     download(file, (err, fileContent: FileWithMeta) => {
       if (err) return reject(err);
@@ -162,7 +160,7 @@ const getMetadata = (fileHash: string, cb: Function) => {
   });
 };
 
-const getMetadataAsPromised = (
+export const getMetadataAsPromised = (
   fileHash: string,
 ): Promise<MetadataWithName> => {
   return new Promise((resolve, reject) => {
@@ -171,6 +169,12 @@ const getMetadataAsPromised = (
 
       resolve(metaData);
     });
+  });
+};
+
+export const getReadiness = async () => {
+  minioClient.listBuckets(function (err, buckets) {
+    if (err) return console.log(err);
   });
 };
 
@@ -202,22 +206,6 @@ const establishConnection = async () => {
   }
 };
 
-export const verifyMinioBucket = (): Promise<boolean> => {
-  return new Promise((resolve, reject) => {
-    minioClient.listBuckets(async function (err, buckets) {
-      if (err) {
-        console.log(err);
-        reject(err);
-      }
-      if (buckets.length === 0) {
-        await establishConnection();
-      }
-      resolve(true);
-    });
-  });
-};
-
-
-
+establishConnection();
 
 export default minioClient;

--- a/storage-service/src/minio.ts
+++ b/storage-service/src/minio.ts
@@ -54,6 +54,7 @@ const makeBucket = (bucket: string, cb: Function) => {
         return cb(null, true);
       });
     }
+    return cb(null, true);
   });
 };
 
@@ -74,7 +75,7 @@ const upload = (
   cb: Function,
 ) => {
   const s = new Readable();
-  s._read = () => { };
+  s._read = () => {};
   s.push(content);
   s.push(null);
 
@@ -184,7 +185,7 @@ const sleep = (ms) => {
   });
 };
 
-const establishConnection = async () => {
+export const establishConnection = async () => {
   const retries = 20;
   for (let i = 0; i <= retries; i++) {
     try {
@@ -205,7 +206,5 @@ const establishConnection = async () => {
     }
   }
 };
-
-establishConnection();
 
 export default minioClient;


### PR DESCRIPTION
### Description
Follow up of https://github.com/openkfw/TruBudget/issues/946


### Solution
Instead of verifying that a valid minio bucket exists, the storage-service will throw an error with an explicit message to restart storage-service to initialize the minio container correctly (hence, a minio bucket will be created).

### How to test
To reproduce a setup with storage-service and minio, but without a minio bucket, see #946

Closes #972
Reverts commits from #953
