### PR TITLE
1453 remove jwt from storage

### DIFF
--- a/api/src/httpd/server.ts
+++ b/api/src/httpd/server.ts
@@ -38,13 +38,13 @@ const addTokenHandling = (server: FastifyInstance, jwtSecret: string): void => {
     secret: jwtSecret,
     cookie: {
       cookieName: "token",
-      signed: true,
+      signed: false,
     },
   });
 
   server.decorate("authenticate", async (request: FastifyRequest, reply: FastifyReply) => {
     try {
-      if (!request.headers.authorization && request.cookies.token) {
+      if (request.cookies.token) {
         request.headers.authorization = `Bearer ${request.cookies.token}`;
       }
       await request.jwtVerify();

--- a/api/src/user_authenticate.ts
+++ b/api/src/user_authenticate.ts
@@ -57,7 +57,6 @@ interface LoginResponse {
     groupId: string;
     displayName: string;
   }>;
-  token: string; // JWT
 }
 
 /**
@@ -121,15 +120,6 @@ const swaggerSchema = {
                         displayName: { type: "string", example: "All Manager Group" },
                       },
                     },
-                  },
-                  token: {
-                    type: "string",
-                    example:
-                      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJyb290IiwiYWRkcm" +
-                      "VzcyI6IjFIVXF2dHE5WU1QaXlMZUxWM3pGRks5dGpBblVDVTNFbTQzaVBrIiwib3JnYW" +
-                      "5pemF0aW9uIjoiS2ZXIiwib3JnYW5pemF0aW9uQWRkcmVzcyI6IjFIVXF2dHE5WU1QaXl" +
-                      "MZUxWM3pGRks5dGpBblVDVTNFbTQzaVBrIiwiZ3JvdXBzIjpbXSwiaWF0IjoxNTM2ODI2M" +
-                      "TkyLCJleHAiOjE1MzY4Mjk3OTJ9.PZbjTpsgnIHjNaDHos9LVwwrckYhpWjv1DDiojskylI",
                   },
                 },
               },
@@ -248,7 +238,6 @@ export function addHttpHandler(
         organization: token.organization,
         allowedIntents: token.allowedIntents,
         groups: groups.map((x) => ({ groupId: x.id, displayName: x.displayName })),
-        token: signedJwt,
       };
       const body = {
         apiVersion: "1.0",
@@ -259,9 +248,9 @@ export function addHttpHandler(
       reply
         .setCookie("token", signedJwt, {
           path: "/",
-          secure: true,
+          secure: process.env.NODE_ENV !== "development",
           httpOnly: true,
-          sameSite: true,
+          sameSite: "strict",
         })
         .status(200)
         .send(body);

--- a/e2e-test/cypress/integration/excel_export_spec.js
+++ b/e2e-test/cypress/integration/excel_export_spec.js
@@ -1,11 +1,6 @@
-let exportBaseUrl = Cypress.config("baseUrl");
+const exportUrl = Cypress.env("EXPORT_SERVICE_BASE_URL") || `${Cypress.config("baseUrl")}/api/export/xlsx`;
 
-if (Cypress.env("EXPORT_SERVICE_BASE_URL")) {
-  exportBaseUrl = Cypress.env("EXPORT_SERVICE_BASE_URL");
-}
-let exportUrl = `${exportBaseUrl}/api/export/xlsx`;
-
-let file = "cypress/fixtures/TruBudget_Export.xlsx";
+let file = "cypress/downloads/TruBudget_Export.xlsx";
 
 before(() => {
   //download directly to fixture folder, without pop-ups
@@ -13,7 +8,7 @@ before(() => {
     cy.wrap(
       Cypress.automation("remote:debugger:protocol", {
         command: "Page.setDownloadBehavior",
-        params: { behavior: "allow", downloadPath: "cypress/fixtures" }
+        params: { behavior: "allow", downloadPath: "cypress/downloads" }
       }),
       { log: false }
     );
@@ -22,7 +17,7 @@ before(() => {
 
 describe("Excel Export feature", function() {
   it("Tests the export of an excel file in english", function() {
-    cy.intercept(exportUrl + "/download?lang=en*").as("export");
+    cy.intercept(`${exportUrl}/download?lang=en`).as("export");
 
     //login
     cy.visit("/");
@@ -32,9 +27,8 @@ describe("Excel Export feature", function() {
     cy.visit("/projects");
     cy.get("[data-test=openSideNavbar]").click();
     cy.get("[data-test=side-navigation]").should("be.visible");
-    cy.get("[data-test=side-navigation-export]")
-      .should("be.visible")
-      .click();
+    cy.get("[data-test=side-navigation-export]").should("be.visible");
+    cy.get("[data-test=side-navigation-export]").click();
 
     // test exported file
     cy.wait("@export").should(interception => {
@@ -63,7 +57,7 @@ describe("Excel Export feature", function() {
   });
 
   it("Tests the export of an excel file in french", function() {
-    cy.intercept(exportUrl + "/download?lang=fr*").as("export");
+    cy.intercept(`${exportUrl}/download?lang=fr*`).as("export");
 
     //login
     cy.visit("/");

--- a/e2e-test/cypress/integration/subproject_permissions_spec.js
+++ b/e2e-test/cypress/integration/subproject_permissions_spec.js
@@ -1,7 +1,7 @@
 import _cloneDeep from "lodash/cloneDeep";
 
 const executingUser = { id: "mstein", displayname: "Mauro Stein" };
-const testUser = { id: "thouse", displayname: "Tom House", password: "test" };
+const testUser = { id: "jdoe", displayname: "Jane Doe", password: "test" };
 const testUser2 = { id: "jxavier", displayname: "Jane Xavier", password: "test" };
 const testUser3 = { id: "pkleffmann", displayname: "Piet Kleffmann" };
 const testGroup = { id: "admins", displayname: "Admins" };
@@ -479,6 +479,8 @@ describe("Subproject Permissions", function() {
       // grant permissions to testgroup
       cy.grantProjectPermission(projectId, "project.list", testGroup.id),
       cy.grantProjectPermission(projectId, "project.viewDetails", testGroup.id),
+      cy.grantProjectPermission(projectId, "project.intent.listPermissions", testGroup.id),
+      cy.grantProjectPermission(projectId, "project.intent.grantPermission", testGroup.id),
       cy.grantSubprojectPermission(projectId, subprojectId, "subproject.list", testGroup.id),
       cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testGroup.id),
       cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testGroup.id),
@@ -487,6 +489,8 @@ describe("Subproject Permissions", function() {
       // Modify permissionsBeforeTestingr regarding theprevious api calls
       permissionsBeforeTesting.project["project.list"].push(testGroup.id);
       permissionsBeforeTesting.project["project.viewDetails"].push(testGroup.id);
+      permissionsBeforeTesting.project["project.intent.listPermissions"].push(testGroup.id);
+      permissionsBeforeTesting.project["project.intent.grantPermission"].push(testGroup.id);
       permissionsBeforeTesting.subproject["subproject.list"].push(testGroup.id);
       permissionsBeforeTesting.subproject["subproject.viewDetails"].push(testGroup.id);
       permissionsBeforeTesting.subproject["subproject.intent.listPermissions"].push(testGroup.id);

--- a/e2e-test/cypress/integration/users_spec.js
+++ b/e2e-test/cypress/integration/users_spec.js
@@ -79,6 +79,8 @@ describe("Users/Groups Dashboard", function() {
   });
 
   it("Create new user", function() {
+    cy.login();
+    cy.visit("/users");
     cy.get("[data-test=create]").click();
     cy.get("[data-test=accountname] input")
       .type("Test User")
@@ -87,15 +89,18 @@ describe("Users/Groups Dashboard", function() {
       .type("testuser")
       .should("have.value", "testuser");
     cy.get("[data-test=password-new-user] input")
-      .type("Testing1")
-      .should("have.value", "Testing1");
+      .type("Testing1Testing1")
+      .should("have.value", "Testing1Testing1");
     cy.get("[data-test=password-new-user-confirm] input")
-      .type("Testing1")
-      .should("have.value", "Testing1");
+      .type("Testing1Testing1")
+      .should("have.value", "Testing1Testing1");
     cy.get("[data-test=submit]").click();
   });
 
   it("Created user should be visible", function() {
+    cy.login();
+    cy.visit("/users");
+
     cy.get("[data-test=user-testuser]")
       .find("th")
       .then($th => {

--- a/e2e-test/cypress/integration/workflowitem_permissions_spec.js
+++ b/e2e-test/cypress/integration/workflowitem_permissions_spec.js
@@ -409,6 +409,7 @@ describe("Workflowitem Permissions", function() {
       cy.grantProjectPermission(projectId, "project.list", testGroupId),
       cy.grantProjectPermission(projectId, "project.viewDetails", testGroupId),
       cy.grantProjectPermission(projectId, "project.intent.listPermissions", testGroupId),
+      cy.grantProjectPermission(projectId, "project.intent.grantPermission", testGroupId),
       cy.grantSubprojectPermission(projectId, subprojectId, "subproject.list", testGroupId),
       cy.grantSubprojectPermission(projectId, subprojectId, "subproject.viewDetails", testGroupId),
       cy.grantSubprojectPermission(projectId, subprojectId, "subproject.intent.listPermissions", testGroupId),
@@ -419,8 +420,17 @@ describe("Workflowitem Permissions", function() {
         "workflowitem.intent.listPermissions",
         testGroupId
       ),
-      cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.list", testGroupId)
+      cy.grantWorkflowitemPermission(projectId, subprojectId, workflowitemId, "workflowitem.list", testGroupId),
+      cy.grantWorkflowitemPermission(
+        projectId,
+        subprojectId,
+        workflowitemId,
+        "workflowitem.intent.grantPermission",
+        testGroupId
+      )
     ]).then(() => {
+      permissionsBeforeTesting.project["project.intent.grantPermission"].push(testGroupId);
+      permissionsBeforeTesting.workflowitem["intent.grantPermission"].push(testGroupId);
       // user from testgroup grant other group some permission
       cy.login(testUser2.id, "test");
 

--- a/e2e-test/cypress/plugins/index.js
+++ b/e2e-test/cypress/plugins/index.js
@@ -74,14 +74,14 @@ function isProvisioned(baseUrl) {
       response.headers["set-cookie"][0].split(";")[0] => "token={JWT_Token}"
       response.headers["set-cookie"][0].split(";")[0].replace("token=", "") => "{JWT_Token}"
       */
-      let JWTtoken = response.data.data.user.token;
-      if (!JWTtoken) {
-        JWTtoken = response.headers["set-cookie"][0].split(";")[0].replace("token=", "");
-      }
+      let cookie = response.headers["set-cookie"][0];
+      let JWTtoken = response.headers["set-cookie"][0].split(";")[0].replace("token=", "");
+
       return axios
         .get(`${baseUrl}/api/provisioned`, {
           headers: {
-            Authorization: "Bearer " + JWTtoken
+            Authorization: "Bearer " + JWTtoken,
+            Cookie: cookie
           }
         })
         .then(response => {

--- a/e2e-test/cypress/support/commands.js
+++ b/e2e-test/cypress/support/commands.js
@@ -22,7 +22,8 @@
 
 const baseUrl = Cypress.env("API_BASE_URL") || Cypress.config("baseUrl");
 
-let token = undefined;
+//let token = undefined;
+let cookie = undefined;
 
 Cypress.Commands.add("login", (username = "mstein", password = "test", opts = { language: "en-gb" }) => {
   cy.request({
@@ -35,7 +36,6 @@ Cypress.Commands.add("login", (username = "mstein", password = "test", opts = { 
   }).then(response => {
     const state = {
       login: {
-        jwt: response.body.data.user.token,
         isUserLoggedIn: true,
         environment: "Test",
         productionActive: false,
@@ -48,14 +48,9 @@ Cypress.Commands.add("login", (username = "mstein", password = "test", opts = { 
     };
     localStorage.setItem("state", JSON.stringify(state));
     /*
-      response.headers["set-cookie"][0] => "token={JWT_Token}; Path=/; HttpOnly; Secure; SameSite=Strict"
-      response.headers["set-cookie"][0].split(";")[0] => "token={JWT_Token}"
-      response.headers["set-cookie"][0].split(";")[0].replace("token=", "") => "{JWT_Token}"
-      */
-    token = response.body.data.user.token;
-    if(!token) {
-      token = response.headers["set-cookie"][0].split(";")[0].replace("token=", "");
-    }
+     * The token is in the cookie header we need to extract it:
+     */
+    cookie = response.headers["set-cookie"][0];
   });
 });
 
@@ -64,7 +59,7 @@ Cypress.Commands.add("addUser", (username, userId, password, organization = "KfW
     url: `${baseUrl}/api/global.createUser`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -87,7 +82,7 @@ Cypress.Commands.add("fetchProjects", () => {
     url: `${baseUrl}/api/project.list`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     }
   })
     .its("body")
@@ -99,7 +94,7 @@ Cypress.Commands.add("fetchSubprojects", projectId => {
     url: `${baseUrl}/api/project.viewDetails?projectId=${projectId}`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     }
   })
     .its("body")
@@ -111,7 +106,7 @@ Cypress.Commands.add("createWorkflowitem", (projectId, subprojectId, displayName
     url: `${baseUrl}/api/subproject.createWorkflowitem`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -139,7 +134,7 @@ Cypress.Commands.add(
       url: `${baseUrl}/api/global.createProject`,
       method: "POST",
       headers: {
-        Authorization: `Bearer ${token}`
+        Cookie: cookie
       },
       body: {
         apiVersion: "1.0",
@@ -168,7 +163,7 @@ Cypress.Commands.add("updateProject", (projectId, opts = {}) => {
     url: `${baseUrl}/api/project.update`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -187,7 +182,7 @@ Cypress.Commands.add("updateProjectAssignee", (projectId, identity) => {
     url: `${baseUrl}/api/project.assign`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -206,7 +201,7 @@ Cypress.Commands.add("updateSubprojectAssignee", (projectId, subprojectId, ident
     url: `${baseUrl}/api/subproject.assign`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -226,7 +221,7 @@ Cypress.Commands.add("updateWorkflowitemAssignee", (projectId, subprojectId, wor
     url: `${baseUrl}/api/workflowitem.assign`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -247,7 +242,7 @@ Cypress.Commands.add("createSubproject", (projectId, displayName, currency = "EU
     url: `${baseUrl}/api/project.createSubproject`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -274,7 +269,7 @@ Cypress.Commands.add("grantProjectPermission", (projectId, intent, identity) => 
     url: `${baseUrl}/api/project.intent.grantPermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -294,7 +289,7 @@ Cypress.Commands.add("revokeProjectPermission", (projectId, intent, identity) =>
     url: `${baseUrl}/api/project.intent.revokePermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -314,7 +309,7 @@ Cypress.Commands.add("grantSubprojectPermission", (projectId, subprojectId, inte
     url: `${baseUrl}/api/subproject.intent.grantPermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -335,7 +330,7 @@ Cypress.Commands.add("revokeSubprojectPermission", (projectId, subprojectId, int
     url: `${baseUrl}/api/subproject.intent.revokePermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -356,7 +351,7 @@ Cypress.Commands.add("grantWorkflowitemPermission", (projectId, subprojectId, wo
     url: `${baseUrl}/api/workflowitem.intent.grantPermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -378,7 +373,7 @@ Cypress.Commands.add("revokeWorkflowitemPermission", (projectId, subprojectId, w
     url: `${baseUrl}/api/workflowitem.intent.revokePermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -400,7 +395,7 @@ Cypress.Commands.add("updateSubprojectPermissions", (projectId, subprojectId, in
     url: `${baseUrl}/api/subproject.intent.grantPermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -421,7 +416,7 @@ Cypress.Commands.add("grantUserPermissions", (userId, intent, identity) => {
     url: `${baseUrl}/api/user.intent.grantPermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -441,7 +436,7 @@ Cypress.Commands.add("revokeUserPermissions", (userId, intent, identity) => {
     url: `${baseUrl}/api/user.intent.revokePermission`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -461,7 +456,7 @@ Cypress.Commands.add("closeProject", projectId => {
     url: `${baseUrl}/api/project.close`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -479,7 +474,7 @@ Cypress.Commands.add("closeSubproject", (projectId, subprojectId) => {
     url: `${baseUrl}/api/subproject.close`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -498,7 +493,7 @@ Cypress.Commands.add("closeWorkflowitem", (projectId, subprojectId, workflowitem
     url: `${baseUrl}/api/workflowitem.close`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -518,7 +513,7 @@ Cypress.Commands.add("updateWorkflowitem", (projectId, subprojectId, workflowite
     url: `${baseUrl}/api/workflowitem.update`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -539,7 +534,7 @@ Cypress.Commands.add("reorderWorkflowitems", (projectId, subprojectId, ordering)
     url: `${baseUrl}/api/subproject.reorderWorkflowitems`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -559,7 +554,7 @@ Cypress.Commands.add("assignWorkflowitem", (projectId, subprojectId, workflowite
     url: `${baseUrl}/api/workflowitem.assign`,
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     body: {
       apiVersion: "1.0",
@@ -580,7 +575,7 @@ Cypress.Commands.add("getUserList", () => {
     url: `${baseUrl}/api/user.list`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     }
   })
     .its("body")
@@ -592,7 +587,7 @@ Cypress.Commands.add("listProjectPermissions", projectId => {
     url: `${baseUrl}/api/project.intent.listPermissions?projectId=${projectId}`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     }
   })
     .its("body")
@@ -604,7 +599,7 @@ Cypress.Commands.add("listSubprojectPermissions", (projectId, subprojectId) => {
     url: `${baseUrl}/api/subproject.intent.listPermissions?projectId=${projectId}&subprojectId=${subprojectId}`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     }
   })
     .its("body")
@@ -616,7 +611,7 @@ Cypress.Commands.add("listWorkflowitemPermissions", (projectId, subprojectId, wo
     url: `${baseUrl}/api/workflowitem.intent.listPermissions?projectId=${projectId}&subprojectId=${subprojectId}&workflowitemId=${workflowitemId}`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     }
   })
     .its("body")
@@ -628,7 +623,7 @@ Cypress.Commands.add("listWorkflowitems", (projectId, subprojectId, workflowitem
     url: `${baseUrl}/api/workflowitem.list?projectId=${projectId}&subprojectId=${subprojectId}&workflowitemId=${workflowitemId}`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     }
   })
     .its("body")
@@ -640,7 +635,7 @@ Cypress.Commands.add("createBackup", () => {
     url: `${baseUrl}/api/system.createBackup`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     timeout: 60000
   })
@@ -653,7 +648,7 @@ Cypress.Commands.add("getVersion", () => {
     url: `${baseUrl}/api/version`,
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`
+      Cookie: cookie
     },
     timeout: 60000
   })

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -477,7 +477,7 @@ class Api {
   };
   export = (devModeEnvironment) => {
     const path = this.getExportServiceUrl(`download?lang=${strings.getLanguage()}`, devModeEnvironment);
-    return instance.get(path, { responseType: "blob" });
+    return instance.get(path, { responseType: "blob", withCredentials: true });
   };
   fetchExportServiceVersion = () => {
     const path = this.getExportServiceUrl("version");

--- a/frontend/src/localStorage.js
+++ b/frontend/src/localStorage.js
@@ -12,7 +12,6 @@ const parseActions = (state) => state.getIn(["actions", "lastAction"]);
 
 const parseFromState = (state) => ({
   login: {
-    jwt: state.getIn(["login", "jwt"]),
     isUserLoggedIn: state.getIn(["login", "isUserLoggedIn"]),
     language: state.getIn(["login", "language"]),
     id: state.getIn(["login", "id"]),

--- a/frontend/src/pages/Login/LoginPageContainer.js
+++ b/frontend/src/pages/Login/LoginPageContainer.js
@@ -68,7 +68,6 @@ const mapDispatchToProps = (dispatch) => {
 const mapStateToProps = (state) => {
   return {
     username: state.getIn(["login", "username"]),
-    jwt: state.getIn(["login", "jwt"]),
     isUserLoggedIn: state.getIn(["login", "isUserLoggedIn"]),
     password: state.getIn(["login", "password"]),
     language: state.getIn(["login", "language"]),

--- a/frontend/src/pages/Login/reducer.js
+++ b/frontend/src/pages/Login/reducer.js
@@ -39,7 +39,6 @@ export const defaultState = fromJS({
   groups: [],
   avatarBackground: "/avatar_back.jpeg",
   avatar: "/lego_avatar_female2.jpg",
-  jwt: "",
   isUserLoggedIn: false,
   adminLoginFailed: false,
   language: "en-gb",
@@ -114,14 +113,12 @@ export default function loginReducer(state = defaultState, action) {
     case FETCH_ADMIN_USER_SUCCESS:
       return state.merge({
         loggedInAdminUser: action.user,
-        jwt: action.jwt,
         isUserLoggedIn: action.user.isUserLoggedIn
       });
 
     case LOGIN_SUCCESS: {
       const user = action.user;
       return state.merge({
-        jwt: user.token,
         isUserLoggedIn: action.isUserLoggedIn,
         id: user.id,
         displayName: user.displayName,

--- a/frontend/src/pages/Notifications/NotificationPageContainer.js
+++ b/frontend/src/pages/Notifications/NotificationPageContainer.js
@@ -61,7 +61,6 @@ const mapDispatchToProps = (dispatch) => {
 
 const mapStateToProps = (state) => {
   return {
-    jwt: state.getIn(["login", "jwt"]),
     isUserLoggedIn: state.getIn(["login", "isUserLoggedIn"]),
     notifications: state.getIn(["notifications", "notifications"]),
     notificationsPerPage: state.getIn(["notifications", "notificationPageSize"]),

--- a/frontend/src/sagas.js
+++ b/frontend/src/sagas.js
@@ -255,10 +255,6 @@ const getEmailAddress = (state) => {
   return state.getIn(["login", "emailAddress"]);
 };
 
-const getJwt = (state) => {
-  return state.getIn(["login", "jwt"]);
-};
-
 // eslint-disable-next-line no-unused-vars
 const _getUserLoggedIn = (state) => {
   return state.getIn(["login", "isUserLoggedIn"]);
@@ -384,8 +380,6 @@ const getNotificationState = (state) => {
 };
 
 function* callApi(func, ...args) {
-  const token = yield select(getJwt);
-  yield call(api.setAuthorizationHeader, token);
   yield call(api.setBaseUrl);
   const { data = {} } = yield call(func, ...args);
   return data;
@@ -2820,8 +2814,7 @@ export function* restoreBackupSaga({ file, showLoading = true }) {
     type: DISABLE_ALL_LIVE_UPDATES
   });
   yield execute(function* () {
-    const token = yield select(getJwt);
-    yield call(api.restoreFromBackup, token, file);
+    yield call(api.restoreFromBackup, "", file);
     yield put({
       type: RESTORE_BACKUP_SUCCESS
     });

--- a/provisioning/src/api.js
+++ b/provisioning/src/api.js
@@ -13,10 +13,8 @@ const authenticate = async (axios, userId, password) => {
   const body = response.data;
   if (body.apiVersion !== "1.0") throw Error("unexpected API version");
    /*
-      response.headers["set-cookie"][0] => "token={JWT_Token}; Path=/; HttpOnly; Secure; SameSite=Strict"
-      response.headers["set-cookie"][0].split(";")[0] => "token={JWT_Token}"
-      response.headers["set-cookie"][0].split(";")[0].replace("token=", "") => "{JWT_Token}"
-      */
+    * The token is in the cookie header we need to extract it:
+    */
   let token = body.data.user.token;
   if(!token) {
     token = response.headers["set-cookie"][0].split(";")[0].replace("token=", "");


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
The PR [improvement of cookie management](https://github.com/openkfw/TruBudget/pull/1287/files#diff-02a570b6695e4fbb6f3525f5e5e534125d1a2d4cd05600d88c5cd47db6bbe6b3) adds a cookie based authentication, but there are still unused remains of jwt token logic being stored in Redux and browser's local storage. This PR removes the unused jwt token references from the ui and e2e-tests.
Closes #1453
