### PR TITLE
Fix filter in document caching

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -45,10 +45,11 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x]
-        project: [
+        project:
+          [
             frontend,
             api,
-            # blockchain,
+            blockchain,
             provisioning,
             e2e-test,
             excel-export-service,

--- a/api/src/service/cache2.ts
+++ b/api/src/service/cache2.ts
@@ -204,7 +204,7 @@ export function getCacheInstance(ctx: Ctx, cache: Cache2): CacheInstance {
             return false;
         }
       };
-      return cache.eventsByStream.get("offchain_documents") || [].filter(documentFilter);
+      return (cache.eventsByStream.get("offchain_documents") || []).filter(documentFilter);
     },
     getStorageServiceUrlPublishedEvents: (): Result.Type<BusinessEvent[]> => {
       logger.trace("Getting storageserviceurl-published events from cache");
@@ -216,7 +216,7 @@ export function getCacheInstance(ctx: Ctx, cache: Cache2): CacheInstance {
             return false;
         }
       };
-      return cache.eventsByStream.get("offchain_documents") || [].filter(storageServiceUrlFilter);
+      return (cache.eventsByStream.get("offchain_documents") || []).filter(storageServiceUrlFilter);
     },
     getSecretPublishedEvents: (): Result.Type<BusinessEvent[]> => {
       logger.trace("Getting Secret published events from cache");
@@ -228,7 +228,7 @@ export function getCacheInstance(ctx: Ctx, cache: Cache2): CacheInstance {
             return false;
         }
       };
-      return cache.eventsByStream.get("offchain_documents") || [].filter(secretPhublishedFilter);
+      return (cache.eventsByStream.get("offchain_documents") || []).filter(secretPhublishedFilter);
     },
 
     getProjects: async (): Promise<Project.Project[]> => {


### PR DESCRIPTION
### Description
The fix in #1024 was not sufficient. The documents were still uploaded to the cache because of a bug in how the  filter in the document caching was applied

Closes #1022
