### PR TITLE
Special chars in fileName fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ### Fixed -->
 
+## [1.29.1] - 2022-03-02
+
+<!-- ### Added -->
+
+<!-- ### Changed -->
+
+<!-- ### Deprecated -->
+
+<!-- ### Removed -->
+
+### Fixed
+
+- Fixed a bug where it was not possible to upload documents to a workflowitem if the file name contained special characters or accents [#1079](https://github.com/openkfw/TruBudget/pull/1079)
+
 ## [1.29.0] - 2022-03-02
 
 ### Added

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.21.4",
         "bcryptjs": "^2.4.3",
         "better-npm-audit": "^3.4.0",
+        "content-disposition": "^0.5.4",
         "fastify": "^3.11.0",
         "fastify-cors": "^6.0.2",
         "fastify-helmet": "^5.3.2",

--- a/api/package.json
+++ b/api/package.json
@@ -73,6 +73,7 @@
     "axios": "^0.21.4",
     "bcryptjs": "^2.4.3",
     "better-npm-audit": "^3.4.0",
+    "content-disposition": "^0.5.4",
     "fastify": "^3.11.0",
     "fastify-cors": "^6.0.2",
     "fastify-helmet": "^5.3.2",

--- a/api/src/service/Client_storage_service.ts
+++ b/api/src/service/Client_storage_service.ts
@@ -72,7 +72,7 @@ export default class StorageServiceClient implements StorageServiceClientI {
     logger.debug(`Uploading Object "${name}"`);
 
     let requestData: UploadRequest = {
-      fileName: name,
+      fileName: encodeURIComponent(name),
       content: data,
     };
     if (config.encryptionPassword) {
@@ -103,7 +103,7 @@ export default class StorageServiceClient implements StorageServiceClientI {
 
     let documentObject: StorageObject = {
       id: DownloadResponseResult.data.meta.docid,
-      fileName: DownloadResponseResult.data.meta.filename,
+      fileName: decodeURIComponent(DownloadResponseResult.data.meta.filename),
       base64: DownloadResponseResult.data.data,
     };
 

--- a/api/src/workflowitem_download_document.ts
+++ b/api/src/workflowitem_download_document.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance, RequestGenericInterface } from "fastify";
 import { VError } from "verror";
+import * as contentDisposition from "content-disposition";
 
 import { toHttpError } from "./http_errors";
 import * as NotAuthenticated from "./http_errors/not_authenticated";
@@ -133,7 +134,7 @@ export function addHttpHandler(server: FastifyInstance, urlPrefix: string, servi
         const code = 200;
         reply.headers({
           "Content-Type": "application/octet-stream",
-          "Content-Disposition": `attachment; filename="${documentResult.fileName}"`,
+          "Content-Disposition": contentDisposition(documentResult.fileName),
         });
 
         reply.status(code).send(Buffer.from(documentResult.base64, "base64"));

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "better-npm-audit": "^3.4.0",
         "chart.js": "^2.9.3",
         "connected-react-router": "^6.6.1",
+        "content-disposition-attachment": "^0.2.0",
         "date-fns": "^2.16.1",
         "dayjs": "^1.8.14",
         "downshift": "^2.0.16",
@@ -6103,6 +6104,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/content-disposition-attachment": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/content-disposition-attachment/-/content-disposition-attachment-0.2.0.tgz",
+      "integrity": "sha512-6N6SIvW2ebxxGwXZkFbPoXvbIPAewuUP2Z+TexH0mZIaT2hhWPFUBNmCLSFGbLERBYcd9BKDn2DubBkVvSJ36w=="
     },
     "node_modules/content-disposition/node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -23519,6 +23525,11 @@
           "dev": true
         }
       }
+    },
+    "content-disposition-attachment": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/content-disposition-attachment/-/content-disposition-attachment-0.2.0.tgz",
+      "integrity": "sha512-6N6SIvW2ebxxGwXZkFbPoXvbIPAewuUP2Z+TexH0mZIaT2hhWPFUBNmCLSFGbLERBYcd9BKDn2DubBkVvSJ36w=="
     },
     "content-type": {
       "version": "1.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "better-npm-audit": "^3.4.0",
     "chart.js": "^2.9.3",
     "connected-react-router": "^6.6.1",
+    "content-disposition-attachment": "^0.2.0",
     "date-fns": "^2.16.1",
     "dayjs": "^1.8.14",
     "downshift": "^2.0.16",


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
Upload of documents failed if file name contained special characters. MinIO does not support special characters in the metadata field (where the file name was saved).

- [x] the file name was encoded in the api before sending it to the storage service and after receiving it, so it is saved without special characters on MinIO.
- [x] the `content-disposition` header that was set by the api in the response for `documentl.download` is also not allowed to contain special characters - so the libraries [content-disposition](https://www.npmjs.com/package/content-disposition) on the api side and [content-disposition-attachment](https://github.com/lujjjh/content-disposition-attachment) in the frontend were used to encode & decode the header

Closes #1054 
