### PR TITLE
ui: webp backward compatibility

### DIFF
--- a/e2e-test/cypress/integration/project_budget_spec.js
+++ b/e2e-test/cypress/integration/project_budget_spec.js
@@ -38,14 +38,14 @@ describe("Project budget test", function () {
   }
 
   beforeEach(() => {
-    cy.login();
-    cy.visit("/projects");
     cy.intercept({ method: "GET", url: apiRoutev2 + "**/project.list*" }).as("listProjects");
     cy.intercept({ method: "GET", url: apiRoute + "/project.viewDetails*" }).as("viewDetailsProject");
     cy.intercept({ method: "POST", url: apiRoute + "/global.createProject" }).as("createProject");
     cy.intercept({ method: "POST", url: apiRoute + "/project.createSubproject" }).as("createSubproject");
     cy.intercept({ method: "POST", url: apiRoute + "/project.budget.deleteProjected" }).as("deleteBudget");
     cy.intercept({ method: "POST", url: apiRoute + "/project.budget.updateProjected" }).as("updateBudget");
+    cy.login();
+    cy.visit("/projects").wait("@listProjects");
     setProjectsPerPage(100);
   });
 
@@ -217,6 +217,8 @@ describe("Project budget test", function () {
       cy.wait("@updateBudget");
       cy.wait("@updateBudget");
       cy.wait("@listProjects");
+      cy.visit(`/projects`).wait("@listProjects");
+      cy.wait(500);
       // Check if changes have been saved
       cy.get("[data-test=pe-button]").last().click();
       // Check if editing worked properly

--- a/frontend/src/pages/Overview/CardView.js
+++ b/frontend/src/pages/Overview/CardView.js
@@ -23,6 +23,14 @@ import ProjectCard from "./ProjectCard";
 
 import "./CardView.scss";
 
+const webpVersion = (imagePath) => {
+  // if imagePath matches Thumbnail_*.jpg, replace .jpg with .webp
+  if (imagePath.match(/Thumbnail_\d+.jpg/)) {
+    return imagePath.replace(".jpg", ".webp");
+  }
+  return imagePath;
+};
+
 const displayTags = ({ tags, storeSearchTerm, showNavSearchBar, searchTermArray }) => {
   return tags.map((tag) => (
     <SelectablePill
@@ -62,7 +70,7 @@ const getTableEntries = ({
     } = data;
     const budgets = <BudgetsList budgets={projectedBudgets} />;
     const mappedStatus = strings.common.status + ": " + statusMapping(status);
-    const imagePath = !_isEmpty(thumbnail) ? thumbnail : "Default_thumbnail.jpg";
+    const imagePath = !_isEmpty(thumbnail) ? webpVersion(thumbnail) : "Default_thumbnail.jpg";
     const dateString = unixTsToString(creationUnixTs);
     const isOpen = status === "open";
     const editDisabled = !(canUpdateProject(allowedIntents) && isOpen);

--- a/provisioning/src/data/test/amazon_fund.json
+++ b/provisioning/src/data/test/amazon_fund.json
@@ -1,6 +1,7 @@
 {
   "displayName": "Amazonas Fund",
   "description": "Projects in 2017",
+  "thumbnail": "/Thumbnail_0039.jpg",
   "status": "open",
   "assignee": "jxavier",
   "projectedBudgets": [

--- a/provisioning/src/data/test/biodiversity.json
+++ b/provisioning/src/data/test/biodiversity.json
@@ -1,6 +1,7 @@
 {
   "displayName": "Carribean Biodiversity Fund",
   "description": "Projects in 2023",
+  "thumbnail": "/Thumbnail_0031.webp",
   "status": "open",
   "assignee": "jxavier",
   "projectedBudgets": [

--- a/provisioning/src/data/test/close_test.json
+++ b/provisioning/src/data/test/close_test.json
@@ -1,6 +1,7 @@
 {
   "displayName": "project.close test project",
   "description": "project.close test data",
+  "thumbnail": "/Thumbnail_0017.webp",
   "status": "open",
   "assignee": "mstein",
   "projectedBudgets": [

--- a/provisioning/src/data/test/multiple_donors_1.json
+++ b/provisioning/src/data/test/multiple_donors_1.json
@@ -1,6 +1,7 @@
 {
   "displayName": "Multiple Donors I",
   "description": "Financed by a single organization: ACME pays everything, with disbursements in multiple currencies.",
+  "thumbnail": "/Thumbnail_0003.webp",
   "projectedBudgets": [
     {
       "organization": "ACME",

--- a/provisioning/src/data/test/multiple_donors_2.json
+++ b/provisioning/src/data/test/multiple_donors_2.json
@@ -1,6 +1,7 @@
 {
   "displayName": "Multiple Donors II",
   "description": "Financed by a multiple organizations, each using their own currency. Disbursements always use the (local) contract currency.",
+  "thumbnail": "/Thumbnail_0042.webp",
   "projectedBudgets": [
     {
       "organization": "ACME Bank",

--- a/provisioning/src/data/test/school.json
+++ b/provisioning/src/data/test/school.json
@@ -1,6 +1,7 @@
 {
   "displayName": "Primary School Project",
   "description": "Projects in 2018",
+  "thumbnail": "/Thumbnail_0048.webp",
   "status": "open",
   "assignee": "jxavier",
   "projectedBudgets": [

--- a/scripts/operation/docker-compose.yml
+++ b/scripts/operation/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       CERT_CA_PATH: ${CERT_CA_PATH}
       CERT_KEY_PATH: ${CERT_KEY_PATH}
       AUTOSTART: ${AUTOSTART}
+      MULTICHAIN_FEED_ENABLED: ${MULTICHAIN_FEED_ENABLED}
     networks:
       mynetwork:
         ipv4_address: 172.21.0.11


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [ ] I fixed all necessary PR warnings
- [ ] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [ ] I did a self review before requesting a review from another team member

### Description


### How to test

Amazonas is provisioned with jpg image as background, but ui shows the new webp image instead.

1. <E.g. login as user XYZ>
2. <E.g. try to create new subproject>
3. <E.g. You should not see error in console>
4. ...

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #1814
