### PR TITLE
doc: add proper link for ssh cloning

### DIFF
--- a/docs/developer/developer-setup.md
+++ b/docs/developer/developer-setup.md
@@ -112,7 +112,7 @@ Clone the repository from Github:
 If you haven't done the SSH setup so far, please follow the instructions on how to setup your [SSH-connection](https://help.github.com/en/articles/connecting-to-github-with-ssh)
 
 ```bash
-git clone https://github.com/openkfw/TruBudget.git
+git clone git@github.com:openkfw/TruBudget.git
 ```
 
 - HTTPS:


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [ ] I fixed all necessary PR warnings
- [x] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description

I was looking at the documentation in order to set up a local TruBudget environment and I noticed that the url for the `ssh` section was actually the `https` one, thought it would be good to change it
