### PR TITLE
Fix bug in getting offchain docs

### DIFF
--- a/api/src/service/workflowitem_document_download.ts
+++ b/api/src/service/workflowitem_document_download.ts
@@ -44,7 +44,9 @@ export async function getDocument(
           1,
         );
 
-        const documentEvents: WorkflowitemDocumentUploaded.Event[] = items.map((i) => i.data.json);
+        const documentEvents: WorkflowitemDocumentUploaded.Event[] = items
+          .filter((i) => i.data.json.type === "workflowitem_document_uploaded")
+          .map((i) => i.data.json);
         if (documentEvents.length > 1) {
           logger.warn("Duplicate document with this id");
           return new VError(


### PR DESCRIPTION
### Description
Add a fix to a bug in #1024 where all events from the `offchain_documents` stream were loaded as offchain docs, instead of just events with type `workflowitem_document_uploaded`. This caused errors when getting docs stored in the external storage service.

