### PR TITLE
Frontend: more descriptive validation messages - create user form

### DIFF
--- a/e2e-test/cypress/integration/users_spec.js
+++ b/e2e-test/cypress/integration/users_spec.js
@@ -107,7 +107,7 @@ describe("Users/Groups Dashboard", function () {
       });
   });
 
-  it("New user cannot be named 'root'", function () {
+  it("User cannot be named 'root'", function () {
     cy.login();
     cy.visit("/users");
     cy.get("[data-test=create]").click();
@@ -116,11 +116,11 @@ describe("Users/Groups Dashboard", function () {
     cy.get("[data-test=password-new-user] input").type("Testing1").should("have.value", "Testing1");
     cy.get("[data-test=password-new-user-confirm] input").type("Testing1").should("have.value", "Testing1");
     cy.get("[data-test=submit]").should("be.disabled");
-    cy.get("#username-helper-text").contains("Invalid login ID");
+    cy.get("#username-helper-text").contains(`Login ID cannot be "root"`);
     cy.get("[data-test=cancel]").click();
   });
 
-  it("New user cannot have space in the name", function () {
+  it("User cannot have space in the name", function () {
     cy.login();
     cy.visit("/users");
     cy.get("[data-test=create]").click();
@@ -129,11 +129,28 @@ describe("Users/Groups Dashboard", function () {
     cy.get("[data-test=password-new-user] input").type("Testing1").should("have.value", "Testing1");
     cy.get("[data-test=password-new-user-confirm] input").type("Testing1").should("have.value", "Testing1");
     cy.get("[data-test=submit]").should("be.disabled");
-    cy.get("#username-helper-text").contains("Invalid login ID");
+    cy.get("#username-helper-text").contains(
+      `Your login ID must: Not contain spaces or special characters; Use "-", "_" or camelCase instead`,
+    );
     cy.get("[data-test=cancel]").click();
   });
 
-  it("An info is shown if the password and confirmation-password are not equal", function () {
+  it("User cannot have special characters in the name", function () {
+    cy.login();
+    cy.visit("/users");
+    cy.get("[data-test=create]").click();
+    cy.get("[data-test=accountname] input").type("Test User").should("have.value", "Test User");
+    cy.get("[data-test=username] input").type("test@user").should("have.value", "test@user");
+    cy.get("[data-test=password-new-user] input").type("Testing1").should("have.value", "Testing1");
+    cy.get("[data-test=password-new-user-confirm] input").type("Testing1").should("have.value", "Testing1");
+    cy.get("[data-test=submit]").should("be.disabled");
+    cy.get("#username-helper-text").contains(
+      `Your login ID must: Not contain spaces or special characters; Use "-", "_" or camelCase instead`,
+    );
+    cy.get("[data-test=cancel]").click();
+  });
+
+  it("Password and confirmation-password are not equal", function () {
     cy.login();
     cy.visit("/users");
     cy.get("[data-test=create]").click();
@@ -149,7 +166,7 @@ describe("Users/Groups Dashboard", function () {
     cy.get("[data-test=cancel]").click();
   });
 
-  it("A validation error message is shown if password isn't at least 8 characters long", function () {
+  it("Password must be at least 8 characters long", function () {
     cy.login();
     cy.visit("/users");
     cy.get("[data-test=create]").click();
@@ -162,7 +179,7 @@ describe("Users/Groups Dashboard", function () {
     cy.get("[data-test=cancel]").click();
   });
 
-  it("A validation error message is shown if password doesn't contain at least one number", function () {
+  it("Password must contain at least one number", function () {
     cy.login();
     cy.visit("/users");
     cy.get("[data-test=create]").click();
@@ -177,7 +194,7 @@ describe("Users/Groups Dashboard", function () {
     cy.get("[data-test=cancel]").click();
   });
 
-  it("A validation error message is shown if the accountname is touched but stays empty", function () {
+  it("Accountname is touched but stays empty", function () {
     cy.login();
     cy.visit("/users");
     cy.get("[data-test=create]").click();
@@ -187,6 +204,47 @@ describe("Users/Groups Dashboard", function () {
     cy.get("[data-test=password-new-user-confirm] input").type("password1").should("have.value", "password1");
     cy.get("[data-test=submit]").should("be.disabled");
     cy.get("[data-test=accountname]").contains("Account name cannot be empty");
+    cy.get("[data-test=cancel]").click();
+  });
+
+  it("Accountname must be at least 3 characters long", function () {
+    cy.login();
+    cy.visit("/users");
+    cy.get("[data-test=create]").click();
+    cy.get("[data-test=accountname] input").type("us").should("have.value", "us");
+    cy.get("[data-test=username] input").type("newUser").should("have.value", "newUser");
+    cy.get("[data-test=password-new-user] input").type("password1").should("have.value", "password1");
+    cy.get("[data-test=password-new-user-confirm] input").type("password1").should("have.value", "password1");
+    cy.get("[data-test=submit]").should("be.disabled");
+    cy.get("[data-test=accountname]").contains("Your account name must: Be at least 3 characters long");
+    cy.get("[data-test=cancel]").click();
+  });
+
+  it("Accountname must not contain any special characters", function () {
+    cy.login();
+    cy.visit("/users");
+    cy.get("[data-test=create]").click();
+    cy.get("[data-test=accountname] input").type("New@User").should("have.value", "New@User");
+    cy.get("[data-test=username] input").type("newUser").should("have.value", "newUser");
+    cy.get("[data-test=password-new-user] input").type("password1").should("have.value", "password1");
+    cy.get("[data-test=password-new-user-confirm] input").type("password1").should("have.value", "password1");
+    cy.get("[data-test=submit]").should("be.disabled");
+    cy.get("[data-test=accountname]").contains(
+      `Your account name must: Not contain special characters; Use "-", "_" or space instead`,
+    );
+    cy.get("[data-test=cancel]").click();
+  });
+
+  it("Login ID must be at least 4 characters long", function () {
+    cy.login();
+    cy.visit("/users");
+    cy.get("[data-test=create]").click();
+    cy.get("[data-test=accountname] input").type("newUser").should("have.value", "newUser");
+    cy.get("[data-test=username] input").type("new").should("have.value", "new");
+    cy.get("[data-test=password-new-user] input").type("password1").should("have.value", "password1");
+    cy.get("[data-test=password-new-user-confirm] input").type("password1").should("have.value", "password1");
+    cy.get("[data-test=submit]").should("be.disabled");
+    cy.get("[data-test=username]").contains("Your login ID must: Be at least 4 characters long");
     cy.get("[data-test=cancel]").click();
   });
 });

--- a/e2e-test/cypress/integration/users_spec.js
+++ b/e2e-test/cypress/integration/users_spec.js
@@ -207,16 +207,16 @@ describe("Users/Groups Dashboard", function () {
     cy.get("[data-test=cancel]").click();
   });
 
-  it("Accountname must be at least 3 characters long", function () {
+  it("Accountname must be at least 4 characters long", function () {
     cy.login();
     cy.visit("/users");
     cy.get("[data-test=create]").click();
-    cy.get("[data-test=accountname] input").type("us").should("have.value", "us");
+    cy.get("[data-test=accountname] input").type("new").should("have.value", "new");
     cy.get("[data-test=username] input").type("newUser").should("have.value", "newUser");
     cy.get("[data-test=password-new-user] input").type("password1").should("have.value", "password1");
     cy.get("[data-test=password-new-user-confirm] input").type("password1").should("have.value", "password1");
     cy.get("[data-test=submit]").should("be.disabled");
-    cy.get("[data-test=accountname]").contains("Your account name must: Be at least 3 characters long");
+    cy.get("[data-test=accountname]").contains("Your account name must: Be at least 4 characters long");
     cy.get("[data-test=cancel]").click();
   });
 

--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -186,7 +186,16 @@ const en = {
     account_name_error: "Account name cannot be empty",
     login_id_error: "Login ID cannot be empty",
     password_error: "Password cannot be empty",
-    confirm_password_error: "Confirm password cannot be empty"
+    confirm_password_error: "Confirm password cannot be empty",
+    account_name_conditions_preface: "Your account name must:",
+    account_name_conditions_forbidden: "Not contain special characters",
+    account_name_conditions_solution: `Use "-", "_" or space instead`,
+    account_name_conditions_length: "Be at least 3 characters long",
+    login_id_no_root: `Login ID cannot be "root"`,
+    login_id_conditions_preface: "Your login ID must:",
+    login_id_conditions_length: "Be at least 4 characters long",
+    login_id_conditions_forbidden: "Not contain spaces or special characters",
+    login_id_conditions_solution: `Use "-", "_" or camelCase instead`
   },
 
   userProfile: {

--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -190,7 +190,7 @@ const en = {
     account_name_conditions_preface: "Your account name must:",
     account_name_conditions_forbidden: "Not contain special characters",
     account_name_conditions_solution: `Use "-", "_" or space instead`,
-    account_name_conditions_length: "Be at least 3 characters long",
+    account_name_conditions_length: "Be at least 4 characters long",
     login_id_no_root: `Login ID cannot be "root"`,
     login_id_conditions_preface: "Your login ID must:",
     login_id_conditions_length: "Be at least 4 characters long",

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -322,7 +322,7 @@ const fr = {
     account_name_conditions_preface: "Le nom de votre compte doit:",
     account_name_conditions_forbidden: "Ne contient pas de caractères spéciaux",
     account_name_conditions_solution: `Utilisez plutôt "-", "_" ou un espace`,
-    account_name_conditions_length: "Comporter au moins 3 caractères",
+    account_name_conditions_length: "Comporter au moins 4 caractères",
     login_id_no_root: `L'ID de connexion ne peut pas être "root"`,
     login_id_conditions_preface: "Votre identifiant de connexion doit",
     login_id_conditions_length: "Comporter au moins 4 caractères",

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -318,7 +318,16 @@ const fr = {
     account_name_error: "Le nom du compte ne peut pas être vide",
     login_id_error: `L'ID de connexion ne peut pas être vide`,
     password_error: "Le mot de passe ne peut pas être vide",
-    confirm_password_error: "Confirmer que le mot de passe ne peut pas être vide"
+    confirm_password_error: "Confirmer que le mot de passe ne peut pas être vide",
+    account_name_conditions_preface: "Le nom de votre compte doit:",
+    account_name_conditions_forbidden: "Ne contient pas de caractères spéciaux",
+    account_name_conditions_solution: `Utilisez plutôt "-", "_" ou un espace`,
+    account_name_conditions_length: "Comporter au moins 3 caractères",
+    login_id_no_root: `L'ID de connexion ne peut pas être "root"`,
+    login_id_conditions_preface: "Votre identifiant de connexion doit",
+    login_id_conditions_length: "Comporter au moins 4 caractères",
+    login_id_conditions_forbidden: "Ne contient pas d'espaces ni de caractères spéciaux",
+    login_id_conditions_solution: `Utilisez plutôt "-", "_" ou camelCase`
   },
 
   nodesDashboard: {

--- a/frontend/src/languages/georgian.js
+++ b/frontend/src/languages/georgian.js
@@ -187,7 +187,16 @@ const ka = {
     account_name_error: "ანგარიშის სახელი არ შეიძლება იყოს ცარიელი",
     login_id_error: "შესვლის ID არ შეიძლება იყოს ცარიელი",
     password_error: "პაროლი არ შეიძლება იყოს ცარიელი",
-    confirm_password_error: "დაადასტურეთ, რომ პაროლი არ შეიძლება იყოს ცარიელი"
+    confirm_password_error: "დაადასტურეთ, რომ პაროლი არ შეიძლება იყოს ცარიელი",
+    account_name_conditions_preface: "თქვენი ანგარიშის სახელი უნდა:",
+    account_name_conditions_forbidden: "არ შეიცავს სპეციალურ სიმბოლოებს",
+    account_name_conditions_solution: `ამის ნაცვლად გამოიყენეთ "-", "_" ან სივრცე`,
+    account_name_conditions_length: "იყოს მინიმუმ 3 სიმბოლო",
+    login_id_no_root: `შესვლის ID არ შეიძლება იყოს "root"`,
+    login_id_conditions_preface: "თქვენი შესვლის ID უნდა:",
+    login_id_conditions_length: "იყოს მინიმუმ 4 სიმბოლო",
+    login_id_conditions_forbidden: "არ შეიცავს სივრცეებს ​​ან სპეციალურ სიმბოლოებს",
+    login_id_conditions_solution: `ამის ნაცვლად გამოიყენეთ "-", "_" ან camelCase`
   },
 
   userProfile: {

--- a/frontend/src/languages/georgian.js
+++ b/frontend/src/languages/georgian.js
@@ -191,7 +191,7 @@ const ka = {
     account_name_conditions_preface: "თქვენი ანგარიშის სახელი უნდა:",
     account_name_conditions_forbidden: "არ შეიცავს სპეციალურ სიმბოლოებს",
     account_name_conditions_solution: `ამის ნაცვლად გამოიყენეთ "-", "_" ან სივრცე`,
-    account_name_conditions_length: "იყოს მინიმუმ 3 სიმბოლო",
+    account_name_conditions_length: "იყოს მინიმუმ 4 სიმბოლო",
     login_id_no_root: `შესვლის ID არ შეიძლება იყოს "root"`,
     login_id_conditions_preface: "თქვენი შესვლის ID უნდა:",
     login_id_conditions_length: "იყოს მინიმუმ 4 სიმბოლო",

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -316,7 +316,16 @@ const de = {
     account_name_error: "Der Kontoname darf nicht leer sein",
     login_id_error: "Die Anmelde-ID darf nicht leer sein",
     password_error: "Passwort kann nicht leer sein",
-    confirm_password_error: "Bestätigen Sie, dass das Passwort nicht leer sein darf"
+    confirm_password_error: "Bestätigen Sie, dass das Passwort nicht leer sein darf",
+    account_name_conditions_preface: "Ihr Kontoname muss:",
+    account_name_conditions_forbidden: "Enthält keine Sonderzeichen",
+    account_name_conditions_solution: `Verwenden Sie stattdessen „-“, „_“ oder ein Leerzeichen`,
+    account_name_conditions_length: "Mindestens 3 Zeichen lang sein",
+    login_id_no_root: `Die Anmelde-ID darf nicht „root“ sein.`,
+    login_id_conditions_preface: "Ihre Login-ID muss:",
+    login_id_conditions_length: "Mindestens 4 Zeichen lang sein",
+    login_id_conditions_forbidden: "Enthält keine Leerzeichen oder Sonderzeichen",
+    login_id_conditions_solution: `Verwenden Sie stattdessen „-“, „_“ oder camelCase`
   },
   userProfile: {
     invalid_email_address: "Ungültige E-Mail Adresse"

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -320,7 +320,7 @@ const de = {
     account_name_conditions_preface: "Ihr Kontoname muss:",
     account_name_conditions_forbidden: "Enthält keine Sonderzeichen",
     account_name_conditions_solution: `Verwenden Sie stattdessen „-“, „_“ oder ein Leerzeichen`,
-    account_name_conditions_length: "Mindestens 3 Zeichen lang sein",
+    account_name_conditions_length: "Mindestens 4 Zeichen lang sein",
     login_id_no_root: `Die Anmelde-ID darf nicht „root“ sein.`,
     login_id_conditions_preface: "Ihre Login-ID muss:",
     login_id_conditions_length: "Mindestens 4 Zeichen lang sein",

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -188,7 +188,16 @@ const pt = {
     account_name_error: "O nome da conta não pode ficar vazio",
     login_id_error: "O ID de login não pode ficar vazio",
     password_error: "A senha não pode ficar vazia",
-    confirm_password_error: "A confirmação da senha não pode ficar vazia"
+    confirm_password_error: "A confirmação da senha não pode ficar vazia",
+    account_name_conditions_preface: "O nome da sua conta deve:",
+    account_name_conditions_forbidden: "Não contém caracteres especiais",
+    account_name_conditions_solution: `Use "-", "_" ou espaço`,
+    account_name_conditions_length: "Ter pelo menos 3 caracteres",
+    login_id_no_root: `O ID de login não pode ser "root"`,
+    login_id_conditions_preface: "Seu ID de login deve:",
+    login_id_conditions_length: "Ter pelo menos 4 caracteres",
+    login_id_conditions_forbidden: "Não contém espaços ou caracteres especiais",
+    login_id_conditions_solution: `Use "-", "_" ou camelCase`
   },
 
   userProfile: {

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -192,7 +192,7 @@ const pt = {
     account_name_conditions_preface: "O nome da sua conta deve:",
     account_name_conditions_forbidden: "Não contém caracteres especiais",
     account_name_conditions_solution: `Use "-", "_" ou espaço`,
-    account_name_conditions_length: "Ter pelo menos 3 caracteres",
+    account_name_conditions_length: "Ter pelo menos 4 caracteres",
     login_id_no_root: `O ID de login não pode ser "root"`,
     login_id_conditions_preface: "Seu ID de login deve:",
     login_id_conditions_length: "Ter pelo menos 4 caracteres",

--- a/frontend/src/pages/Users/UserDialogContent.js
+++ b/frontend/src/pages/Users/UserDialogContent.js
@@ -52,6 +52,7 @@ const UserDialogContent = ({
   setOrganization,
   setIsUserFormValid
 }) => {
+  const accountnameRegex = /^([A-Za-zÀ-ÿ0-9-_ ]*)$/;
   const usernameRegex = /^([A-Za-zÀ-ÿ0-9-_]*)$/;
   const passwordRegex = /^(?=.*[A-Za-zÀ-ÿ].*)(?=.*[0-9].*)([A-Za-zÀ-ÿ0-9-_!?@#$&*,.:/()[\] ])*$/;
 
@@ -63,21 +64,35 @@ const UserDialogContent = ({
   };
 
   const userSchema = Yup.object().shape({
-    accountname: Yup.string().required(`${strings.users.account_name_error}`),
+    accountname: Yup.string()
+      .required(`${strings.users.account_name_error}`)
+      .min(3, `${strings.users.account_name_conditions_preface} ${strings.users.account_name_conditions_length}`)
+      .matches(
+        accountnameRegex,
+        `${strings.users.account_name_conditions_preface} ${strings.users.account_name_conditions_forbidden}; ${strings.users.account_name_conditions_solution}`
+      )
+      .trim(),
     username: Yup.string()
       .required(`${strings.users.login_id_error}`)
-      .matches(usernameRegex, strings.users.username_invalid)
-      .notOneOf(["root"], strings.users.username_invalid),
+      .min(4, `${strings.users.login_id_conditions_preface} ${strings.users.login_id_conditions_length}`)
+      .matches(
+        usernameRegex,
+        `${strings.users.login_id_conditions_preface} ${strings.users.login_id_conditions_forbidden}; ${strings.users.login_id_conditions_solution}`
+      )
+      .notOneOf(["root"], strings.users.login_id_no_root)
+      .trim(),
     password: Yup.string()
       .required(`${strings.users.password_error}`)
       .min(8, `${strings.users.password_conditions_preface} ${strings.users.password_conditions_length}`)
       .matches(
         passwordRegex,
         `${strings.users.password_conditions_preface} ${strings.users.password_conditions_letter}; ${strings.users.password_conditions_number}`
-      ),
+      )
+      .trim(),
     confirmPassword: Yup.string()
       .required(`${strings.users.confirm_password_error}`)
       .oneOf([Yup.ref("password"), null], strings.users.no_password_match)
+      .trim()
   });
 
   const handleIsFormValid = (errors, isValid) => {

--- a/frontend/src/pages/Users/UserDialogContent.js
+++ b/frontend/src/pages/Users/UserDialogContent.js
@@ -66,7 +66,7 @@ const UserDialogContent = ({
   const userSchema = Yup.object().shape({
     accountname: Yup.string()
       .required(`${strings.users.account_name_error}`)
-      .min(3, `${strings.users.account_name_conditions_preface} ${strings.users.account_name_conditions_length}`)
+      .min(4, `${strings.users.account_name_conditions_preface} ${strings.users.account_name_conditions_length}`)
       .matches(
         accountnameRegex,
         `${strings.users.account_name_conditions_preface} ${strings.users.account_name_conditions_forbidden}; ${strings.users.account_name_conditions_solution}`


### PR DESCRIPTION
### Checklist
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [ ] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
- Add more descriptive validation messages in Create user form
- new messages are related to Account name and Login ID fields
- Add e2e tests on behalf of new validation messages

<img width="1149" alt="Screenshot 2024-03-08 at 10 11 50" src="https://github.com/openkfw/TruBudget/assets/55734106/8679d749-2bfa-4cf6-a3b6-2d6c099178d1">
<img width="1149" alt="Screenshot 2024-03-08 at 10 24 55" src="https://github.com/openkfw/TruBudget/assets/55734106/65bc62e9-5676-40a9-9371-76ea417b15ad">


"Closes #1704 "
