### PR TITLE
provisioning: Return exit 1 on failure, retry on status code 500-504

### DIFF
--- a/provisioning/src/index.js
+++ b/provisioning/src/index.js
@@ -657,10 +657,8 @@ const provisionBlockchain = async (host, port, rootSecret, organization) => {
     log.info("Set provision_ended flag on multichain");
     await setProvisionEndFlag(axios);
   } catch (err) {
-    log.warn({ err }, "Provisioning failed");
-    if (err.code && err.code === "MAX_RETRIES") {
-      process.exit(1);
-    }
+    log.error({ err }, "Provisioning failed");
+    process.exit(1);
   }
 };
 

--- a/provisioning/src/lib.js
+++ b/provisioning/src/lib.js
@@ -21,15 +21,15 @@ async function withRetry(cb, maxTimes = 24, timeoutMs = 20000) {
       log.error({ err: err.data.error.message }, "The request had no effect");
     } else if (
       // Stop provisioning but retry same request
-      (err.status >= 400 && err.status < 500) ||
+      (err.status >= 400 && err.status <= 504) ||
       (!err.response && err.code === "ECONNREFUSED") ||
       (!err.response && err.code === "ECONNABORTED") ||
       (!err.response && err.code === "ECONNRESET")
     ) {
       log.warn(
-        `Server Error with status code ${err.status} (${
-          err.data.error.message
-        }), retry in ${timeoutMs / 1000} seconds`
+        `Server Error with status code ${err.status} (${err.data}), retry in ${
+          timeoutMs / 1000
+        } seconds`
       );
       await timeout(timeoutMs);
       return await withRetry(cb, --maxTimes);


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [ ] I fixed all necessary PR warnings
- [ ] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [ ] I did a self review before requesting a review from another team member

### Description

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes ModifyMe
