### PR TITLE
1790 Optimise project and subproject dialog styles

### DIFF
--- a/frontend/src/pages/Common/Budget.js
+++ b/frontend/src/pages/Common/Budget.js
@@ -265,98 +265,96 @@ const Budget = (props) => {
         </TableBody>
       </Table>
 
-      <Table>
-        <TableBody>
-          <TableRow key={`pb-row-add`}>
-            <TableCell>
-              <div className="cell">
-                {_isEmpty(projectProjectedBudgets) ? (
-                  <>
-                    <TextField
-                      variant="standard"
-                      className="input-field-with-icon"
-                      label={strings.common.organization}
-                      value={organization}
-                      onChange={(e) => {
-                        setOrganization(e.target.value);
-                      }}
-                      type="text"
-                      aria-label="organization"
-                      id="organizationinput"
-                      inputProps={{
-                        "data-test": "organization-input"
-                      }}
-                      disabled={isEditing}
-                    />
-                    <CustomInfoTooltip title={strings.subproject.organization_info} />
-                  </>
-                ) : (
-                  <div className="input-container">
-                    <DropDown
-                      className="input-field-with-icon"
-                      value={organization}
-                      floatingLabel={strings.common.organization}
-                      onChange={(e) => setOrganization(e)}
-                      id="organizations"
-                      disabled={isEditing}
-                    >
-                      {getOrganizationMenuItems(projectProjectedBudgets)}
-                    </DropDown>
-                    <CustomInfoTooltip title={strings.subproject.organization_info} />
-                  </div>
-                )}
-
-                <DropDown
-                  className="input-field"
-                  value={currency}
-                  floatingLabel={strings.common.currency}
-                  onChange={(currency) => {
-                    setCurrency(currency);
-                  }}
-                  id="currencies"
-                  disabled={isEditing}
-                  error={!isSaveable}
-                  errorText={strings.common.projected_budget_exists}
-                >
-                  {getCurrencyMenuItems(currencies)}
-                </DropDown>
-                <TextField
-                  variant="standard"
-                  label={strings.common.total_budget}
-                  data-test="projected-budget"
-                  disabled={isEditing}
-                  value={budgetAmountAdd}
-                  onChange={(v) => {
-                    if (numberSignsRegex.test(v.target.value)) {
-                      setBudgetAmountAdd(v.target.value);
-                      setIsValidBudgetAmountAdd(validateLanguagePattern(v.target.value) || _isEmpty(v.target.value));
-                    }
-                  }}
-                  type="text"
-                  multiline={false}
-                  aria-label="projectedbudget"
-                  id="projectedbudgetinput"
-                  className="input-field-with-icon"
-                  error={!isValidBudgetAmountAdd}
-                  helperText={!isValidBudgetAmountAdd ? strings.common.invalid_format : ""}
-                />
-                <CustomInfoTooltip title={strings.subproject.total_budget_info} />
-              </div>
-            </TableCell>
-            <TableCell align="right">
-              <Button
-                variant="contained"
-                color="secondary"
-                data-test="add-projected-budget"
-                disabled={!budgetAmountAdd || !currency || !organization || !isSaveable || !isValidBudgetAmountAdd}
-                onClick={saveProjectedBudget}
+      <div className="add-organization-budget">
+        <div className="first-budget-row">
+          {_isEmpty(projectProjectedBudgets) ? (
+            <div className="input-container">
+              <TextField
+                variant="standard"
+                className="input-field"
+                label={strings.common.organization}
+                value={organization}
+                onChange={(e) => {
+                  setOrganization(e.target.value);
+                }}
+                type="text"
+                aria-label="organization"
+                id="organizationinput"
+                inputProps={{
+                  "data-test": "organization-input"
+                }}
+                disabled={isEditing}
+              />
+              <CustomInfoTooltip title={strings.subproject.organization_info} />
+            </div>
+          ) : (
+            <div className="input-container">
+              <DropDown
+                formClassName="dropdown-form"
+                className="input-field"
+                value={organization}
+                floatingLabel={strings.common.organization}
+                onChange={(e) => setOrganization(e)}
+                id="organizations"
+                disabled={isEditing}
               >
-                {`${strings.common.add}`}
-              </Button>
-            </TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
+                {getOrganizationMenuItems(projectProjectedBudgets)}
+              </DropDown>
+              <CustomInfoTooltip title={strings.subproject.organization_info} />
+            </div>
+          )}
+          <div className="input-container">
+            <TextField
+              variant="standard"
+              label={strings.common.total_budget}
+              data-test="projected-budget"
+              disabled={isEditing}
+              value={budgetAmountAdd}
+              onChange={(v) => {
+                if (numberSignsRegex.test(v.target.value)) {
+                  setBudgetAmountAdd(v.target.value);
+                  setIsValidBudgetAmountAdd(validateLanguagePattern(v.target.value) || _isEmpty(v.target.value));
+                }
+              }}
+              type="text"
+              multiline={false}
+              aria-label="projectedbudget"
+              id="projectedbudgetinput"
+              className="input-field"
+              error={!isValidBudgetAmountAdd}
+              helperText={!isValidBudgetAmountAdd ? strings.common.invalid_format : ""}
+            />
+            <CustomInfoTooltip title={strings.subproject.total_budget_info} />
+          </div>
+        </div>
+        <div className={_isEmpty(projectProjectedBudgets) ? "second-budget-row" : "second-budget-row without-width"}>
+          <DropDown
+            formClassName="dropdown-form currency"
+            className="input-field"
+            value={currency}
+            floatingLabel={strings.common.currency}
+            onChange={(currency) => {
+              setCurrency(currency);
+            }}
+            id="currencies"
+            disabled={isEditing}
+            error={!isSaveable}
+            errorText={strings.common.projected_budget_exists}
+          >
+            {getCurrencyMenuItems(currencies)}
+          </DropDown>
+          <Button
+            className="add-org-button"
+            variant="contained"
+            color="secondary"
+            data-test="add-projected-budget"
+            disabled={!budgetAmountAdd || !currency || !organization || !isSaveable || !isValidBudgetAmountAdd}
+            onClick={saveProjectedBudget}
+          >
+            {`${strings.common.add}`}
+          </Button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/Common/Budget.scss
+++ b/frontend/src/pages/Common/Budget.scss
@@ -1,25 +1,25 @@
+@import "../../mixins.scss";
+
 .input-field {
   min-width: 200px;
-  margin-right: 1rem;
   flex-grow: 1;
-}
-
-.input-field-with-icon {
-  min-width: 200px;
-  flex-grow: 1;
+  @include tablet {
+    width: 50%;
+  }
 }
 
 .input-container {
   display: flex;
-  width: 45%;
+  width: 50%;
   padding-right: 1.25rem;
-  align-items: flex-end;
-}
-
-.cell {
-  display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: flex-start;
+  flex-direction: row;
+  @include tablet {
+    &:nth-of-type(2n) {
+      padding-right: 0;
+    }
+  }
 }
 
 .help-icon {
@@ -27,4 +27,58 @@
   margin-top: 1.25rem;
   margin-bottom: 0.5rem;
   font-size: x-large;
+}
+
+.add-organization-budget {
+  margin-top: 0.3rem;
+  display: flex;
+  width: 100%;
+  @include tablet {
+    justify-content: center;
+    flex-direction: column;
+  }
+}
+
+.organiaztion-info {
+  min-width: 50%;
+}
+
+.add-org-button {
+  margin-top: 0.5rem;
+  margin-bottom: 0.3rem;
+  @include tablet {
+    width: 50%;
+  }
+}
+
+.first-budget-row {
+  width: 70%;
+}
+
+.second-budget-row {
+  width: 30%;
+  &.without-width {
+    width: auto;
+  }
+}
+
+.first-budget-row,
+.second-budget-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  @include tablet {
+    width: 100%;
+  }
+}
+
+.dropdown-form {
+  width: 100%;
+  margin-right: 1rem;
+  &.currency {
+    @include tablet {
+      width: 50%;
+    }
+  }
 }

--- a/frontend/src/pages/Common/NewDropdown.js
+++ b/frontend/src/pages/Common/NewDropdown.js
@@ -23,13 +23,14 @@ const Dropdown = (props) => {
     disabled,
     error,
     errorText,
-    className
+    className,
+    formClassName
   } = props;
 
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <form autoComplete="off">
+    <form className={formClassName} autoComplete="off">
       <div className="dropdown-container">
         <FormControl
           disabled={disabled}


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [ ] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
- optimise styles of budget row in Project and Sub project dialogs
- this is to prevent horizontal scroll bars appearing, hiding fields and buttons and forcing user to scroll add budget
<img width="690" alt="Screenshot 2024-04-22 at 12 45 46" src="https://github.com/openkfw/TruBudget/assets/55734106/30e00394-45dc-4b40-b882-035a5aab50ca">
<img width="691" alt="Screenshot 2024-04-22 at 12 46 06" src="https://github.com/openkfw/TruBudget/assets/55734106/e0640174-bd03-4bef-b6d4-4eafc6de0b98">
<img width="918" alt="Screenshot 2024-04-22 at 12 46 23" src="https://github.com/openkfw/TruBudget/assets/55734106/46b44094-1125-4527-9787-8779c32d0c58">

### How to test

1. login as any user
2. open Create/Edit project dialog
3. resize browser window and see that in smaller size the budget row in dialog changes
4. try the same in Sub project dialog

Closes #1790
