### PR TITLE
Frontend: modify subproject form flow for default aassignee

### DIFF
--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -273,7 +273,8 @@ const en = {
       "Only allow workflowitem of type restricted. When assigning a restricted workflowitem permissions are automatically granted and revoked. The assigner will only keep the view permissions.",
     workflowitem_assignee: "Default assignee",
     organization_info: "Organization",
-    total_budget_info: "Total budget"
+    total_budget_info: "Total budget",
+    default_assignee_warning: "Default assignee cannot be changed once Subproject is created"
   },
 
   workflow: {

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -196,7 +196,8 @@ const fr = {
       "Autoriser uniquement l'élément de flux de travail de type restreint. Lors de l'attribution d'un élément de flux de travail restreint, les autorisations sont automatiquement accordées et révoquées. Le cédant ne conservera que les autorisations d'affichage.",
     workflowitem_assignee: "Default assignee",
     organization_info: "Organization",
-    total_budget_info: "Total budget"
+    total_budget_info: "Total budget",
+    default_assignee_warning: "Default assignee cannot be changed once Subproject is created"
   },
 
   workflow: {

--- a/frontend/src/languages/georgian.js
+++ b/frontend/src/languages/georgian.js
@@ -275,7 +275,8 @@ const ka = {
       "მხოლოდ ტიპის workflowitem- ის აკრძალვა შეზღუდულია. შეზღუდული workflowitem- ის მინიჭებისას, ნებართვები ავტომატურად გაიცემა და გაუქმდება. შემკვეთი მხოლოდ ნახვის ნებართვებს ინახავს.",
     workflowitem_assignee: "ნაგულისხმევი მიმღები",
     organization_info: "Organization",
-    total_budget_info: "Total budget"
+    total_budget_info: "Total budget",
+    default_assignee_warning: "Default assignee cannot be changed once Subproject is created"
   },
 
   workflow: {

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -193,7 +193,8 @@ const de = {
       "Nur Workflow-Elemente vom Typ 'eingeschränkt' zulassen. Bei Zuweisung eines eingeschränkten Workflow-Items an einen anderen User werden Berechtigungen automatisch erteilt und entzogen. Der Zuweisende behält nur die Anzeigerechte.",
     workflowitem_assignee: "Vorausgewählter Verantwortlicher",
     organization_info: "Organization",
-    total_budget_info: "Total budget"
+    total_budget_info: "Total budget",
+    default_assignee_warning: "Default assignee cannot be changed once Subproject is created"
   },
 
   workflow: {

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -275,7 +275,8 @@ const pt = {
       "Permitir apenas item de fluxo de trabalho do tipo restrito. Ao atribuir um item de fluxo de trabalho restrito, as permissões são concedidas e revogadas automaticamente. O atribuidor manterá apenas as permissões de visualização.",
     workflowitem_assignee: "Cessionário padrão",
     organization_info: "Organization",
-    total_budget_info: "Total budget"
+    total_budget_info: "Total budget",
+    default_assignee_warning: "Default assignee cannot be changed once Subproject is created"
   },
 
   workflow: {

--- a/frontend/src/pages/SubProjects/SubprojectDialogContent.js
+++ b/frontend/src/pages/SubProjects/SubprojectDialogContent.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import CancelIcon from "@mui/icons-material/Cancel";
-import { IconButton } from "@mui/material";
+import { Alert, IconButton } from "@mui/material";
 import Divider from "@mui/material/Divider";
 import MenuItem from "@mui/material/MenuItem";
 
@@ -129,6 +129,7 @@ const SubprojectDialogContent = (props) => {
                 />
               </div>
             </div>
+            <Alert severity="warning">{strings.subproject.default_assignee_warning}</Alert>
           </>
         ) : null}
       </div>


### PR DESCRIPTION
### Checklist
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
- Add warning message into Subproject form in regards to improving UX flow, so that user can see important info that once he assign Default assignee, he cannot be changed
- accurate translations will be added later
<img width="845" alt="Screenshot 2024-03-15 at 09 17 48" src="https://github.com/openkfw/TruBudget/assets/55734106/bdb3c44b-3e15-4b03-b102-5a0b4bf4fb2c">

Closes #1720 

Closes ModifyMe
