### PR TITLE
fe: add fe password validation when creating user

### DIFF
--- a/e2e-test/cypress/integration/users_spec.js
+++ b/e2e-test/cypress/integration/users_spec.js
@@ -87,11 +87,11 @@ describe("Users/Groups Dashboard", function() {
       .type("testuser")
       .should("have.value", "testuser");
     cy.get("[data-test=password-new-user] input")
-      .type("test")
-      .should("have.value", "test");
+      .type("Testing1")
+      .should("have.value", "Testing1");
     cy.get("[data-test=password-new-user-confirm] input")
-      .type("test")
-      .should("have.value", "test");
+      .type("Testing1")
+      .should("have.value", "Testing1");
     cy.get("[data-test=submit]").click();
   });
 
@@ -113,11 +113,11 @@ describe("Users/Groups Dashboard", function() {
       .type("root")
       .should("have.value", "root");
     cy.get("[data-test=password-new-user] input")
-      .type("test")
-      .should("have.value", "test");
+      .type("Testing1")
+      .should("have.value", "Testing1");
     cy.get("[data-test=password-new-user-confirm] input")
-      .type("test")
-      .should("have.value", "test");
+      .type("Testing1")
+      .should("have.value", "Testing1");
     cy.get("[data-test=submit]").click();
     cy.get("#username-helper-text").contains("Invalid login ID");
     cy.get("[data-test=cancel]").click();
@@ -132,11 +132,11 @@ describe("Users/Groups Dashboard", function() {
       .type("newUser")
       .should("have.value", "newUser");
     cy.get("[data-test=password-new-user] input")
-      .type("password")
-      .should("have.value", "password");
+      .type("password1")
+      .should("have.value", "password1");
     cy.get("[data-test=password-new-user-confirm] input")
-      .type("differentPassword")
-      .should("have.value", "differentPassword");
+      .type("differentPassword1")
+      .should("have.value", "differentPassword1");
     cy.get("[data-test=submit]").click();
     cy.get("[data-test=password-new-user-confirm]").contains("Passwords don't match");
   });

--- a/frontend/src/pages/Users/UserDialogContent.js
+++ b/frontend/src/pages/Users/UserDialogContent.js
@@ -49,7 +49,8 @@ const UserDialogContent = ({
   organization,
   usernameInvalid,
   setConfirmPassword,
-  hasNewPasswordFailed
+  hasNewPasswordFailed,
+  failedText
 }) => {
   const { displayName, password, username } = user;
 
@@ -102,7 +103,7 @@ const UserDialogContent = ({
           label={strings.users.new_user_password_confirmation}
           failed={hasNewPasswordFailed}
           data-test="password-new-user-confirm"
-          failedText={strings.users.no_password_match}
+          failedText={failedText}
         />
       </div>
     </div>


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description

Password validation in backend is turned on only if `NODE_ENV == production`. For testing purposes, either set the environment variable to production, or enforce strict `safePasswordSchema` in `api/src/lib/joiValidation.ts`.

Provisioning users, however, fails under these conditions, because their passwords do not meet the conditions.

Requirements are at least 8 characters, at least 1 number, at least one letter. 

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #1421
