### PR TITLE
storage-service: Check minio status on readiness

### DIFF
--- a/storage-service/src/minio.ts
+++ b/storage-service/src/minio.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import * as Minio from "minio";
 import { v4 } from "uuid";
 import config from "./config";
@@ -37,6 +38,18 @@ const minioClient: any = new Minio.Client({
 });
 
 const bucketName: string = config.storage.bucketName;
+
+export const getMinioStatus = async () => {
+  try {
+    await axios.get(
+      `http://${config.storage.host}:${config.storage.port}/minio/health/ready`,
+    );
+  } catch (error) {
+    log.error({ error }, "Error during health check on minio-server");
+    return { status: 504, statusText: "Not ready. Waiting for Minio server" };
+  }
+  return { status: 200, statusText: "Ready" };
+};
 
 const makeBucket = (bucket: string, cb: Function) => {
   minioClient.bucketExists(bucket, (err: any, exists: any) => {


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/master/CONTRIBUTING.md).
- [ ] I fixed all necessary PR warnings
- [ ] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [ ] I did a self review before requesting a review from another team member

### Description

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes ModifyMe
