### PR TITLE
ui: Adapt CSP header in nginx config 

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,7 +5,7 @@ server {
     add_header X-Frame-Options "sameorigin";
     add_header X-Content-Type-Options "nosniff";
     # If data mus be fetched from external servers (e.g. exchange rates), add the URL to connect-src:
-    add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://sdw-wsrest.ecb.europa.eu/service/data/EXR/; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; child-src 'self' blob:; frame-ancestors 'self'; form-action 'self'";
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://sdw-wsrest.ecb.europa.eu/service/data/EXR/; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; child-src 'self' blob:; frame-ancestors 'self'; form-action 'self'; script-src 'self' 'unsafe-inline'; object-src 'none'; img-src 'self' data: https://validator.swagger.io;";
 
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;


### PR DESCRIPTION
## Issue
The swagger documentation doesn't work in deployment besides from localhost.

## Solution

This PR adds a few csp header entries to the nginx of Trubudget's frontend

- [ ] Add "script-src 'unsafe-inline'" and "img-src data: https://validator.swagger.io" which is needed for swagger docs
- [ ] Add object-src none which is best practice



### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [ ] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description



