### PR TITLE
api: Fix storage service readiness call

### DIFF
--- a/api/src/service/Client_storage_service.ts
+++ b/api/src/service/Client_storage_service.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import { performance } from "perf_hooks";
 import { VError } from "verror";
 import * as Result from "../result";
@@ -47,11 +47,12 @@ export default class StorageServiceClient implements StorageServiceClientI {
   }
 
   public async isReady(): Promise<boolean> {
-    return this.axiosInstance.get("/readiness");
+    const result: AxiosResponse<any> = await this.axiosInstance.get("/readiness");
+    return result.status === 200;
   }
 
   public async getVersion(): Promise<Version> {
-    const result = await this.axiosInstance.get("/version");
+    const result: AxiosResponse<any> = await this.axiosInstance.get("/version");
     if (result.status !== 200) {
       return {
         release: "",

--- a/provisioning/src/lib.js
+++ b/provisioning/src/lib.js
@@ -27,9 +27,9 @@ async function withRetry(cb, maxTimes = 24, timeoutMs = 20000) {
       (!err.response && err.code === "ECONNRESET")
     ) {
       log.warn(
-        `Server Error with status code ${err.status} (${err.data}), retry in ${
-          timeoutMs / 1000
-        } seconds`
+        `Server Error with status code ${err.status}, ${
+          err.code
+        }:  (${JSON.stringify(err.data)}), retry in ${timeoutMs / 1000} seconds`
       );
       await timeout(timeoutMs);
       return await withRetry(cb, --maxTimes);


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [ ] I fixed all necessary PR warnings
- [ ] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [ ] I did a self review before requesting a review from another team member

### Description

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes ModifyMe
