### PR TITLE
1850 Long worfklow item title breaks layout

### DIFF
--- a/frontend/src/pages/Workflows/WorkflowItem.js
+++ b/frontend/src/pages/Workflows/WorkflowItem.js
@@ -432,9 +432,11 @@ export const WorkflowItem = ({
                 <div className="info-cell">{infoButton}</div>
                 <div className="info-cell">{attachmentButton}</div>
                 <div className={workflowSelectable ? "workflow-cell" : "workflow-cell not-selectable"}>
-                  <Typography variant="body2" className="typographs">
-                    {displayName}
-                  </Typography>
+                  <Tooltip id="workflow-title" title={displayName}>
+                    <Typography variant="body2" className="workflow-item-title">
+                      {displayName}
+                    </Typography>
+                  </Tooltip>
                 </div>
                 <div className={workflowSelectable ? "workflow-cell" : "workflow-cell not-selectable"}>
                   <Typography variant="body2" className="typographs" component="div" data-test="workflowitem-amount">

--- a/frontend/src/pages/Workflows/WorkflowItem.scss
+++ b/frontend/src/pages/Workflows/WorkflowItem.scss
@@ -147,6 +147,17 @@
   width: 100%;
 }
 
+.workflow-item-title {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin-right: 0.3rem;
+  margin-left: -0.5rem;
+  cursor: pointer;
+}
+
 .workflow-item-card {
   margin-left: 3rem;
   margin-right: 0.625rem;


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
- removed problem where long workflow item title breaks the UI layout
- now it can only grow to 2 lines of text
- there is tooltip present so that user can view the whole title if he wants
<img width="934" alt="Screenshot 2024-05-31 at 10 46 56" src="https://github.com/openkfw/TruBudget/assets/55734106/0f674d20-a6e0-4647-b765-4ff1c7e9122d">


### How to test

1. login
2. go to project-> subproject -> create workflow item
3. give workflow item unusual long title and click submit
4. see that title is not breaking UI layout and on hover you can see the tooltip with the whole title

Closes #1850

