### PR TITLE
ui: replace deprecated ListItem button in side nav

### DIFF
--- a/frontend/src/pages/Navbar/SideNavCard.js
+++ b/frontend/src/pages/Navbar/SideNavCard.js
@@ -8,12 +8,13 @@ import ExportIcon from "@mui/icons-material/ListAlt";
 import SocialNotificationIcon from "@mui/icons-material/NotificationsActive";
 import UsersIcon from "@mui/icons-material/PeopleOutline";
 import SettingsIcon from "@mui/icons-material/Settings";
-import { IconButton } from "@mui/material";
 import Avatar from "@mui/material/Avatar";
 import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
+import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Subheader from "@mui/material/ListSubheader";
@@ -99,46 +100,46 @@ const SideNavCard = ({
       </div>
       <List>
         <Subheader>{strings.navigation.selections}</Subheader>
-        <ListItem onClick={() => navigate("/")} data-test="side-navigation-projects">
+        <ListItemButton onClick={() => navigate("/")} data-test="side-navigation-projects">
           <ListItemIcon>
             <ProjectIcon />
           </ListItemIcon>
           <ListItemText primary={strings.navigation.menu_item_projects} />
-        </ListItem>
-        <ListItem onClick={() => navigate("/notifications")} data-test="side-navigation-notifications">
+        </ListItemButton>
+        <ListItemButton onClick={() => navigate("/notifications")} data-test="side-navigation-notifications">
           <ListItemIcon>
             <SocialNotificationIcon />
           </ListItemIcon>
           <ListItemText primary={strings.navigation.menu_item_notifications} />
-        </ListItem>
-        <ListItem onClick={() => navigate("/users")} data-test="side-navigation-users">
+        </ListItemButton>
+        <ListItemButton onClick={() => navigate("/users")} data-test="side-navigation-users">
           <ListItemIcon>
             <UsersIcon />
           </ListItemIcon>
           <ListItemText primary={strings.navigation.menu_item_users} />
-        </ListItem>
+        </ListItemButton>
         {nodeDashboardEnabled ? (
-          <ListItem onClick={() => navigate("/nodes")} data-test="side-navigation-nodes">
+          <ListItemButton onClick={() => navigate("/nodes")} data-test="side-navigation-nodes">
             <ListItemIcon>
               <NodesIcon />
             </ListItemIcon>
             <ListItemText primary={strings.nodesDashboard.nodes} />
-          </ListItem>
+          </ListItemButton>
         ) : null}
         {exportServiceAvailable ? (
-          <ListItem onClick={() => exportData(environment)} data-test="side-navigation-export">
+          <ListItemButton onClick={() => exportData(environment)} data-test="side-navigation-export">
             <ListItemIcon>
               <ExportIcon />
             </ListItemIcon>
             <ListItemText primary={strings.navigation.menu_item_export} />
-          </ListItem>
+          </ListItemButton>
         ) : null}
-        <ListItem onClick={() => navigate("/status")} data-test="side-navigation-service-status">
+        <ListItemButton onClick={() => navigate("/status")} data-test="side-navigation-service-status">
           <ListItemIcon>
             <StatusIcon />
           </ListItemIcon>
           <ListItemText primary={strings.navigation.service_status} />
-        </ListItem>
+        </ListItemButton>
       </List>
       <Divider />
       {userId === "root" ? (

--- a/frontend/src/pages/Overview/reducer.js
+++ b/frontend/src/pages/Overview/reducer.js
@@ -109,10 +109,14 @@ export default function overviewReducer(state = defaultState, action) {
     case SHOW_PROJECT_ADDITIONAL_DATA:
       return state.merge({
         idForInfo: fromJS(action.id),
-        isProjectAdditionalDataShown: true
+        isProjectAdditionalDataShown: true,
+        isLiveUpdateAllProjectsEnabled: false
       });
     case HIDE_PROJECT_ADDITIONAL_DATA:
-      return state.set("isProjectAdditionalDataShown", false);
+      return state.merge({
+        isProjectAdditionalDataShown: false,
+        isLiveUpdateAllProjectsEnabled: true
+      });
     case HIDE_PROJECT_DIALOG:
       return state.merge({
         projectToAdd: defaultState.getIn(["projectToAdd"]),


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description

`<ListItem button` had been deprecated.

Due to failing tests, project updates had to be paused when editing additional data, otherwise re-render discarded any changes. IDK how were the tests passing until now.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #1444
