### PR TITLE
Add check for user and group name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Removed -->
 
-<!-- ### Fixed -->
+### Fixed
+
+- Fixed a bug where it was possible to create users and groups with the same id. This will not be allowed in the future. However, if a user and a group with the same id already exist in the same network the permission system will not work correctly, so the user should be disabled by the admin [#943](https://github.com/openkfw/TruBudget/issues/943).
 
 ## [1.25.0] - 2021-08-31
 

--- a/api/src/service/domain/organization/group_create.spec.ts
+++ b/api/src/service/domain/organization/group_create.spec.ts
@@ -33,7 +33,7 @@ const requestData: RequestData = {
 const baseRepository = {
   getGlobalPermissions: () => Promise.resolve(noPermissions),
   groupExists: () => Promise.resolve(false),
-
+  userExists: () => Promise.resolve(false),
 };
 
 describe("Create a new group: authorization", () => {
@@ -44,11 +44,10 @@ describe("Create a new group: authorization", () => {
   });
 
   it("With the global.createGroup permission, a user can create a new group", async () => {
-    const result = await createGroup(ctx, alice, requestData,
-      {
-        ...baseRepository,
-        getGlobalPermissions: () => Promise.resolve(grantPermissions),
-      });
+    const result = await createGroup(ctx, alice, requestData, {
+      ...baseRepository,
+      getGlobalPermissions: () => Promise.resolve(grantPermissions),
+    });
     assert.isTrue(Result.isOk(result));
   });
 
@@ -62,7 +61,16 @@ describe("Create a new group: conditions", () => {
   it("Group that already exists cannot be created", async () => {
     const result = await createGroup(ctx, root, requestData, {
       ...baseRepository,
-      groupExists: groupId => Promise.resolve(true),
+      groupExists: (groupId) => Promise.resolve(true),
+    });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, AlreadyExists);
+  });
+
+  it("Group cannot be created if user with that id already exists", async () => {
+    const result = await createGroup(ctx, root, requestData, {
+      ...baseRepository,
+      userExists: (groupId) => Promise.resolve(true),
     });
     assert.isTrue(Result.isErr(result));
     assert.instanceOf(result, AlreadyExists);

--- a/api/src/service/domain/organization/user_create.spec.ts
+++ b/api/src/service/domain/organization/user_create.spec.ts
@@ -35,6 +35,7 @@ const dummyKeyPair = {
 const baseRepository = {
   getGlobalPermissions: () => Promise.resolve(noPermissions),
   userExists: (userId) => Promise.resolve(false),
+  groupExists: (userId) => Promise.resolve(false),
   organizationExists: (organization) => Promise.resolve(true),
   createKeyPair: () => Promise.resolve(dummyKeyPair),
   hash: (plaintext) => Promise.resolve("dummyHash"),
@@ -64,6 +65,15 @@ describe("Create a new user: conditions", () => {
     const result = await createUser(ctx, root, requestData, {
       ...baseRepository,
       userExists: (userId) => Promise.resolve(true),
+    });
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(result, AlreadyExists);
+  });
+
+  it("User cannot be created if group with that id exists", async () => {
+    const result = await createUser(ctx, root, requestData, {
+      ...baseRepository,
+      groupExists: (userId) => Promise.resolve(true),
     });
     assert.isTrue(Result.isErr(result));
     assert.instanceOf(result, AlreadyExists);

--- a/api/src/service/group_create.ts
+++ b/api/src/service/group_create.ts
@@ -8,6 +8,7 @@ import { ServiceUser } from "./domain/organization/service_user";
 import { getGlobalPermissions } from "./global_permissions_get";
 import { groupExists } from "./group_query";
 import { store } from "./store";
+import { userExists } from "./user_query";
 
 interface Group {
   id: string;
@@ -24,6 +25,7 @@ export async function createGroup(
   const groupCreateResult = await GroupCreate.createGroup(ctx, serviceUser, requestData, {
     getGlobalPermissions: async () => getGlobalPermissions(conn, ctx, serviceUser),
     groupExists: async (groupId) => groupExists(conn, ctx, serviceUser, groupId),
+    userExists: async (groupId) => userExists(conn, ctx, serviceUser, groupId),
   });
   if (Result.isErr(groupCreateResult)) return new VError(groupCreateResult, "create group failed");
   const newEvents = groupCreateResult;

--- a/api/src/service/user_create.ts
+++ b/api/src/service/user_create.ts
@@ -30,6 +30,7 @@ export async function createUser(
     createKeyPair: async () => createkeypairs(conn.multichainClient),
     hash: async (plaintext) => hashPassword(plaintext),
     encrypt: async (plaintext) => encrypt(organizationSecret, plaintext),
+    groupExists: async (userId) => GroupQuery.groupExists(conn, ctx, serviceUser, userId),
   });
   if (Result.isErr(newEventsResult)) {
     return new VError(newEventsResult, "failed to create user");


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
It should not be possible to create a group or a user with an id that is already taken (by a user or a group). So far the check was only done for users on user creation and for groups on group creation. Now both are checked in either case

Closes #943 
