### PR TITLE
api: hide 400 error details from user

### DIFF
--- a/api/src/http_errors.ts
+++ b/api/src/http_errors.ts
@@ -25,6 +25,14 @@ export function toHttpError(error: unknown | unknown[]): { code: number; body: E
     code: Math.max(acc.code, err.code),
     message: acc.message === "" ? err.message : `${acc.message}, ${err.message}`,
   }));
+  // don't reveal details in case of authentication issue
+  // - replace error message with generic "authentication failed"
+  if (httpError.code === 400) {
+    return {
+      code: httpError.code,
+      body: toErrorBody({ code: httpError.code, message: "authentication failed" }),
+    };
+  }
   return { code: httpError.code, body: toErrorBody(httpError) };
 }
 


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description

Please see https://github.com/openkfw/TruBudget/issues/1424 .
To test, try logging in with existing user and incorrect password. Try logging in with non-existing user.
Message in the body of http response should be the same. 
API logs are  unchanged: ifferent error messages are published in these scenarios. It's just the details going back to the client that are censored.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #1424 
