### PR TITLE
add push to quay.io

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -156,6 +156,8 @@ jobs:
       PRIVATE_REGISTRY_PASSWORD: ${{ secrets.PRIVATE_REGISTRY_PASSWORD}}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME}}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD}}
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME}}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD}}
       IMAGE_NAME: ${{ matrix.image_name}}
 
     steps:

--- a/scripts/pipeline/publish-docker-images.sh
+++ b/scripts/pipeline/publish-docker-images.sh
@@ -88,6 +88,10 @@ then
     # log into docker hub
     echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     docker push "$TAG"
+    # also log into quay and push
+    echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+    docker tag "$TAG" "quay.io/$TAG"
+    docker push "quay.io/$TAG"
 fi
 
 # if new release is published push 2 images:
@@ -103,4 +107,10 @@ then
     docker push "$TAG_RELEASE"
     docker tag "$TAG" "$TAG_LATEST"
     docker push "$TAG_LATEST"
+    # also log into quay and push
+    echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+    docker tag "$TAG" "quay.io/$TAG_RELEASE"
+    docker push "quay.io/$TAG_RELEASE"
+    docker tag "$TAG" "quay.io/$TAG_LATEST"
+    docker push "quay.io/$TAG_LATEST"
 fi


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

extend github actions to also push images to [quay.io/trubudget](https://quay.io/organization/trubudget)

- added robot to action secrets
- updated github build action
