### PR TITLE
Validate assignee when creating workflow item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add additional checks that prevent creation of a workflow item with an assigned user that has a disabled account or does not exist.
 - Add a warning in the workflowitem dialog for overwriting permissions [#1189](https://github.com/openkfw/TruBudget/issues/1189)
 - Add Budgets in Table-View [#1226](https://github.com/openkfw/TruBudget/issues/1226)
 - Add Button to view additional data object in Table-View [#1203](https://github.com/openkfw/TruBudget/issues/1203)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Add additional checks that prevent creation of a workflow item with an assigned user that has a disabled account or does not exist. [#1327](https://github.com/openkfw/TruBudget/issues/1327)
 - Fixed a bug where restoring a backup corrupts the blockchain [#1285](https://github.com/openkfw/TruBudget/issues/1285)
 - Fixed a bug where downloading documents from other organizations in a network was not possible in a specific edge-case [#1192](https://github.com/openkfw/TruBudget/issues/1192)
 - Fixed a bug where HTTP 500 errors with different causes would result in displaying the same message that is not relevant to the error itself [#1319](https://github.com/openkfw/TruBudget/issues/1319)
@@ -37,7 +38,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add additional checks that prevent creation of a workflow item with an assigned user that has a disabled account or does not exist.
 - Add a warning in the workflowitem dialog for overwriting permissions [#1189](https://github.com/openkfw/TruBudget/issues/1189)
 - Add Budgets in Table-View [#1226](https://github.com/openkfw/TruBudget/issues/1226)
 - Add Button to view additional data object in Table-View [#1203](https://github.com/openkfw/TruBudget/issues/1203)

--- a/api/src/service/domain/workflow/workflowitem_create.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.spec.ts
@@ -41,6 +41,7 @@ describe("Create workflowitem", () => {
 
     const result = await WorkflowitemCreate.createWorkflowitem(ctx, root, data, {
       workflowitemExists: async (_projectId, _subprojectId, _workflowitemId) => false,
+      userExists: async (_userId) => false,
       getSubproject: async () => baseSubproject,
       applyWorkflowitemType: () => [],
       uploadDocumentToStorageService: () => Promise.resolve([]),
@@ -62,6 +63,7 @@ describe("Create workflowitem", () => {
 
     const result = await WorkflowitemCreate.createWorkflowitem(ctx, alice, data, {
       workflowitemExists: async (_projectId, _subprojectId, _workflowitemId) => false,
+      userExists: async (_userId) => false,
       getSubproject: async () => baseSubproject,
       applyWorkflowitemType: () => [],
       uploadDocumentToStorageService: () => Promise.resolve([]),

--- a/api/src/service/domain/workflow/workflowitem_create.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.spec.ts
@@ -41,7 +41,7 @@ describe("Create workflowitem", () => {
 
     const result = await WorkflowitemCreate.createWorkflowitem(ctx, root, data, {
       workflowitemExists: async (_projectId, _subprojectId, _workflowitemId) => false,
-      userExists: async (_userId) => false,
+      userExists: async (_userId) => true,
       getSubproject: async () => baseSubproject,
       applyWorkflowitemType: () => [],
       uploadDocumentToStorageService: () => Promise.resolve([]),
@@ -63,7 +63,7 @@ describe("Create workflowitem", () => {
 
     const result = await WorkflowitemCreate.createWorkflowitem(ctx, alice, data, {
       workflowitemExists: async (_projectId, _subprojectId, _workflowitemId) => false,
-      userExists: async (_userId) => false,
+      userExists: async (_userId) => true,
       getSubproject: async () => baseSubproject,
       applyWorkflowitemType: () => [],
       uploadDocumentToStorageService: () => Promise.resolve([]),

--- a/api/src/service/domain/workflow/workflowitem_create.spec.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.spec.ts
@@ -5,6 +5,8 @@ import * as Result from "../../../result";
 import { PreconditionError } from "../errors/precondition_error";
 import { ServiceUser } from "../organization/service_user";
 import { Subproject } from "./subproject";
+import { UserRecord } from "../organization/user_record";
+import { Permissions } from "../permissions";
 import * as WorkflowitemCreate from "./workflowitem_create";
 
 const ctx: Ctx = { requestId: "", source: "test" };
@@ -29,6 +31,32 @@ const baseSubproject: Subproject = {
   additionalData: {},
 };
 
+const normalUser: UserRecord = {
+  id: "test",
+  createdAt: new Date().toISOString(), // ISO timestamp
+  displayName: "testuser",
+  organization: "Test Org",
+  passwordHash: "abc",
+  address: "testaddress",
+  encryptedPrivKey: "abcd",
+  permissions: {["user.authenticate"]: ["test"]},
+  log: [],
+  additionalData: {}
+}
+
+const disabledUser: UserRecord = {
+  id: "test",
+  createdAt: new Date().toISOString(), // ISO timestamp
+  displayName: "testuser",
+  organization: "Test Org",
+  passwordHash: "abc",
+  address: "testaddress",
+  encryptedPrivKey: "abcd",
+  permissions: {}, // no auth permissions
+  log: [],
+  additionalData: {}
+}
+
 describe("Create workflowitem", () => {
   it("Root cannot create a workflow item", async () => {
     const data: WorkflowitemCreate.RequestData = {
@@ -42,6 +70,7 @@ describe("Create workflowitem", () => {
     const result = await WorkflowitemCreate.createWorkflowitem(ctx, root, data, {
       workflowitemExists: async (_projectId, _subprojectId, _workflowitemId) => false,
       userExists: async (_userId) => true,
+      getUser: async (_userId) => normalUser,
       getSubproject: async () => baseSubproject,
       applyWorkflowitemType: () => [],
       uploadDocumentToStorageService: () => Promise.resolve([]),
@@ -64,6 +93,53 @@ describe("Create workflowitem", () => {
     const result = await WorkflowitemCreate.createWorkflowitem(ctx, alice, data, {
       workflowitemExists: async (_projectId, _subprojectId, _workflowitemId) => false,
       userExists: async (_userId) => true,
+      getUser: async (_userId) => normalUser,
+      getSubproject: async () => baseSubproject,
+      applyWorkflowitemType: () => [],
+      uploadDocumentToStorageService: () => Promise.resolve([]),
+      getAllDocumentReferences: async () => [],
+    });
+
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(Result.unwrapErr(result), PreconditionError);
+  });
+
+  it("Cannot create a workflow item if the assigned user does not exist!", async () => {
+    const data: WorkflowitemCreate.RequestData = {
+      projectId: "test",
+      subprojectId: "dummy-subproject",
+      displayName: "test",
+      amountType: "N/A",
+      workflowitemType: "general",
+    };
+
+    const result = await WorkflowitemCreate.createWorkflowitem(ctx, alice, data, {
+      workflowitemExists: async (_projectId, _subprojectId, _workflowitemId) => false,
+      userExists: async (_userId) => false,
+      getUser: async (_userId) => normalUser,
+      getSubproject: async () => baseSubproject,
+      applyWorkflowitemType: () => [],
+      uploadDocumentToStorageService: () => Promise.resolve([]),
+      getAllDocumentReferences: async () => [],
+    });
+
+    assert.isTrue(Result.isErr(result));
+    assert.instanceOf(Result.unwrapErr(result), PreconditionError);
+  });
+
+  it("Cannot create a workflow item if the assigned user is disabled!", async () => {
+    const data: WorkflowitemCreate.RequestData = {
+      projectId: "test",
+      subprojectId: "dummy-subproject",
+      displayName: "test",
+      amountType: "N/A",
+      workflowitemType: "general",
+    };
+
+    const result = await WorkflowitemCreate.createWorkflowitem(ctx, alice, data, {
+      workflowitemExists: async (_projectId, _subprojectId, _workflowitemId) => false,
+      userExists: async (_userId) => false,
+      getUser: async (_userId) => disabledUser,
       getSubproject: async () => baseSubproject,
       applyWorkflowitemType: () => [],
       uploadDocumentToStorageService: () => Promise.resolve([]),

--- a/api/src/service/domain/workflow/workflowitem_create.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.ts
@@ -77,6 +77,9 @@ interface Repository {
     subprojectId: string,
     workflowitemId: string,
   ): Promise<boolean>;
+  userExists(
+    userId: string
+  ): Promise<Result.Type<boolean>>;
   getSubproject(
     projectId: string,
     subprojectId: string,
@@ -201,6 +204,14 @@ export async function createWorkflowitem(
     return new AlreadyExists(ctx, workflowitemCreated, workflowitemCreated.workflowitem.id);
   }
 
+  logger.trace({ item: workflowitemCreated }, "Check if assignee exists");
+  const isUserExists = await repository.userExists(
+    workflowitemCreated.workflowitem.assignee
+  );
+
+  if(!isUserExists) {
+    return new VError("user exists check failed");
+  }
   const subprojectResult = await repository.getSubproject(reqData.projectId, reqData.subprojectId);
   if (Result.isErr(subprojectResult)) {
     return new VError(subprojectResult, "failed to get subproject");

--- a/api/src/service/domain/workflow/workflowitem_create.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.ts
@@ -239,7 +239,7 @@ export async function createWorkflowitem(
     return new PreconditionError(
       ctx,
       workflowitemCreated,
-      "disabled users are not allowed to create workflow items!"
+      "disabled users are not allowed to be assigned to workflowitems"
     );
   }
 

--- a/api/src/service/domain/workflow/workflowitem_create.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.ts
@@ -235,7 +235,7 @@ export async function createWorkflowitem(
 
   const userPermissions = userResult.permissions;
 
-  if(userPermissions["user.authenticate"] === undefined || userPermissions["user.authenticate"].length === 0) {
+  if(!userPermissions["user.authenticate"] || !userPermissions["user.authenticate"].length) {
     return new PreconditionError(
       ctx,
       workflowitemCreated,

--- a/api/src/service/domain/workflow/workflowitem_create.ts
+++ b/api/src/service/domain/workflow/workflowitem_create.ts
@@ -210,7 +210,10 @@ export async function createWorkflowitem(
   );
 
   if(!isUserExists) {
-    return new VError("user exists check failed");
+    return new PreconditionError(
+      ctx,
+      workflowitemCreated,
+      "assigned user does not exist!");
   }
   const subprojectResult = await repository.getSubproject(reqData.projectId, reqData.subprojectId);
   if (Result.isErr(subprojectResult)) {

--- a/api/src/service/workflowitem_create.ts
+++ b/api/src/service/workflowitem_create.ts
@@ -46,6 +46,11 @@ export async function createWorkflowitem(
       ) => {
         return userExists(conn, ctx, serviceUser, userId);
       },
+      getUser: async (
+        userId: string
+      ) =>  {
+        return UserQuery.getUser(conn, ctx, serviceUser, userId)
+      },
       getSubproject: async (projectId: string, subprojectId: string) =>
         cache.getSubproject(projectId, subprojectId),
       applyWorkflowitemType: (event: BusinessEvent, workflowitem: Workflowitem.Workflowitem) => {

--- a/api/src/service/workflowitem_create.ts
+++ b/api/src/service/workflowitem_create.ts
@@ -7,6 +7,7 @@ import * as Cache from "./cache2";
 import { StorageServiceClientI } from "./Client_storage_service.h";
 import { ConnToken } from "./conn";
 import { BusinessEvent } from "./domain/business_event";
+import { userExists } from "./domain/organization/user_query";
 import * as DocumentGet from "./domain/document/document_get";
 import * as DocumentUpload from "./domain/document/document_upload";
 import * as DocumentUploaded from "./domain/document/document_uploaded";
@@ -39,6 +40,11 @@ export async function createWorkflowitem(
       ) => {
         const item = await cache.getWorkflowitem(projectId, subprojectId, workflowitemId);
         return Result.isOk(item);
+      },
+      userExists: async (
+        userId: string
+      ) => {
+        return userExists(conn, ctx, serviceUser, userId);
       },
       getSubproject: async (projectId: string, subprojectId: string) =>
         cache.getSubproject(projectId, subprojectId),


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

2 validations on API Level are added:
1- Disabled users are not allowed to be assigned to workflow items.
2- Users that do not exist are not allowed to be assigned to workflow items.

Closes #1327 
