### PR TITLE
Change blockchain persistence to volumes

### DIFF
--- a/blockchain/package-lock.json
+++ b/blockchain/package-lock.json
@@ -4094,9 +4094,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
-      "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.0.tgz",
+      "integrity": "sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -10444,9 +10444,9 @@
       }
     },
     "jose": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
-      "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g=="
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.0.tgz",
+      "integrity": "sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw=="
     },
     "joycon": {
       "version": "3.1.1",

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -120,6 +120,38 @@ If the configuration looks fine start the whole setup with `docker-compose up`.
 docker-compose --project-directory . -f blockchain/docker-compose.alphanode.yml -f excel-export-service/docker-compose.yml -f storage-service/docker-compose.yml -f storage-service/persistence.docker-compose.yml -f blockchain/persistence.docker-compose.yml -f api/docker-compose.yml -f frontend/docker-compose.yml up
 ```
 
+## Persistence
+
+There are two options how to persist data of a container:
+
+1. Bind-Mount
+   This option mounts a folder of the host system into the container. This is NOT recommended. There are limitations to that option. Since TruBudget is using non-root users to run a container the folder on the host system has to have the same user rights set before mounted into the container. Details can be found in the [official docker documentation](https://docs.docker.com/storage/bind-mounts/).
+
+   Example of a bind-mount
+
+   ```
+    version: "3"
+    services:
+      blockchain:
+        volumes:
+          - /tmp/alpha_chain:${MULTICHAIN_DIR}
+   ```
+
+2. Volume
+   This option mounts a volume create via docker into the container. This is the recommended option for TruBudget's persisted services. Details can be found in the [official docker documentation](https://docs.docker.com/storage/volumes/).
+   Example of a bind-mount
+
+   ```
+    version: "3"
+    services:
+      blockchain:
+        volumes:
+          - alpha-volume:${MULTICHAIN_DIR}
+
+    volumes:
+      alpha-volume:
+   ```
+
 ## E2E-test
 
 To run the E2E-test a provisioned TruBudget instance has to be up and running. To achieve this execute following command first:

--- a/docker-compose/blockchain/docker-compose.alphanode.yml
+++ b/docker-compose/blockchain/docker-compose.alphanode.yml
@@ -8,6 +8,7 @@ services:
       MULTICHAIN_RPC_PORT: ${MULTICHAIN_RPC_PORT}
       ORGANIZATION: ${ORGANIZATION}
       P2P_PORT: ${P2P_PORT}
+      MULTICHAIN_DIR: ${MULTICHAIN_DIR}
     # networks:
     #   mynetwork:
     #     ipv4_address: 172.20.0.11

--- a/docker-compose/blockchain/persistence.docker-compose.yml
+++ b/docker-compose/blockchain/persistence.docker-compose.yml
@@ -3,4 +3,7 @@ version: "3"
 services:
   blockchain:
     volumes:
-      - ./alphaVolume:${MULTICHAIN_DIR}/.multichain
+      - alpha-volume:${MULTICHAIN_DIR}
+
+volumes:
+  alpha-volume:


### PR DESCRIPTION
### Description

This PR changes the bind-mount persistence of blockchain's docker-compose file to volume since it's not possible to mount a folder with bind-mount with the latest blockchain image. 
The latest image is using a non-root user. Using volumes there is no issue, but using bind-mount the folder on the host system has to have permissions set to the non-root user in the container which could be a user not existing on the host.

There is also a doc section added.
