### PR TITLE
2036 rename participating stakeholder

### DIFF
--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -129,7 +129,7 @@ const en = {
     tag: "Tag",
     task_status: "Task status",
     thumbnail: "Thumbnail",
-    total_budget: "Participating Stakeholder",
+    total_budget: "Associated Budget",
     tour: "Tour",
     tourStart: "Start Tour",
     tourRestart: "Restart Tour",
@@ -317,7 +317,7 @@ const en = {
       "Only allow workflow action of type restricted. When assigning a restricted workflow action permissions are automatically granted and revoked. The assigner will only keep the view permissions.",
     workflowitem_assignee: "Fixed assignee",
     organization_info: "Funding organization",
-    total_budget_info: "Participating Stakeholder",
+    total_budget_info: "Associated Budget",
     default_assignee_warning: "Fixed assignee cannot be changed once Subproject is created.",
     default_assignee_warning2:
       "Fixed assignee will be assigned to all workflow items in subproject without an option to change it."
@@ -482,7 +482,7 @@ const en = {
     projected_budget_ratio: "Projected Budget Ratio",
     projected_budgets_distribution: "Projected Budgets Distribution",
     subproject_analytics: "Subproject Analytics",
-    total_budget_distribution: "Participating Stakeholder Distribution",
+    total_budget_distribution: "Associated Budget Distribution",
     total: "Total:"
   },
 

--- a/frontend/src/languages/french.js
+++ b/frontend/src/languages/french.js
@@ -130,7 +130,7 @@ const fr = {
     tag: "Tag",
     task_status: "Etat de la tâche",
     thumbnail: "Vignette",
-    total_budget: "Coût total",
+    total_budget: "Budget associé",
     tour: "Tour",
     tourStart: "Start Tour",
     tourRestart: "Restart Tour",
@@ -235,7 +235,7 @@ const fr = {
       "Autoriser uniquement l'élément de flux de travail de type restreint. Lors de l'attribution d'un élément de flux de travail restreint, les autorisations sont automatiquement accordées et révoquées. Le cédant ne conservera que les autorisations d'affichage.",
     workflowitem_assignee: "Fixed assignee",
     organization_info: "Organisme de financement",
-    total_budget_info: "Partie prenante participante",
+    total_budget_info: "Budget associé",
     default_assignee_warning: "Fixed assignee cannot be changed once Subproject is created.",
     default_assignee_warning2:
       "Fixed assignee will be assigned to all workflow action items in subproject without an option to change it."
@@ -488,7 +488,7 @@ const fr = {
     projected_budget_ratio: "Taux d’estimation du budget(estimé/total)",
     projected_budgets_distribution: "Répartition du coût total",
     subproject_analytics: "Analyse de la composante",
-    total_budget_distribution: "Répartition du coût total",
+    total_budget_distribution: "Répartition du budget associé",
     total: "Total:"
   },
 

--- a/frontend/src/languages/georgian.js
+++ b/frontend/src/languages/georgian.js
@@ -129,7 +129,7 @@ const ka = {
     tag: "თაგი",
     task_status: "დავალების სტატუსი",
     thumbnail: "Thumbnail",
-    total_budget: "მთლიანი ბიუჯეტი",
+    total_budget: "ასოცირებული ბიუჯეტი",
     tour: "Tour",
     tourStart: "Start Tour",
     tourRestart: "Restart Tour",
@@ -319,7 +319,7 @@ const ka = {
       "მხოლოდ ტიპის workflow action- ის აკრძალვა შეზღუდულია. შეზღუდული workflow action- ის მინიჭებისას, ნებართვები ავტომატურად გაიცემა და გაუქმდება. შემკვეთი მხოლოდ ნახვის ნებართვებს ინახავს.",
     workflowitem_assignee: "ფიქსირებული მიმწოდებელი",
     organization_info: "დამფინანსებელი ორგანიზაცია",
-    total_budget_info: "მონაწილე დაინტერესებული მხარე",
+    total_budget_info: "ასოცირებული ბიუჯეტი",
     default_assignee_warning: "Fixed assignee cannot be changed once Subproject is created.",
     default_assignee_warning2:
       "Fixed assignee will be assigned to all workflow actions in subproject without an option to change it."
@@ -484,7 +484,7 @@ const ka = {
     projected_budget_ratio: "Projected Budget Ratio",
     projected_budgets_distribution: "დაგეგმილი ბიუჯეტის განაწილება",
     subproject_analytics: "ქვეპროექტების ანალიტიკა",
-    total_budget_distribution: "მთლიანი ბიუჯეტის განაწილება",
+    total_budget_distribution: "ასოცირებული ბიუჯეტის განაწილება",
     total: "სულ:"
   },
 

--- a/frontend/src/languages/german.js
+++ b/frontend/src/languages/german.js
@@ -125,7 +125,7 @@ const de = {
     invalid_tag: "Ungültiger Tag",
     invalid_format: "Ungültiges Format",
     task_status: "Task status",
-    total_budget: "Gesamtes Budget",
+    total_budget: "Zugehöriges Budget",
     tour: "Tour",
     tourStart: "Start Tour",
     tourRestart: "Restart Tour",
@@ -230,7 +230,7 @@ const de = {
       "Nur Workflow-Elemente vom Typ 'eingeschränkt' zulassen. Bei Zuweisung eines eingeschränkten Workflow-Items an einen anderen User werden Berechtigungen automatisch erteilt und entzogen. Der Zuweisende behält nur die Anzeigerechte.",
     workflowitem_assignee: "Fester Zuständiger",
     organization_info: "Förderer",
-    total_budget_info: "Beteiligter Stakeholder",
+    total_budget_info: "Zugehöriges Budget",
     default_assignee_warning: "Fixed assignee cannot be changed once Subproject is created.",
     default_assignee_warning2:
       "Fixed assignee will be assigned to all workflow items in subproject without an option to change it."
@@ -486,7 +486,7 @@ const de = {
     projected_budget_ratio: "Projizierte Budgetquote",
     projected_budgets_distribution: "Verteilung des geplanten Budgets",
     subproject_analytics: "Subprojekt Analyse",
-    total_budget_distribution: "Gesamte Budget Verteilung",
+    total_budget_distribution: "Zugehörige Budgetverteilung",
     total: "Gesamt:"
   },
 

--- a/frontend/src/languages/portuguese.js
+++ b/frontend/src/languages/portuguese.js
@@ -130,7 +130,7 @@ const pt = {
     tag: "Tag",
     task_status: "Status da tarefa",
     thumbnail: "Miniatura",
-    total_budget: "Orçamento total",
+    total_budget: "Orçamento associado",
     tour: "Tour",
     tourStart: "Start Tour",
     tourRestart: "Restart Tour",
@@ -319,7 +319,7 @@ const pt = {
       "Permitir apenas item de fluxo de trabalho do tipo restrito. Ao atribuir um item de fluxo de trabalho restrito, as permissões são concedidas e revogadas automaticamente. O atribuidor manterá apenas as permissões de visualização.",
     workflowitem_assignee: "Cessionário padrão",
     organization_info: "Organização financiadora",
-    total_budget_info: "Parte interessada participante",
+    total_budget_info: "Orçamento associado",
     default_assignee_warning: "Fixed assignee cannot be changed once Subproject is created.",
     default_assignee_warning2:
       "Fixed assignee will be assigned to all workflow actions items in subproject without an option to change it."
@@ -486,7 +486,7 @@ const pt = {
     projected_budget_ratio: "% do Orçamento Projetado",
     projected_budgets_distribution: "Distribuição dos orçamentos projetados",
     subproject_analytics: "Dashboard do Subprojeto",
-    total_budget_distribution: "Distribuição do Orçamento Total",
+    total_budget_distribution: "Distribuição do Orçamento associado",
     total: "Total:"
   },
 


### PR DESCRIPTION
### Checklist

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/openkfw/TruBudget/blob/main/.github/CONTRIBUTING.md#open-a-pull-request).
- [x] I fixed all necessary PR warnings
- [x] The commit history is clean
- [ ] The E2E tests are passing
- [ ] If possible, the issue has been divided into more subtasks
- [x] I did a self review before requesting a review from another team member

### Description
Renamed "Participating Stakeholder" to "Associated Budget" in all languages

### How to test

1. Run application
2. Login with user in different languages
3. Check in subproject, whether "Participating Stakeholder" is correctly renamed to "Associated Budget"
<img width="1852" height="856" alt="image" src="https://github.com/user-attachments/assets/0b6b40cb-973a-41c7-91d8-317a57f61fed" />

Closes #2036 
