### PR TITLE
api: Refresh token in authenticateAd route

### DIFF
--- a/api/src/authenticationUtils.ts
+++ b/api/src/authenticationUtils.ts
@@ -1,0 +1,24 @@
+import * as jsonwebtoken from "jsonwebtoken";
+
+import { JwtConfig } from "./config";
+
+export const refreshTokenExpirationInDays = 8;
+export const accessTokenExpirationInMinutesWithrefreshToken = 10;
+
+/**
+ * Creates a refresh JWT Token
+ *
+ * @param userId the current user ID
+ * @returns a string containing the encoded JWT token
+ */
+export function createRefreshJWTToken(
+  payload: {},
+  key: string,
+  algorithm: JwtConfig["algorithm"] = "HS256",
+): string {
+  const secretOrPrivateKey = algorithm === "RS256" ? Buffer.from(key, "base64") : key;
+  return jsonwebtoken.sign(payload, secretOrPrivateKey, {
+    expiresIn: `${refreshTokenExpirationInDays}d`,
+    algorithm,
+  });
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -401,6 +401,8 @@ if (authProxy.enabled) {
         ),
       getGroupsForUser: (ctx, serviceUser, userId) =>
         GroupQueryService.getGroupsForUser(db, ctx, serviceUser, userId),
+      storeRefreshToken: async (userId, refreshToken, validUntil) =>
+        dbConnection?.insertRefreshToken(userId, refreshToken, validUntil),
     },
     jwt,
   );

--- a/api/src/user_authenticate.ts
+++ b/api/src/user_authenticate.ts
@@ -3,6 +3,11 @@ import Joi = require("joi");
 import * as jsonwebtoken from "jsonwebtoken";
 import { VError } from "verror";
 
+import {
+  accessTokenExpirationInMinutesWithrefreshToken,
+  createRefreshJWTToken,
+  refreshTokenExpirationInDays,
+} from "./authenticationUtils";
 import { JwtConfig, config } from "./config";
 import { toHttpError } from "./http_errors";
 import { assertUnreachable } from "./lib/assertUnreachable";
@@ -15,8 +20,6 @@ import { Group } from "./service/domain/organization/group";
 import { ServiceUser } from "./service/domain/organization/service_user";
 
 export const MAX_GROUPS_LENGTH = 3000;
-export const accessTokenExpirationInMinutesWithrefreshToken = 10;
-export const refreshTokenExpirationInDays = 8;
 
 /**
  * Represents the request body of the endpoint
@@ -363,22 +366,4 @@ function createJWT(
     secretOrPrivateKey,
     { expiresIn, algorithm },
   );
-}
-
-/**
- * Creates a refresh JWT Token
- *
- * @param userId the current user ID
- * @returns a string containing the encoded JWT token
- */
-function createRefreshJWTToken(
-  payload: {},
-  key: string,
-  algorithm: JwtConfig["algorithm"] = "HS256",
-): string {
-  const secretOrPrivateKey = algorithm === "RS256" ? Buffer.from(key, "base64") : key;
-  return jsonwebtoken.sign(payload, secretOrPrivateKey, {
-    expiresIn: `${refreshTokenExpirationInDays}d`,
-    algorithm,
-  });
 }

--- a/api/src/user_refreshToken.ts
+++ b/api/src/user_refreshToken.ts
@@ -2,6 +2,7 @@ import Joi = require("joi");
 import * as jsonwebtoken from "jsonwebtoken";
 import { VError } from "verror";
 
+import { accessTokenExpirationInMinutesWithrefreshToken } from "./authenticationUtils";
 import { JwtConfig, config } from "./config";
 import { toHttpError } from "./http_errors";
 import { AuthenticatedRequest } from "./httpd/lib";
@@ -12,10 +13,7 @@ import { AuthToken } from "./service/domain/organization/auth_token";
 import { Group } from "./service/domain/organization/group";
 import { ServiceUser } from "./service/domain/organization/service_user";
 import { AugmentedFastifyInstance } from "./types";
-import {
-  MAX_GROUPS_LENGTH,
-  accessTokenExpirationInMinutesWithrefreshToken,
-} from "./user_authenticate";
+import { MAX_GROUPS_LENGTH } from "./user_authenticate";
 
 /**
  * Represents the request body of the endpoint


### PR DESCRIPTION
### Checklist

<!-- [x] instead of [ ] checks the task -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [x] The E2E tests are passing
- [x] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description


### How to test

1. Start auth proxy
2. Login with auth proxy
3. Refresh token should work

<!-- Adding following line closes the mentioned issue automatically when the PR is merged -->
<!-- e.g. "Closes #123" -->

Closes #2000 
