### PR TITLE
set high default api initialDelaySeconds

### DIFF
--- a/helm/api/templates/deployment.yaml
+++ b/helm/api/templates/deployment.yaml
@@ -50,14 +50,14 @@ spec:
           httpGet:
             path: /api/liveness
             port: {{ .Values.api.env.PORT }}
-          initialDelaySeconds: 10
+          initialDelaySeconds: {{ .Values.api.livenessProbe.initialDelaySeconds }}
           periodSeconds: 5
           timeoutSeconds: 10
         readinessProbe:
           httpGet:
             path: /api/readiness
             port: {{ .Values.api.env.PORT }}
-          initialDelaySeconds: 10
+          initialDelaySeconds: {{ .Values.api.readinessProbe.initialDelaySeconds }}
           periodSeconds: 10
           timeoutSeconds: 10
 

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -23,6 +23,11 @@ api:
     memLimit: 200Mi
     cpuRequest: 100m
     cpuLimit: 150m
+  livenessProbe:
+    # Prevents being killed during initial data load phase
+    initialDelaySeconds:  500
+  readinessProbe:
+    initialDelaySeconds:  500
 
 service:
   name: api


### PR DESCRIPTION
### Checklist

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [X ] I fixed all necessary PR warnings
- [ X] The commit history is clean
- [ ] The E2E tests are passing
- [ X] If possible, the issue has been divided into more subtasks
- [X ] I did a self review before requesting a review from another team member

### Description

Creating sandboxes fails because the api pod is killed before it reaches liveness. Setting a very high value for initialDelaySeconds prevents being killed in this phase. The initial phase takes very long because filling the database with sample data takes quite a time.

### How to test

Timeouts are environment specific. A final test can only be done on the final (prod) systems.
