### PR TITLE
bc: add informative log on backup restore error

### DIFF
--- a/e2e-test/cypress/plugins/index.js
+++ b/e2e-test/cypress/plugins/index.js
@@ -23,6 +23,9 @@ const shell = require("shelljs");
 require("dotenv").config();
 
 function apiReportsReadiness(baseUrl) {
+  if (baseUrl.includes("localhost")) {
+    baseUrl = baseUrl.replace("localhost", "127.0.0.1");
+  }
   return axios
     .get(`${baseUrl}/api/readiness`)
     .then((response) => {
@@ -35,12 +38,16 @@ function apiReportsReadiness(baseUrl) {
       }
     })
     .catch((err) => {
-      console.log(`API is not ready yet: ${err}`);
+      console.log(`API is not ready yet: ${err.message}`);
+      console.log(err);
       return false;
     });
 }
 
 function excelExportReportsReadiness(exportServiceBaseUrl) {
+  if (exportServiceBaseUrl.includes("localhost")) {
+    exportServiceBaseUrl = exportServiceBaseUrl.replace("localhost", "127.0.0.1");
+  }
   return axios
     .get(`${exportServiceBaseUrl}/readiness`)
     .then((response) => {


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [ ] I fixed all necessary PR warnings
- [x] The commit history is clean
- [ ] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description


### How to test

#### 1

1. Configure orgnaization in env variables and start
2. log in as admin
3. download backup
4. change organization value in env vars and restart
5. log in as admin
6. restore backup
7. inspect blockchain logs



####  2
Try similar scenario, but change  MULTICHAIN_RPC_PASSWORD.

#### 3

If you are feeling particularly meticulous, try making a backup from 1.x version a restoring to 2.x version.

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #1835
