### PR TITLE
Frontend tooltips for text inputs in subproject dialog

### DIFF
--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -271,7 +271,9 @@ const en = {
     subproject_general_workflowitem_type: "Only allow workflowitems of type general",
     subproject_restricted_workflowitem_type:
       "Only allow workflowitem of type restricted. When assigning a restricted workflowitem permissions are automatically granted and revoked. The assigner will only keep the view permissions.",
-    workflowitem_assignee: "Default assignee"
+    workflowitem_assignee: "Default assignee",
+    organization_info: "Organization",
+    total_budget_info: "Total budget"
   },
 
   workflow: {

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -194,7 +194,9 @@ const fr = {
     subproject_general_workflowitem_type: "Autoriser uniquement les éléments de workflow de type général",
     subproject_restricted_workflowitem_type:
       "Autoriser uniquement l'élément de flux de travail de type restreint. Lors de l'attribution d'un élément de flux de travail restreint, les autorisations sont automatiquement accordées et révoquées. Le cédant ne conservera que les autorisations d'affichage.",
-    workflowitem_assignee: "Default assignee"
+    workflowitem_assignee: "Default assignee",
+    organization_info: "Organization",
+    total_budget_info: "Total budget"
   },
 
   workflow: {

--- a/frontend/src/languages/georgian.js
+++ b/frontend/src/languages/georgian.js
@@ -273,7 +273,9 @@ const ka = {
     subproject_general_workflowitem_type: "დაუშვით მხოლოდ workflowitem ტიპის ზოგადი",
     subproject_restricted_workflowitem_type:
       "მხოლოდ ტიპის workflowitem- ის აკრძალვა შეზღუდულია. შეზღუდული workflowitem- ის მინიჭებისას, ნებართვები ავტომატურად გაიცემა და გაუქმდება. შემკვეთი მხოლოდ ნახვის ნებართვებს ინახავს.",
-    workflowitem_assignee: "ნაგულისხმევი მიმღები"
+    workflowitem_assignee: "ნაგულისხმევი მიმღები",
+    organization_info: "Organization",
+    total_budget_info: "Total budget"
   },
 
   workflow: {

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -191,7 +191,9 @@ const de = {
     subproject_general_workflowitem_type: "Nur Workflow-Elemente vom Typ 'general' zulassen",
     subproject_restricted_workflowitem_type:
       "Nur Workflow-Elemente vom Typ 'eingeschränkt' zulassen. Bei Zuweisung eines eingeschränkten Workflow-Items an einen anderen User werden Berechtigungen automatisch erteilt und entzogen. Der Zuweisende behält nur die Anzeigerechte.",
-    workflowitem_assignee: "Vorausgewählter Verantwortlicher"
+    workflowitem_assignee: "Vorausgewählter Verantwortlicher",
+    organization_info: "Organization",
+    total_budget_info: "Total budget"
   },
 
   workflow: {

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -273,7 +273,9 @@ const pt = {
     subproject_general_workflowitem_type: "Permitir apenas itens de fluxo de trabalho do tipo geral",
     subproject_restricted_workflowitem_type:
       "Permitir apenas item de fluxo de trabalho do tipo restrito. Ao atribuir um item de fluxo de trabalho restrito, as permissões são concedidas e revogadas automaticamente. O atribuidor manterá apenas as permissões de visualização.",
-    workflowitem_assignee: "Cessionário padrão"
+    workflowitem_assignee: "Cessionário padrão",
+    organization_info: "Organization",
+    total_budget_info: "Total budget"
   },
 
   workflow: {

--- a/frontend/src/pages/Common/Budget.js
+++ b/frontend/src/pages/Common/Budget.js
@@ -40,7 +40,7 @@ const styles = {
   helpIcon: { color: "rgba(0,0, 0, 0.42)", marginTop: "20px", marginBottom: "7px", fontSize: "x-large" }
 };
 
-const CustomHelpTooltip = (props) => {
+const CustomInfoTooltip = (props) => {
   const [open, setOpen] = useState(false);
 
   const handleTooltipOpen = () => {
@@ -299,7 +299,7 @@ const Budget = (props) => {
                       }}
                       disabled={isEditing}
                     />
-                    <CustomHelpTooltip title="Placeholder for Organization" />
+                    <CustomInfoTooltip title={strings.subproject.organization_info} />
                   </>
                 ) : (
                   <div style={styles.inputContainer}>
@@ -313,7 +313,7 @@ const Budget = (props) => {
                     >
                       {getOrganizationMenuItems(projectProjectedBudgets)}
                     </DropDown>
-                    <CustomHelpTooltip title="Placeholder for Organization" />
+                    <CustomInfoTooltip title={strings.subproject.organization_info} />
                   </div>
                 )}
 
@@ -351,7 +351,7 @@ const Budget = (props) => {
                   error={!isValidBudgetAmountAdd}
                   helperText={!isValidBudgetAmountAdd ? strings.common.invalid_format : ""}
                 />
-                <CustomHelpTooltip title="Placeholder for Total budget" />
+                <CustomInfoTooltip title={strings.subproject.total_budget_info} />
               </div>
             </TableCell>
             <TableCell align="right">

--- a/frontend/src/pages/Common/Budget.js
+++ b/frontend/src/pages/Common/Budget.js
@@ -4,7 +4,9 @@ import _isEmpty from "lodash/isEmpty";
 import DoneIcon from "@mui/icons-material/Check";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import Button from "@mui/material/Button";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
 import MenuItem from "@mui/material/MenuItem";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -12,6 +14,7 @@ import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
 
 import {
   fromAmountString,
@@ -26,7 +29,41 @@ import DropDown from "./NewDropdown";
 
 const styles = {
   inputfield: { minWidth: 200, marginRight: "16px", flexGrow: "1" },
-  cell: { display: "flex", justifyContent: "space-between" }
+  inputFieldWithIcon: { minWidth: 200, flexGrow: "1" },
+  inputContainer: {
+    display: "flex",
+    width: "45%",
+    paddingRight: 20,
+    alignItems: "flex-end"
+  },
+  cell: { display: "flex", justifyContent: "space-between" },
+  helpIcon: { color: "rgba(0,0, 0, 0.42)", marginTop: "20px", marginBottom: "7px", fontSize: "x-large" }
+};
+
+const CustomHelpTooltip = (props) => {
+  const [open, setOpen] = useState(false);
+
+  const handleTooltipOpen = () => {
+    setOpen(true);
+  };
+  const handleTooltipClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <ClickAwayListener onClickAway={handleTooltipClose}>
+      <Tooltip
+        title={props.title}
+        onOpen={handleTooltipOpen}
+        onClose={handleTooltipClose}
+        open={open}
+        disableFocusListener
+        disableHoverListener
+      >
+        <InfoOutlinedIcon style={styles.helpIcon} onClick={handleTooltipOpen} />
+      </Tooltip>
+    </ClickAwayListener>
+  );
 };
 
 const renderProjectedBudgetAmount = ({
@@ -148,91 +185,6 @@ const getCurrencyMenuItems = (currencies) => {
   });
 };
 
-const renderAddProjectedBudget = ({
-  projectProjectedBudgets,
-  organization,
-  setOrganization,
-  currency,
-  setCurrency,
-  isEditing,
-  isSaveable,
-  currencies,
-  setBudgetAmountAdd,
-  budgetAmountAdd,
-  setIsValidBudgetAmountAdd,
-  isValidBudgetAmountAdd,
-  styles
-}) => {
-  return (
-    <div style={styles.cell}>
-      {_isEmpty(projectProjectedBudgets) ? (
-        <TextField
-          variant="standard"
-          style={styles.inputfield}
-          label={strings.common.organization}
-          value={organization}
-          onChange={(e) => {
-            setOrganization(e.target.value);
-          }}
-          type="text"
-          aria-label="organization"
-          id="organizationinput"
-          inputProps={{
-            "data-test": "organization-input"
-          }}
-          disabled={isEditing}
-        />
-      ) : (
-        <DropDown
-          style={styles.inputfield}
-          value={organization}
-          floatingLabel={strings.common.organization}
-          onChange={(e) => setOrganization(e)}
-          id="organizations"
-          disabled={isEditing}
-        >
-          {getOrganizationMenuItems(projectProjectedBudgets)}
-        </DropDown>
-      )}
-
-      <DropDown
-        style={styles.inputfield}
-        value={currency}
-        floatingLabel={strings.common.currency}
-        onChange={(currency) => {
-          setCurrency(currency);
-        }}
-        id="currencies"
-        disabled={isEditing}
-        error={!isSaveable}
-        errorText={strings.common.projected_budget_exists}
-      >
-        {getCurrencyMenuItems(currencies)}
-      </DropDown>
-      <TextField
-        variant="standard"
-        label={strings.common.total_budget}
-        data-test="projected-budget"
-        disabled={isEditing}
-        value={budgetAmountAdd}
-        onChange={(v) => {
-          if (numberSignsRegex.test(v.target.value)) {
-            setBudgetAmountAdd(v.target.value);
-            setIsValidBudgetAmountAdd(validateLanguagePattern(v.target.value) || _isEmpty(v.target.value));
-          }
-        }}
-        type="text"
-        multiline={false}
-        aria-label="projectedbudget"
-        id="projectedbudgetinput"
-        style={styles.inputfield}
-        error={!isValidBudgetAmountAdd}
-        helperText={!isValidBudgetAmountAdd ? strings.common.invalid_format : ""}
-      />
-    </div>
-  );
-};
-
 const Budget = (props) => {
   const [isSaveable, setIsSaveable] = useState(true);
   const [isValidBudgetAmountAdd, setIsValidBudgetAmountAdd] = useState(true);
@@ -328,21 +280,79 @@ const Budget = (props) => {
         <TableBody>
           <TableRow key={`pb-row-add`}>
             <TableCell>
-              {renderAddProjectedBudget({
-                projectProjectedBudgets,
-                organization,
-                setOrganization,
-                currency,
-                setCurrency,
-                isEditing,
-                isSaveable,
-                currencies,
-                setBudgetAmountAdd,
-                budgetAmountAdd,
-                setIsValidBudgetAmountAdd,
-                isValidBudgetAmountAdd,
-                styles
-              })}
+              <div style={styles.cell}>
+                {_isEmpty(projectProjectedBudgets) ? (
+                  <>
+                    <TextField
+                      variant="standard"
+                      style={styles.inputFieldWithIcon}
+                      label={strings.common.organization}
+                      value={organization}
+                      onChange={(e) => {
+                        setOrganization(e.target.value);
+                      }}
+                      type="text"
+                      aria-label="organization"
+                      id="organizationinput"
+                      inputProps={{
+                        "data-test": "organization-input"
+                      }}
+                      disabled={isEditing}
+                    />
+                    <CustomHelpTooltip title="Placeholder for Organization" />
+                  </>
+                ) : (
+                  <div style={styles.inputContainer}>
+                    <DropDown
+                      style={styles.inputFieldWithIcon}
+                      value={organization}
+                      floatingLabel={strings.common.organization}
+                      onChange={(e) => setOrganization(e)}
+                      id="organizations"
+                      disabled={isEditing}
+                    >
+                      {getOrganizationMenuItems(projectProjectedBudgets)}
+                    </DropDown>
+                    <CustomHelpTooltip title="Placeholder for Organization" />
+                  </div>
+                )}
+
+                <DropDown
+                  style={styles.inputfield}
+                  value={currency}
+                  floatingLabel={strings.common.currency}
+                  onChange={(currency) => {
+                    setCurrency(currency);
+                  }}
+                  id="currencies"
+                  disabled={isEditing}
+                  error={!isSaveable}
+                  errorText={strings.common.projected_budget_exists}
+                >
+                  {getCurrencyMenuItems(currencies)}
+                </DropDown>
+                <TextField
+                  variant="standard"
+                  label={strings.common.total_budget}
+                  data-test="projected-budget"
+                  disabled={isEditing}
+                  value={budgetAmountAdd}
+                  onChange={(v) => {
+                    if (numberSignsRegex.test(v.target.value)) {
+                      setBudgetAmountAdd(v.target.value);
+                      setIsValidBudgetAmountAdd(validateLanguagePattern(v.target.value) || _isEmpty(v.target.value));
+                    }
+                  }}
+                  type="text"
+                  multiline={false}
+                  aria-label="projectedbudget"
+                  id="projectedbudgetinput"
+                  style={styles.inputFieldWithIcon}
+                  error={!isValidBudgetAmountAdd}
+                  helperText={!isValidBudgetAmountAdd ? strings.common.invalid_format : ""}
+                />
+                <CustomHelpTooltip title="Placeholder for Total budget" />
+              </div>
             </TableCell>
             <TableCell align="right">
               <Button


### PR DESCRIPTION
### Checklist
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [ ] I fixed all necessary PR warnings
- [x] The commit history is clean
- [ ] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
- add 2 Icon clickable tooltips for Organization dropdown field and Total budget field in  "Add subproject dialog"
- Icons are clickable and tooltips disappear when clicked away from the icon
- Don't mind the Tooltip messages for now, they are just placeholders, real strings with translations will be added in separate PR
<img width="834" alt="Screenshot 2024-03-13 at 14 27 38" src="https://github.com/openkfw/TruBudget/assets/55734106/884d9fdb-251c-4c91-9ca1-655bdfaa742f">

Closes #1698 
