### PR TITLE
api:Create local custom rule warning when using absolute import

### DIFF
--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["plugin:@typescript-eslint/recommended", "prettier"],
-  "plugins": ["import", "unused-imports"],
+  "plugins": ["import", "unused-imports", "local-rules"],
   "env": {
     "node": true,
     "mocha": true,
@@ -75,6 +75,7 @@
     "prefer-template": 0,
     "operator-assignment": 0,
     "prefer-const": 0,
+    "local-rules/no-absolute-imports": 1,
     "no-plusplus": 0,
     "no-cond-assign": 0,
     "no-irregular-whitespace": 0,

--- a/api/eslint-local-rules/index.js
+++ b/api/eslint-local-rules/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "no-absolute-imports": require("./no-absolute-imports"),
+};

--- a/api/eslint-local-rules/no-absolute-imports.js
+++ b/api/eslint-local-rules/no-absolute-imports.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  meta: {
+    type: 'problem', // Defines this as a warning
+    docs: {
+      description: 'Warn about absolute imports not listed in package.json',
+      category: 'Best Practices',
+      recommended: false
+    },
+    schema: [] // No options for now
+  },
+
+  create(context) {
+    const filePath = path.resolve(context.getCwd(), 'package.json');
+    let packageJsonDeps = {};
+
+    // Read package.json to get the list of dependencies
+    try {
+      const packageJson = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      packageJsonDeps = {
+        ...packageJson.dependencies,
+        ...packageJson.devDependencies,
+        ...packageJson.peerDependencies,
+        ...packageJson.optionalDependencies
+      };
+    } catch (error) {
+      context.report({
+        message: `Could not read package.json: ${error.message}`,
+      });
+    }
+
+    return {
+      ImportDeclaration(node) {
+        const importSource = node.source.value;
+        const isAbsoluteImport = !importSource.startsWith('./') && !importSource.startsWith('../');
+        const isPackageIncluded = Object.keys(packageJsonDeps).includes(importSource);
+
+        if (isAbsoluteImport && !isPackageIncluded) {
+          context.report({
+            node,
+            message: `The import "${importSource}" is not listed in your package.json.`,
+          });
+        }
+      },
+    };
+  },
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-local-rules": "^3.0.2",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-unused-imports": "^2.0.0",
         "lodash.isempty": "^4.4.0",
@@ -4222,6 +4223,12 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/eslint-plugin-local-rules": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz",
+      "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
+      "dev": true
     },
     "node_modules/eslint-plugin-promise": {
       "version": "6.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -127,6 +127,7 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-local-rules": "^3.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-unused-imports": "^2.0.0",
     "lodash.isempty": "^4.4.0",

--- a/blockchain/.eslintrc
+++ b/blockchain/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["airbnb-base", "prettier"],
-  "plugins": ["unused-imports"],
+  "plugins": ["unused-imports", "local-rules"],
   "env": {
     "node": true,
     "mocha": true,
@@ -35,6 +35,7 @@
     "linebreak-style": 0,
     "arrow-body-style": 0,
     "func-names": 0,
+    "local-rules/no-absolute-imports": 1,
     "no-unused-expressions": 0,
     "space-before-function-paren": 0,
     "strict": [2, "global"],

--- a/blockchain/eslint-local-rules/index.js
+++ b/blockchain/eslint-local-rules/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "no-absolute-imports": require("./no-absolute-imports"),
+};

--- a/blockchain/eslint-local-rules/no-absolute-imports.js
+++ b/blockchain/eslint-local-rules/no-absolute-imports.js
@@ -34,23 +34,14 @@ module.exports = {
     return {
       ImportDeclaration(node) {
         const importSource = node.source.value;
-        const isAbsoluteImport =
-          !importSource.startsWith("./") && !importSource.startsWith("../");
+        const isAbsoluteImport = !importSource.startsWith("./") && !importSource.startsWith("../");
         const importSourceLibNameFromPath = importSource.split("/")[0];
         const isPackageIncluded =
           Object.keys(packageJsonDeps).includes(importSource) ||
           Object.keys(packageJsonDeps).includes(importSourceLibNameFromPath);
-        const isPackageACommonJsModule = [
-          "fs",
-          "path",
-          "child_process",
-        ].includes(importSource);
+        const isPackageACommonJsModule = ["fs", "path", "child_process"].includes(importSource);
 
-        if (
-          isAbsoluteImport &&
-          !isPackageIncluded &&
-          !isPackageACommonJsModule
-        ) {
+        if (isAbsoluteImport && !isPackageIncluded && !isPackageACommonJsModule) {
           context.report({
             node,
             message: `The import "${importSource}" is not listed in your package.json.`,

--- a/blockchain/package-lock.json
+++ b/blockchain/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-local-rules": "^3.0.2",
         "eslint-plugin-unused-imports": "^2.0.0",
         "jshint": "^2.13.4",
         "mocha": "^10.0.0",
@@ -2604,6 +2605,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eslint-plugin-local-rules": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz",
+      "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
+      "dev": true
     },
     "node_modules/eslint-plugin-unused-imports": {
       "version": "2.0.0",

--- a/blockchain/package.json
+++ b/blockchain/package.json
@@ -62,6 +62,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-local-rules": "^3.0.2",
     "eslint-plugin-unused-imports": "^2.0.0",
     "jshint": "^2.13.4",
     "mocha": "^10.0.0",

--- a/email-notification-service/.eslintrc
+++ b/email-notification-service/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["plugin:@typescript-eslint/recommended", "prettier"],
-  "plugins": ["unused-imports"],
+  "plugins": ["unused-imports", "local-rules"],
   "env": {
     "node": true,
     "mocha": true,
@@ -31,6 +31,7 @@
     "no-shadow": 0,
     "import/no-unresolved": 0,
     "import/extensions": 0,
+    "local-rules/no-absolute-imports": 1,
     "require-yield": 0,
     "no-param-reassign": 0,
     "comma-dangle": ["error", "always-multiline"],

--- a/email-notification-service/eslint-local-rules/index.js
+++ b/email-notification-service/eslint-local-rules/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "no-absolute-imports": require("./no-absolute-imports"),
+};

--- a/email-notification-service/eslint-local-rules/no-absolute-imports.js
+++ b/email-notification-service/eslint-local-rules/no-absolute-imports.js
@@ -38,8 +38,7 @@ module.exports = {
           !importSource.startsWith("./") && !importSource.startsWith("../");
         const importSourceLibNameFromPath = importSource.split("/")[0];
         const isPackageIncluded =
-          Object.keys(packageJsonDeps).includes(importSource) ||
-          Object.keys(packageJsonDeps).includes(importSourceLibNameFromPath);
+          Object.keys(packageJsonDeps).includes(importSource) || Object.keys(packageJsonDeps).includes(importSourceLibNameFromPath);
         const isPackageACommonJsModule = [
           "fs",
           "path",

--- a/email-notification-service/package-lock.json
+++ b/email-notification-service/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-local-rules": "^3.0.2",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-unused-imports": "^2.0.0",
         "nodemon": "^2.0.19",
@@ -2158,6 +2159,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/eslint-plugin-local-rules": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz",
+      "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
+      "dev": true
     },
     "node_modules/eslint-plugin-promise": {
       "version": "6.1.1",
@@ -7288,6 +7295,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-local-rules": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz",
+      "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
+      "dev": true
     },
     "eslint-plugin-promise": {
       "version": "6.1.1",

--- a/email-notification-service/package.json
+++ b/email-notification-service/package.json
@@ -59,6 +59,7 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-local-rules": "^3.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-unused-imports": "^2.0.0",
     "nodemon": "^2.0.19",

--- a/excel-export-service/.eslintrc
+++ b/excel-export-service/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["plugin:@typescript-eslint/recommended", "prettier"],
-  "plugins": ["unused-imports"],
+  "plugins": ["unused-imports", "local-rules"],
   "env": {
     "node": true,
     "mocha": true,
@@ -31,6 +31,7 @@
     "no-shadow": 0,
     "import/no-unresolved": 0,
     "import/extensions": 0,
+    "local-rules/no-absolute-imports": 1,
     "require-yield": 0,
     "no-param-reassign": 0,
     "comma-dangle": ["error", "always-multiline"],

--- a/excel-export-service/eslint-local-rules/index.js
+++ b/excel-export-service/eslint-local-rules/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "no-absolute-imports": require("./no-absolute-imports"),
+};

--- a/excel-export-service/eslint-local-rules/no-absolute-imports.js
+++ b/excel-export-service/eslint-local-rules/no-absolute-imports.js
@@ -38,8 +38,7 @@ module.exports = {
           !importSource.startsWith("./") && !importSource.startsWith("../");
         const importSourceLibNameFromPath = importSource.split("/")[0];
         const isPackageIncluded =
-          Object.keys(packageJsonDeps).includes(importSource) ||
-          Object.keys(packageJsonDeps).includes(importSourceLibNameFromPath);
+          Object.keys(packageJsonDeps).includes(importSource) || Object.keys(packageJsonDeps).includes(importSourceLibNameFromPath);
         const isPackageACommonJsModule = [
           "fs",
           "path",

--- a/excel-export-service/package-lock.json
+++ b/excel-export-service/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-local-rules": "^3.0.2",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-unused-imports": "^2.0.0",
         "nodemon": "^3.0.2",
@@ -1989,6 +1990,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/eslint-plugin-local-rules": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz",
+      "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
+      "dev": true
     },
     "node_modules/eslint-plugin-promise": {
       "version": "6.1.1",
@@ -6729,6 +6736,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-local-rules": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz",
+      "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
+      "dev": true
     },
     "eslint-plugin-promise": {
       "version": "6.1.1",

--- a/excel-export-service/package.json
+++ b/excel-export-service/package.json
@@ -46,6 +46,7 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-local-rules": "^3.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-unused-imports": "^2.0.0",
     "nodemon": "^3.0.2",

--- a/storage-service/.eslintrc
+++ b/storage-service/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["plugin:@typescript-eslint/recommended", "prettier"],
-  "plugins": ["unused-imports"],
+  "plugins": ["unused-imports", "local-rules"],
   "env": {
     "node": true,
     "mocha": true,
@@ -31,6 +31,7 @@
     "no-shadow": 0,
     "import/no-unresolved": 0,
     "import/extensions": 0,
+    "local-rules/no-absolute-imports": 1,
     "require-yield": 0,
     "no-param-reassign": 0,
     "comma-dangle": ["error", "always-multiline"],

--- a/storage-service/eslint-local-rules/index.js
+++ b/storage-service/eslint-local-rules/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "no-absolute-imports": require("./no-absolute-imports"),
+};

--- a/storage-service/eslint-local-rules/no-absolute-imports.js
+++ b/storage-service/eslint-local-rules/no-absolute-imports.js
@@ -38,8 +38,7 @@ module.exports = {
           !importSource.startsWith("./") && !importSource.startsWith("../");
         const importSourceLibNameFromPath = importSource.split("/")[0];
         const isPackageIncluded =
-          Object.keys(packageJsonDeps).includes(importSource) ||
-          Object.keys(packageJsonDeps).includes(importSourceLibNameFromPath);
+          Object.keys(packageJsonDeps).includes(importSource) || Object.keys(packageJsonDeps).includes(importSourceLibNameFromPath);
         const isPackageACommonJsModule = [
           "fs",
           "path",

--- a/storage-service/package-lock.json
+++ b/storage-service/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-local-rules": "^3.0.2",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-unused-imports": "^2.0.0",
         "nodemon": "^2.0.19",
@@ -2363,6 +2364,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/eslint-plugin-local-rules": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz",
+      "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
+      "dev": true
     },
     "node_modules/eslint-plugin-promise": {
       "version": "6.1.1",

--- a/storage-service/package.json
+++ b/storage-service/package.json
@@ -49,6 +49,7 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-local-rules": "^3.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-unused-imports": "^2.0.0",
     "nodemon": "^2.0.19",


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [ ] I fixed all necessary PR warnings
- [ ] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [ ] I did a self review before requesting a review from another team member

### Description

Custom eslint rule warning for `/api` when using absolute import

### How to test

1. Run `npm run lint` or check code if eslint is setup in VSCode
2. On absolute imports and packages not mentioned in package.json a warning is created



Closes #1994 
