### PR TITLE
frontend: disable live updates when searching

### DIFF
--- a/frontend/src/pages/Overview/OverviewContainer.js
+++ b/frontend/src/pages/Overview/OverviewContainer.js
@@ -13,7 +13,9 @@ import { storeSearchBarDisplayed, storeSearchTerm } from "../Navbar/actions";
 import { fetchAllProjectDetails } from "../SubProjects/actions";
 
 import {
+  disableAllProjectsLiveUpdates,
   editProject,
+  enableAllProjectsLiveUpdates,
   fetchAllProjects,
   hideProjectAdditionalData,
   liveUpdateAllProjects,
@@ -87,6 +89,8 @@ class OverviewContainer extends Component {
 const mapDispatchToProps = (dispatch) => {
   return {
     liveUpdate: () => dispatch(liveUpdateAllProjects()),
+    disableLiveUpdates: () => dispatch(disableAllProjectsLiveUpdates()),
+    enableLiveUpdates: () => dispatch(enableAllProjectsLiveUpdates()),
     showCreationDialog: () => dispatch(showCreationDialog()),
     showEditDialog: (id, displayName, description, thumbnail, projectedBudgets, tags) =>
       dispatch(showEditDialog(id, displayName, description, thumbnail, projectedBudgets, tags)),

--- a/frontend/src/pages/Overview/TableView.js
+++ b/frontend/src/pages/Overview/TableView.js
@@ -268,6 +268,8 @@ const formatTable = ({
 
 const TableView = (props) => {
   const {
+    disableLiveUpdates,
+    enableLiveUpdates,
     filteredProjects,
     showEditDialog,
     showProjectPermissions,
@@ -279,6 +281,7 @@ const TableView = (props) => {
     showNavSearchBar // to open the search bar for CardView in NavBar
   } = props;
 
+  const hasSearchTerm = searchTerm !== "";
   const projects = filteredProjects;
 
   const [status, setStatus] = useState("all");
@@ -299,6 +302,14 @@ const TableView = (props) => {
       searchTerm
     })
   );
+
+  useEffect(() => {
+    if (hasSearchTerm) {
+      disableLiveUpdates();
+    } else {
+      enableLiveUpdates();
+    }
+  }, [disableLiveUpdates, enableLiveUpdates, hasSearchTerm]);
 
   useEffect(() => {
     // Update Table when new project was created
@@ -322,7 +333,7 @@ const TableView = (props) => {
       return;
     }
     let filtered = projects;
-    const hasSearchTerm = searchTerm !== "";
+
     const hasStatus = status !== "all";
     const hasAssignee = assigneeId !== "all";
     const hasStartDate = startDate !== null;
@@ -375,15 +386,16 @@ const TableView = (props) => {
     );
   }, [
     projects,
-    searchTerm,
     status,
     assigneeId,
     startDate,
     endDate,
+    hasSearchTerm,
     showEditDialog,
     showProjectPermissions,
     showProjectAdditionalData,
     storeSearchTerm,
+    searchTerm,
     showNavSearchBar
   ]);
 

--- a/frontend/src/pages/Overview/actions.js
+++ b/frontend/src/pages/Overview/actions.js
@@ -5,6 +5,8 @@ export const FETCH_ALL_PROJECTS = "FETCH_ALL_PROJECTS";
 export const FETCH_ALL_PROJECTS_SUCCESS = "FETCH_ALL_PROJECTS_SUCCESS";
 
 export const LIVE_UPDATE_ALL_PROJECTS = "LIVE_UPDATE_ALL_PROJECTS";
+export const LIVE_UPDATE_ALL_PROJECTS_DISABLE = "LIVE_UPDATE_ALL_PROJECTS_DISABLE";
+export const LIVE_UPDATE_ALL_PROJECTS_ENABLE = "LIVE_UPDATE_ALL_PROJECTS_ENABLE";
 
 export const SHOW_CREATION_DIALOG = "SHOW_CREATION_DIALOG";
 export const HIDE_PROJECT_DIALOG = "HIDE_CREATION_DIALOG";
@@ -62,6 +64,18 @@ export function liveUpdateAllProjects(showLoading = false) {
   return {
     type: LIVE_UPDATE_ALL_PROJECTS,
     showLoading
+  };
+}
+
+export function disableAllProjectsLiveUpdates() {
+  return {
+    type: LIVE_UPDATE_ALL_PROJECTS_DISABLE
+  };
+}
+
+export function enableAllProjectsLiveUpdates() {
+  return {
+    type: LIVE_UPDATE_ALL_PROJECTS_ENABLE
   };
 }
 

--- a/frontend/src/pages/Overview/reducer.js
+++ b/frontend/src/pages/Overview/reducer.js
@@ -21,6 +21,8 @@ import {
   HIDE_PROJECT_ADDITIONAL_DATA,
   HIDE_PROJECT_DIALOG,
   HIDE_PROJECT_PERMISSIONS,
+  LIVE_UPDATE_ALL_PROJECTS_DISABLE,
+  LIVE_UPDATE_ALL_PROJECTS_ENABLE,
   PROJECT_COMMENT,
   PROJECT_CREATION_STEP,
   PROJECT_DELETED_PROJECTED_BUDGET,
@@ -237,8 +239,10 @@ export default function overviewReducer(state = defaultState, action) {
     case STORE_PROJECT_VIEW:
       return state.set("projectView", fromJS(action.projectView));
     case DISABLE_ALL_LIVE_UPDATES:
+    case LIVE_UPDATE_ALL_PROJECTS_DISABLE:
       return state.set("isLiveUpdateAllProjectsEnabled", false);
     case ENABLE_ALL_LIVE_UPDATES:
+    case LIVE_UPDATE_ALL_PROJECTS_ENABLE:
       return state.set("isLiveUpdateAllProjectsEnabled", true);
     default:
       return state;


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description

When user switches to a table view on projects page, and filters projects using a search bar, the projects are correctly filtered. However, these search results are reset in t < 5s. This is due to live update triggering re-render in table view (but not in card view).

Solution is to pause live updates of projects while user is using the search functionality. - Notifications are not affected.


<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
Closes #1536

