### PR TITLE
Change multichain logs to debug level

### DIFF
--- a/blockchain/src/connectToChain.js
+++ b/blockchain/src/connectToChain.js
@@ -92,13 +92,15 @@ function startSlave(
   const mc = spawn(prog, args);
 
   mc.stdout.on("data", (data) => {
-    mdLog.info(`${data}`);
+    mdLog.debug(`${data}`);
     const regex = new RegExp("[0-9a-zA-Z]{30,40}");
     const match = regex.exec(data);
     if (match) address = match[0];
   });
 
-  mc.stderr.on("data", (err) => log.error({ err }, "Error in Slave"));
+  mc.stderr.on("data", (err) =>
+    log.error(Buffer.from(err).toString(), "Error in Slave"),
+  );
 
   mc.on("close", (code, signal) =>
     mdLog.warn(


### PR DESCRIPTION
Fix log output on multichain error

### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [ ] I fixed all necessary PR warnings
- [x] The commit history is clean
- [ ] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description

In this PR 
- multichain logs are changed to debug level instead of info since it's not very readable on log_level info
- a log output is fixed where only a buffer was shown instead of the actual readable error message

